### PR TITLE
Fix of storage unlink in preference popup

### DIFF
--- a/browser/main/modals/PreferencesModal/StorageItem.js
+++ b/browser/main/modals/PreferencesModal/StorageItem.js
@@ -300,10 +300,10 @@ class StorageItem extends React.Component {
     })
 
     if (index === 0) {
-      let { storage, dispatch } = this.props
+      let { storage } = this.props
       dataApi.removeStorage(storage.key)
         .then(() => {
-          dispatch({
+          store.dispatch({
             type: 'REMOVE_STORAGE',
             storageKey: storage.key
           })


### PR DESCRIPTION
The unlink storage in the preference popup isn't working due to an error of calling dispatcher method. With this fix, it should working again.