### PR TITLE
Fix close window on OSX

### DIFF
--- a/lib/main-app.js
+++ b/lib/main-app.js
@@ -231,6 +231,10 @@ app.on('ready', function () {
     if (finderProcess) finderProcess.kill()
   })
 
+  app.on('activate-with-no-open-windows', function(){
+    mainWindow.show()
+  })
+
   var template = require('./main-menu')
   if (process.platform === 'win32') {
     template.unshift({
@@ -272,9 +276,18 @@ app.on('ready', function () {
   if (process.platform === 'win32' || process.platform === 'linux') {
     mainWindow.setMenu(menu)
   }
+
   mainWindow.on('close', function (e) {
-    app.quit()
+    if (process.platform == 'darwin') {
+      if (!appQuit) {
+        e.preventDefault();
+        mainWindow.hide();
+      }
+    } else {
+      quitApp()
+    }
   })
+
   switch (process.platform) {
     case 'darwin':
       spawnFinder()


### PR DESCRIPTION
OSXでのBoostnote利用時に、Main windowのcloseボタンを押すとアプリが終了するようになっていたので、hideするように変更しました。また、closeボタンを押してhideさせた後は、Dockアイコンのクリックで再びwindowの表示を行うようにしました。