### PR TITLE
WIP:  Finder Issue with multiple monitors

### DIFF
--- a/lib/finder-window.js
+++ b/lib/finder-window.js
@@ -4,6 +4,7 @@ const BrowserWindow = electron.BrowserWindow
 const Menu = electron.Menu
 const MenuItem = electron.MenuItem
 const Tray = electron.Tray
+const Screen = electron.screen
 const path = require('path')
 
 var config = {
@@ -23,6 +24,13 @@ var config = {
 if (process.platform === 'darwin') {
   config['always-on-top'] = true
 }
+
+// center finder window on current screen
+var cursor = Screen.getCursorScreenPoint()
+var display = Screen.getDisplayNearestPoint(cursor)
+
+config['x'] = display.bounds.x + (display.bounds.width - config['width']) / 2
+config['y'] = display.bounds.y + (display.bounds.height - config['height']) / 2
 
 var finderWindow = new BrowserWindow(config)
 


### PR DESCRIPTION
Hello.
Regarding the issue #88 , i did some experiments and found out a possible solution.

Basically using the  "screen" module of electron, when open finder I can find the current screen based on mouse pointer position and then manually set x, y position of the finder window to be centered on that screen.

I put the code in finder-window.js but thats not the correct place, because it only called the first time.
Each time the user toggles finder I need to run that code to found out the correct position.

I treid the toggleFinder function in ipcServer.js but I put some console.log and that function doesnt seem to be called.
Where should I put this code to execute every time the finder is toggled?
