### PR TITLE
Hotfix for dark theme

### DIFF
--- a/browser/styles/main/ArticleList.styl
+++ b/browser/styles/main/ArticleList.styl
@@ -30,6 +30,8 @@ articleItemColor = #777
         height 20px
         color articleItemColor
         font-size 11px
+        i
+          margin-right 4px
         .folderName
           overflow ellipsis
           display inline-block

--- a/browser/styles/theme/dark.styl
+++ b/browser/styles/theme/dark.styl
@@ -16,6 +16,8 @@ themeDarkTableOdd = themeDarkPreview
 themeDarkTableEven = darken(themeDarkPreview, 10%)
 themeDarkTableHead = themeDarkTableEven
 themeDarkTableBorder = themeDarkBorder
+themeDarkModalButtonDefault = themeDarkPreview
+themeDarkModalButtonDanger = #BF360C
 
 body[data-theme="dark"]
   .Main
@@ -247,6 +249,30 @@ body[data-theme="dark"]
 
         &:hover
           background-color brandColor
+
+    .DeleteArticleModal.modal
+      .control
+        button
+          transition 0.1s
+          color themeDarkText
+          border-color lighten(themeDarkModalButtonDefault, 20%)
+          background-color themeDarkModalButtonDefault
+
+          &:hover
+            background-color: lighten(themeDarkModalButtonDefault, 10%)
+
+          &:focus
+            border-color themeDarkTopicColor
+
+          &.danger
+            background-color themeDarkModalButtonDanger
+            border-color lighten(themeDarkModalButtonDanger, 30%)
+
+            &:hover
+              background-color: lighten(themeDarkModalButtonDanger, 10%)
+
+            &:focus
+              border-color lighten(themeDarkModalButtonDanger, 50%)
 
     .Preferences.modal
       .sectionInput input,

--- a/browser/styles/theme/dark.styl
+++ b/browser/styles/theme/dark.styl
@@ -188,6 +188,7 @@ body[data-theme="dark"]
         .ArticleEditor
           .CodeEditor
             border-color themeDarkBorder
+            border-radius 0
 
         &>.ArticleDetail-panel-header .ArticleDetail-panel-header-mode
           transition 0.1s

--- a/browser/styles/theme/dark.styl
+++ b/browser/styles/theme/dark.styl
@@ -427,6 +427,14 @@ body[data-theme="dark"]
       a:hover
         background-color alpha(lighten(brandColor, 30%), 0.2) !important
 
+      code
+        border-color darken(themeDarkBorder, 10%)
+        background-color lighten(themeDarkPreview, 5%)
+
+      pre
+        code
+          background-color transparent
+
       table
         thead
           tr

--- a/browser/styles/theme/dark.styl
+++ b/browser/styles/theme/dark.styl
@@ -128,6 +128,10 @@ body[data-theme="dark"]
         &:hover
           background-color lighten(themeDarkList, 5%)
 
+        .ArticleList-item-top
+          .folderName
+            color darken(themeDarkText, 15%)
+
       .divider
         border-color themeDarkBorder
 

--- a/browser/styles/theme/dark.styl
+++ b/browser/styles/theme/dark.styl
@@ -20,6 +20,8 @@ themeDarkModalButtonDefault = themeDarkPreview
 themeDarkModalButtonDanger = #BF360C
 
 body[data-theme="dark"]
+  background-color themeDarkBackground
+
   .Main
     .ArticleNavigator .userInfo .settingBtn .tooltip,
     .ArticleNavigator .ArticleNavigator-folders .ArticleNavigator-folders-header .addBtn .tooltip,

--- a/browser/styles/theme/dark.styl
+++ b/browser/styles/theme/dark.styl
@@ -12,6 +12,10 @@ themeDarkTooltip = rgba(0, 0, 0, 0.7)
 themeDarkFocusText = #FFFFFF
 themeDarkFocusButton = lighten(themeDarkTopicColor, 30%)
 themeDarkBoxShadow = alpha(lighten(themeDarkTopicColor, 10%), 0.4);
+themeDarkTableOdd = themeDarkPreview
+themeDarkTableEven = darken(themeDarkPreview, 10%)
+themeDarkTableHead = themeDarkTableEven
+themeDarkTableBorder = themeDarkBorder
 
 body[data-theme="dark"]
   .Main
@@ -395,3 +399,21 @@ body[data-theme="dark"]
 
       a:hover
         background-color alpha(lighten(brandColor, 30%), 0.2) !important
+
+      table
+        thead
+          tr
+            background-color themeDarkTableHead
+          th
+            border-color themeDarkTableBorder
+            &:last-child
+              border-right solid 1px themeDarkTableBorder
+        tbody
+          tr:nth-child(2n + 1)
+            background-color themeDarkTableOdd
+          tr:nth-child(2n)
+            background-color themeDarkTableEven
+          td
+            border-color themeDarkTableBorder
+            &:last-child
+              border-right solid 1px themeDarkTableBorder


### PR DESCRIPTION
### FIXIT

- [x] Markdown Previewのテーブルスタイル
- [x] メモ削除時モーダルのボタンカラー
- [x] AceEditorの下部 border-radius

----

#### Markdown Previewのテーブルスタイル
![image](https://cloud.githubusercontent.com/assets/1488898/14771888/ac7b41d2-0ad1-11e6-922c-eb7a2fc23d34.png)

ダークテーマを追加した時にMarkdownプレビュー時の
テーブルのスタイルのオーバーライドが漏れてましたので追加でスタイルを定義しました。

#### メモ削除時モーダルのボタンカラー
![image](https://cloud.githubusercontent.com/assets/1488898/14784320/fb47ff4a-0b2f-11e6-922f-2290f279a3a7.png)

メモ削除時のモーダル表示のボタンスタイルが未定義だったため追加しました。

#### AceEditorの下部 border-radius

下記変更にともなって生じた、AceEditor切替時に出る白い余白を修正しました。
https://github.com/BoostIO/Boostnote/commit/934e4d9607f89ccd65d0bf4f3898ae8f2def3535#diff-9facd39aca37bb6f900638a5ae61410aR386

#### その他微調整

- code タグの背景色を設定
- リストのフォルダ名に文字色を設定し位置調整

![image](https://cloud.githubusercontent.com/assets/1488898/14786861/d1156d6e-0b3b-11e6-9ac4-2f83e65f0ef2.png)
