### PR TITLE
Node 6 support

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,7 +1,5 @@
 # Build
 
-You must use Node LTS v4.\*.\* to build Boostnote.
-
 ## Development
 
 We use Webpack HMR to develope Boostnote.

--- a/docs/jp/build.md
+++ b/docs/jp/build.md
@@ -1,7 +1,5 @@
 # Build
 
-ビルドするためにはNode LTS v4.\*.\*が必要です。
-
 ## 開発
 
 Webpack HRMを使います。

--- a/docs/ko/build.md
+++ b/docs/ko/build.md
@@ -1,7 +1,5 @@
 # Build
 
-빌드하기 위해선 Node LTS v4.\*.\* 가 필요합니다.
-
 ## 개발
 
 Webpack HRM을 개발을 위해 사용합니다.

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "standard": "^6.0.8",
     "style-loader": "^0.12.4",
     "stylus": "^0.52.4",
-    "stylus-loader": "^1.3.1",
+    "stylus-loader": "^2.3.1",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
   },


### PR DESCRIPTION
Stylus-loader has already been fixed #50 problem. 

They discussed in this [issue](https://github.com/shama/stylus-loader/issues/120) and fixed in this [commit](https://github.com/shama/stylus-loader/commit/9454f49001f04988a15a7a34e88f10d06bef4922)

I have test with node 4.4.4 and latest stable 6.4 and works well with both.
