### PR TITLE
fix lists formatting in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,16 +39,16 @@ On v0.6.0, You will be able to select any folder in your file system.
 ## Develop
 
 1. turn on HMR server
-
-```
-npm run webpack
-```
+  
+  ```
+  npm run webpack
+  ```
 
 2. run hot mode
-
-```
-npm run hot
-```
+  
+  ```
+  npm run hot
+  ```
 
 > `npm start` is using compiled scripts. see [Build](#Build) to compile scripts.
 
@@ -60,54 +60,54 @@ npm run hot
 
 1. Compile scripts
 
-compile all browser stuff(Javascript, Stylus).
-
-```
-grunt compile
-```
+  compile all browser stuff(Javascript, Stylus).
+  
+  ```
+  grunt compile
+  ```
 
 2. Build executable
 
-build `Boostnote.app` (OS X) / `Boostnote.exe` (Windows)
-
-```
-grunt pack:osx
-grunt pack:windows
-```
+  build `Boostnote.app` (OS X) / `Boostnote.exe` (Windows)
+  
+  ```
+  grunt pack:osx
+  grunt pack:windows
+  ```
 
 3. Codesign (OSX only)
 
-codesign with Certification.
-
-```
-grunt codesign
-```
-
-> `OSX_COMMON_NAME` must be defined inside `/secret/auth_code.json`.
-
-> codesigning on windows is included to creating installer.
+  codesign with Certification.
+  
+  ```
+  grunt codesign
+  ```
+  
+  > `OSX_COMMON_NAME` must be defined inside `/secret/auth_code.json`.
+  
+  > codesigning on windows is included to creating installer.
 
 4. Create installer
 
-create installer, `Boostnote.dmg`(OSX) / `Setup.exe`(Windows).
+  create installer, `Boostnote.dmg`(OSX) / `Setup.exe`(Windows).
+  
+  ```
+  grunt create-windows-installer
+  ```
 
-```
-grunt create-windows-installer
-```
-
-> #### Windows only
-> `WIN_CERT_PASSWORD` must be defined inside `/secret/auth_code.json`.
-> `/secret/authenticode_cer.p12` is required also.
+  > #### Windows only
+  > `WIN_CERT_PASSWORD` must be defined inside `/secret/auth_code.json`.
+  > `/secret/authenticode_cer.p12` is required also.
 
 5. Zip (OSX only)
 
-zip `Boostnote.app` file.
-
-```
-grunt zip:osx
-```
-
-> Stuff(Setup.exe, .nupkg) of Windows are not needed to be zipped.
+  zip `Boostnote.app` file.
+  
+  ```
+  grunt zip:osx
+  ```
+  
+  > Stuff(Setup.exe, .nupkg) of Windows are not needed to be zipped.
 
 ## Using stack
 


### PR DESCRIPTION
The ordered lists in `readme.md` were not rendered properly (every item was detected as `1.` by the parser).

![image](https://cloud.githubusercontent.com/assets/576772/15115786/ef3a94b6-1600-11e6-83e0-b49e041ff50c.png)

This is only a formatting issue to make the steps clearer, I have not changed any word or sentence.