### PR TITLE
displaying markdown codeblocks with line numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/*
 /dist
 /compiled
 /secret
+*.log

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -3,6 +3,15 @@ import emoji from 'markdown-it-emoji'
 import math from '@rokt33r/markdown-it-math'
 import hljs from 'highlight.js'
 
+var createGutter = function (str) {
+  var lc = (str.match(/\n/g) || []).length;
+  var lines = [];
+  for (var i=1; i <= lc; i++) {
+    lines.push('<span>'+i+'</span>');
+  }
+  return '<span>' + lines.join('') + '</span>';
+};
+
 var md = markdownit({
   typographer: true,
   linkify: true,
@@ -11,12 +20,16 @@ var md = markdownit({
   highlight: function (str, lang) {
     if (lang && hljs.getLanguage(lang)) {
       try {
-        return '<pre class="hljs"><code>' +
+        return '<pre class="hljs">' +
+        createGutter(str) +
+        '<code>' +
         hljs.highlight(lang, str).value +
         '</code></pre>'
       } catch (e) {}
     }
-    return '<pre class="hljs"><code>' +
+    return '<pre class="hljs">' +
+    createGutter(str) +
+    '<code>' +
     str.replace(/\&/g, '&amp;').replace(/\</g, '&lt;').replace(/\>/g, '&gt;').replace(/\"/g, '&quot;') +
     '</code></pre>'
   }

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -6,8 +6,8 @@ import hljs from 'highlight.js'
 var createGutter = function (str) {
   var lc = (str.match(/\n/g) || []).length;
   var lines = [];
-  for (var i=1; i <= lc; i++) {
-    lines.push('<span>'+i+'</span>');
+  for (var i = 1; i <= lc; i++) {
+    lines.push('<span>' + i + '</span>');
   }
   return '<span>' + lines.join('') + '</span>';
 };

--- a/browser/styles/mixins/marked.styl
+++ b/browser/styles/mixins/marked.styl
@@ -135,6 +135,19 @@ marked()
       &>pre
         border none
         margin -5px
+    &>span
+      font-family Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro, monospace
+      display block
+      float left
+      margin 0 0.5em 0 -0.5em
+      border-right 1px solid
+      text-align right
+      &>span
+        display block
+        padding 0 .5em 0 1em
+    &>.cl
+      display block
+      clear both
   table
     width 100%
     margin 15px 0 25px


### PR DESCRIPTION
Code blocks with line numbers.

**NOTE**: I wanted to use CSS classes, but somehow the `class` tags were removed after.

The
```stylus
    &>.cl
      display block
      clear both
```
in `marked.styl` is not really necessary, it seems to work without.