### PR TITLE
including ace via npm, not as git submodule anymore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "submodules/ace"]
-	path = submodules/ace
-	url = https://github.com/ajaxorg/ace-builds.git
-	branch = master

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -98,7 +98,7 @@ module.exports = function (grunt) {
       prune: true,
       overwrite: true,
       out: path.join(__dirname, 'dist'),
-      ignore: /submodules\/ace\/(?!src-min)|submodules\/ace\/(?=src-min-noconflict)|node_modules\/devicon\/icons|dist|^\/browser|^\/secret|\.babelrc|\.gitignore|^\/\.gitmodules|^\/gruntfile|^\/readme.md|^\/webpack|^\/appdmg\.json|^\/node_modules\/grunt/
+      ignore: /node_modules\/ace-builds\/(?!src-min)|node_modules\/ace-builds\/(?=src-min-noconflict)|node_modules\/devicon\/icons|dist|^\/browser|^\/secret|\.babelrc|\.gitignore|^\/\.gitmodules|^\/gruntfile|^\/readme.md|^\/webpack|^\/appdmg\.json|^\/node_modules\/grunt/
     }
     switch (platform) {
       case 'win':

--- a/lib/finder.html
+++ b/lib/finder.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <div id="content"></div>
-  <script src="../node_modules/ace/build/src-min/ace.js"></script>
+  <script src="../node_modules/ace-builds/src-min/ace.js"></script>
   <script src="../resources/katex.min.js"></script>
   <script>
     const electron = require('electron')

--- a/lib/finder.html
+++ b/lib/finder.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <div id="content"></div>
-  <script src="../submodules/ace/src-min/ace.js"></script>
+  <script src="../node_modules/ace/build/src-min/ace.js"></script>
   <script src="../resources/katex.min.js"></script>
   <script>
     const electron = require('electron')

--- a/lib/main.html
+++ b/lib/main.html
@@ -55,8 +55,8 @@
 
   <div id="content"></div>
 
-  <script src="../node_modules/ace/build/src-min/ace.js"></script>
-  <script src="../node_modules/ace/build/src-min/ext-themelist.js"></script>
+  <script src="../node_modules/ace-builds/src-min/ace.js"></script>
+  <script src="../node_modules/ace-builds/src-min/ext-themelist.js"></script>
   <script src="../resources/katex.min.js"></script>
   <script type='text/javascript'>
     const electron = require('electron')

--- a/lib/main.html
+++ b/lib/main.html
@@ -55,8 +55,8 @@
 
   <div id="content"></div>
 
-  <script src="../submodules/ace/src-min/ace.js"></script>
-  <script src="../submodules/ace/src-min/ext-themelist.js"></script>
+  <script src="../node_modules/ace/build/src-min/ace.js"></script>
+  <script src="../node_modules/ace/build/src-min/ext-themelist.js"></script>
   <script src="../resources/katex.min.js"></script>
   <script type='text/javascript'>
     const electron = require('electron')

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@rokt33r/markdown-it-math": "^4.0.1",
     "@rokt33r/node-ipc": "^5.0.4",
     "@rokt33r/sanitize-html": "^1.11.2",
-    "ace": "git+ssh://git@github.com/ajaxorg/ace.git",
+    "ace": "git+ssh://git@github.com/ajaxorg/ace-builds.git",
     "devicon": "^2.0.0",
     "electron-gh-releases": "^2.0.2",
     "font-awesome": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@rokt33r/markdown-it-math": "^4.0.1",
     "@rokt33r/node-ipc": "^5.0.4",
     "@rokt33r/sanitize-html": "^1.11.2",
+    "ace": "git+ssh://git@github.com/ajaxorg/ace.git",
     "devicon": "^2.0.0",
     "electron-gh-releases": "^2.0.2",
     "font-awesome": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@rokt33r/markdown-it-math": "^4.0.1",
     "@rokt33r/node-ipc": "^5.0.4",
     "@rokt33r/sanitize-html": "^1.11.2",
-    "ace": "git+ssh://git@github.com/ajaxorg/ace-builds.git",
+    "ace-builds": "git+https://git@github.com/ajaxorg/ace-builds.git",
     "devicon": "^2.0.0",
     "electron-gh-releases": "^2.0.2",
     "font-awesome": "^4.3.0",
@@ -84,9 +84,6 @@
   },
   "optional": false,
   "standard": {
-    "ignore": [
-      "submodules"
-    ],
     "globals": [
       "localStorage"
     ]


### PR DESCRIPTION
This update will not require ace as submodules anymore.
It just needed this entry in the package.json:

`"ace": "git+ssh://git@github.com/ajaxorg/ace.git"`
