### PR TITLE
Enable Changing UI Theme

### DIFF
--- a/browser/main/modals/PreferencesModal/ConfigTab.js
+++ b/browser/main/modals/PreferencesModal/ConfigTab.js
@@ -231,7 +231,6 @@ class ConfigTab extends React.Component {
               <select value={config.ui.theme}
                 onChange={(e) => this.handleUIChange(e)}
                 ref='uiTheme'
-                disabled
               >
                 <option value='default'>Light</option>
                 <option value='dark'>Dark</option>


### PR DESCRIPTION
The UI Theme dropdown is disabled so you can no longer select the dark theme. This change enables the dropdown so you can switch themes.