### PR TITLE
Quick searching

### DIFF
--- a/lib/hotkey.js
+++ b/lib/hotkey.js
@@ -67,7 +67,7 @@ function toggleMain () {
       mainWindow.minimize()
       mainWindow.restore()
     }
-    mainWindow.webContents.send('list-focus')
+    mainWindow.webContents.send('top-focus-search')
   }
 }
 
@@ -114,4 +114,3 @@ ipc.on('hotkeyUpdated', function (event, newKeymap) {
   globalShortcut.unregisterAll()
   registerAllKeys()
 })
-


### PR DESCRIPTION
バックグラウンドから表示するときにはすぐに検索したいので
ホットキーでメイン画面を表示した際に、検索ボックスにフォーカスするようにしました。

> masterだとloading画面で止まってしまうようだったので、
修正済み(?)の開発ブランチ宛にプルリクします…