### PR TITLE
submit the tag when receiving 'tab' key

### DIFF
--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -22,6 +22,10 @@ class TagSelect extends React.Component {
 
   handleNewTagInputKeyDown (e) {
     switch (e.keyCode) {
+      case 9:
+        e.preventDefault()
+        this.submitTag()
+        break
       case 13:
         this.submitTag()
         break


### PR DESCRIPTION
In existing implementation, 'enter' key is only allowed to submit the tag. However, if the user finishes to create the tag and make another tag, the user naturally send 'tab' key.
When receiving 'tab' key, the focus will go to the star icon and nothing is submitted, but the text is still remained. This makes confusing to the user.

This commit provide 'tab' key submitting the tag also.