### PR TITLE
multiple export default causes a error

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -263,5 +263,3 @@ CodeEditor.defaultProps = {
   indentSize: 4,
   indentType: 'space'
 }
-
-export default CodeEditor


### PR DESCRIPTION
In browser/components/CodeEditor.js, export default CadeEditor called twice. No need exporting twice. 

## Error log
```
node_modules/.bin/webpack --config webpack-production.config.js
Hash: 3c381874bfbab95a1e49
Version: webpack 1.13.2
Time: 24538ms
    + 431 hidden modules

ERROR in ./browser/components/CodeEditor.js
Module build failed: SyntaxError: Only one default export allowed per module.

  265 | }
  266 | 
> 267 | export default CodeEditor
      | ^
  268 | 
```