### PR TITLE
Minor accelerator updates

### DIFF
--- a/browser/main/modals/PreferencesModal/ConfigTab.styl
+++ b/browser/main/modals/PreferencesModal/ConfigTab.styl
@@ -86,6 +86,10 @@
   p
     line-height 1.2
 
+colorDarkControl()
+  border-color $ui-dark-borderColor
+  background-color $ui-dark-backgroundColor
+  color $ui-dark-text-color
 body[data-theme="dark"]
   .root
     color $ui-dark-text-color
@@ -108,11 +112,7 @@ body[data-theme="dark"]
   .group-control-rightButton
     colorDarkPrimaryButton()
   .group-hint
-    border-color $ui-dark-borderColor
-    background-color $ui-dark-backgroundColor
-    color $ui-dark-text-color
+    colorDarkControl()
   .group-section-control
     select, .group-section-control-input
-      border-color $ui-dark-borderColor
-      background-color $ui-dark-backgroundColor
-      color $ui-dark-text-color
+      colorDarkControl()

--- a/browser/main/modals/PreferencesModal/ConfigTab.styl
+++ b/browser/main/modals/PreferencesModal/ConfigTab.styl
@@ -111,3 +111,8 @@ body[data-theme="dark"]
     border-color $ui-dark-borderColor
     background-color $ui-dark-backgroundColor
     color $ui-dark-text-color
+  .group-section-control
+    select, .group-section-control-input
+      border-color $ui-dark-borderColor
+      background-color $ui-dark-backgroundColor
+      color $ui-dark-text-color

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -54,7 +54,7 @@ var file = {
   submenu: [
     {
       label: 'New Note',
-      accelerator: OSX ? 'Command + N' : 'Control + N',
+      accelerator: 'CmdOrCtrl + N',
       click: function () {
         mainWindow.webContents.send('top:new-note')
       }
@@ -125,7 +125,7 @@ var view = {
   submenu: [
     {
       label: 'Reload',
-      accelerator: OSX ? 'Command+R' : 'Ctrl+R',
+      accelerator: 'CmdOrCtrl+R',
       click: function () {
         BrowserWindow.getFocusedWindow().reload()
       }

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -125,20 +125,14 @@ var view = {
   submenu: [
     {
       label: 'Reload',
-      accelerator: (function () {
-        if (process.platform === 'darwin') return 'Command+R'
-        else return 'Ctrl+R'
-      })(),
+      accelerator: OSX ? 'Command+R' : 'Ctrl+R',
       click: function () {
         BrowserWindow.getFocusedWindow().reload()
       }
     },
     {
       label: 'Toggle Developer Tools',
-      accelerator: (function () {
-        if (process.platform === 'darwin') return 'Command+Alt+I'
-        else return 'Ctrl+Shift+I'
-      })(),
+      accelerator: OSX ? 'Command+Alt+I' : 'Ctrl+Shift+I',
       click: function () {
         BrowserWindow.getFocusedWindow().toggleDevTools()
       }


### PR DESCRIPTION
This updates the accelerator to use the OSX boolean instead of a new function where appropriate.  Also, for accelerators that are identical across platforms *except* for Command/Control, the 'CmdOrCtrl' modifier is used.

Edit:
The dark theme will also be applied to the input boxes and dropdowns in the Config modal.