### PR TITLE
npmcdn is dead

### DIFF
--- a/oh-my-cdn.json
+++ b/oh-my-cdn.json
@@ -4,6 +4,6 @@
     "react": "https://cdnjs.cloudflare.com/ajax/libs/react/15.0.2/react.js",
     "react-dom": "https://cdnjs.cloudflare.com/ajax/libs/react/15.0.2/react-dom.js",
     "redux": "https://cdnjs.cloudflare.com/ajax/libs/redux/3.5.2/redux.js",
-    "react-redux": "https://npmcdn.com/react-redux@4.4.5/dist/react-redux.min.js"
+    "react-redux": "https://unpkg.com/react-redux@4.4.5/dist/react-redux.min.js"
   }
 }


### PR DESCRIPTION
```
　　　　　　　　 ,,　＿ 
　　　　　　　／ 　　　 ｀ ､ 
　　　　　　/　　(_ﾉL_）　 ヽ 
　　　　　 /　　 ´・　 ・｀　　l　　　　npmcdn is dead.
　　　　 （l　 　　　し　　　　l）　　　it is renamed to unpkg.
　　　　　l　　　　＿＿　　 l　　　　you should use unpkg instead of npmcdn.
　　　　　 >　､ _ 　　　　 ィ 
　　　　 ／　 　　　￣　　 ヽ 
　　 　 /　|　　　　　　　　　iヽ 
　　　　|＼|　　　　　　　　　|/| 
　　　　|　||/＼／＼／＼/|　| 
```