### PR TITLE
Add support for creating .deb file on linux

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -29,10 +29,27 @@ module.exports = function (grunt) {
         certificatePassword: WIN_CERT_PASSWORD,
         noMsi: true
       }
+   },
+  'electron-installer-debian': {
+      app: {
+        options: {
+          arch: 'amd64',
+          categories: [
+              'Development',
+              'Utility'
+          ],
+          icon: path.join(__dirname, 'resources/app.png'),
+          bin: 'Boostnote'
+        },
+        src: path.join(__dirname, 'dist', 'Boostnote-linux-x64'),
+        dest: path.join(__dirname, 'dist')
+      }
     }
   }
+
   grunt.initConfig(initConfig)
   grunt.loadNpmTasks('grunt-electron-installer')
+  grunt.loadNpmTasks('grunt-electron-installer-debian')
 
   grunt.registerTask('compile', function () {
     var done = this.async()
@@ -206,6 +223,9 @@ module.exports = function (grunt) {
       case 'osx':
         grunt.task.run(['compile', 'pack:osx', 'codesign', 'create-osx-installer', 'zip:osx'])
         break
+      case 'linux':
+        grunt.task.run(['compile', 'pack:linux', 'electron-installer-debian'])
+        break;
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "electron-release": "^2.2.0",
     "grunt": "^0.4.5",
     "grunt-electron-installer": "^1.2.0",
+    "grunt-electron-installer-debian": "^0.2.0",
     "history": "^1.17.0",
     "nib": "^1.1.0",
     "react": "^0.14.3",


### PR DESCRIPTION
This PR, adds support to create .deb files to simplify Boostnote installation process of Linux based systems.