### PR TITLE
Feature: Folder color picker

### DIFF
--- a/browser/main/modals/PreferencesModal/StorageItem.js
+++ b/browser/main/modals/PreferencesModal/StorageItem.js
@@ -8,6 +8,7 @@ import store from 'browser/main/store'
 const electron = require('electron')
 const { shell, remote } = electron
 const { Menu, MenuItem } = remote
+import { SketchPicker } from 'react-color'
 
 class UnstyledFolderItem extends React.Component {
   constructor (props) {
@@ -16,6 +17,7 @@ class UnstyledFolderItem extends React.Component {
     this.state = {
       status: 'IDLE',
       folder: {
+        showColumnPicker: false,
         color: props.color,
         name: props.name
       }
@@ -50,22 +52,18 @@ class UnstyledFolderItem extends React.Component {
   }
 
   handleColorButtonClick (e) {
-    var menu = new Menu()
+    const folder = Object.assign({}, this.state.folder, { showColumnPicker: true })
+    this.setState({ folder })
+  }
 
-    consts.FOLDER_COLORS.forEach((color, index) => {
-      menu.append(new MenuItem({
-        label: consts.FOLDER_COLOR_NAMES[index],
-        click: (e) => {
-          let { folder } = this.state
-          folder.color = color
-          this.setState({
-            folder
-          })
-        }
-      }))
-    })
+  handleColorChange (color) {
+    const folder = Object.assign({}, this.state.folder, { color: color.hex })
+    this.setState({ folder })
+  }
 
-    menu.popup(remote.getCurrentWindow())
+  handleColorPickerClose (event) {
+    const folder = Object.assign({}, this.state.folder, { showColumnPicker: false })
+    this.setState({ folder })
   }
 
   handleCancelButtonClick (e) {
@@ -75,12 +73,27 @@ class UnstyledFolderItem extends React.Component {
   }
 
   renderEdit (e) {
+    const popover = { position: 'absolute', zIndex: 2 }
+    const cover = {
+      position: 'fixed',
+      top: 0, right: 0, bottom: 0, left: 0
+    }
     return (
       <div styleName='folderList-item'>
         <div styleName='folderList-item-left'>
           <button styleName='folderList-item-left-colorButton' style={{color: this.state.folder.color}}
-            onClick={(e) => this.handleColorButtonClick(e)}
+            onClick={(e) => !this.state.folder.showColumnPicker && this.handleColorButtonClick(e)}
           >
+          { this.state.folder.showColumnPicker ?
+            <div style={ popover }>
+              <div style={ cover }
+                onClick={ () => this.handleColorPickerClose() } />
+                <SketchPicker
+                  color={this.state.folder.color}
+                  onChange={ (color) => this.handleColorChange(color) }
+                  onChangeComplete={ (color) => this.handleColorChange(color) } />
+              </div>
+          : null }
             <i className='fa fa-square'/>
           </button>
           <input styleName='folderList-item-left-nameInput'

--- a/browser/main/modals/PreferencesModal/StoragesTab.js
+++ b/browser/main/modals/PreferencesModal/StoragesTab.js
@@ -51,12 +51,15 @@ class StoragesTab extends React.Component {
   }
 
   renderList () {
-    let { storages } = this.props
+    let { storages, boundingBox } = this.props
 
+    if (!boundingBox) { return null }
     let storageList = storages.map((storage) => {
       return <StorageItem
         key={storage.key}
         storage={storage}
+        test={true}
+        hostBoundingBox={boundingBox}
       />
     })
     return (
@@ -217,6 +220,14 @@ class StoragesTab extends React.Component {
 }
 
 StoragesTab.propTypes = {
+  boundingBox: PropTypes.shape({
+    bottom: PropTypes.number,
+    height: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number,
+    top: PropTypes.number,
+    width: PropTypes.number
+  }),
   dispatch: PropTypes.func
 }
 

--- a/browser/main/modals/PreferencesModal/index.js
+++ b/browser/main/modals/PreferencesModal/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import ReactDOM from 'react-dom'
 import { connect } from 'react-redux'
 import ConfigTab from './ConfigTab'
 import InfoTab from './InfoTab'
@@ -17,6 +18,8 @@ class Preferences extends React.Component {
 
   componentDidMount () {
     this.refs.root.focus()
+    const boundingBox = this.getContentBoundingBox()
+    this.setState({ boundingBox })
   }
 
   switchTeam (teamId) {
@@ -30,6 +33,7 @@ class Preferences extends React.Component {
   }
 
   renderContent () {
+    const { boundingBox } = this.state;
     let { dispatch, config, storages } = this.props
 
     switch (this.state.currentTab) {
@@ -48,6 +52,7 @@ class Preferences extends React.Component {
           <StoragesTab
             dispatch={dispatch}
             storages={storages}
+            boundingBox={boundingBox}
           />
         )
     }
@@ -57,6 +62,11 @@ class Preferences extends React.Component {
     if (e.keyCode === 27) {
       this.props.close()
     }
+  }
+
+  getContentBoundingBox () {
+    const node = ReactDOM.findDOMNode(this.refs.content)
+    return node.getBoundingClientRect();
   }
 
   render () {
@@ -97,7 +107,7 @@ class Preferences extends React.Component {
         <div styleName='nav'>
           {navButtons}
         </div>
-        <div styleName='content'>
+        <div ref='content' styleName='content'>
           {content}
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "markdown-it-footnote": "^3.0.0",
     "md5": "^2.0.0",
     "moment": "^2.10.3",
+    "react-color": "^2.2.2",
+    "react-dom": "^15.3.0",
     "sander": "^0.5.1",
     "season": "^5.3.0",
     "superagent": "^1.2.0",


### PR DESCRIPTION
This PR is based on the feature request in issue #36. I've implemented a color picker dialog instead of a list of predefined colors for the folders. I hope that we did not do work twice, but I just needed that feature for my notes. ;)

The PR makes use of the wonderful [react-color](https://github.com/casesandberg/react-color/) component which is licensed by the [MIT license](https://github.com/casesandberg/react-color/blob/master/LICENSE).

Actually calculating the position is not that easy because the dimensions of the content area of the modal is required. I calculate the dimensions after they are available and hand them as properties to the child components. You might want to have a closer look to the code to see if you're d'accord with this procedure or if this can be done better. Also see the images below.

Additional note:
Since the list of colors is just used for the menu that I've removed it might be a good idea to remove the color constants also. I cannot decide wether you need them for a different purpose, so I let them stay.

## Preview:

<img width="758" alt="screen shot 2016-08-10 at 17 57 14" src="https://cloud.githubusercontent.com/assets/3976183/17560922/286d852e-5f24-11e6-8a63-af51194c6ad4.png">


If there is not enough space for the picker, e.g. for the items at the bottom, it's re-positioned such that the user does not have to scroll.

<img width="845" alt="screen shot 2016-08-10 at 17 57 07" src="https://cloud.githubusercontent.com/assets/3976183/17560923/28712c38-5f24-11e6-9b7a-92a71f2c00bf.png">
