### PR TITLE
add support for custom url scheme boost://

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -9,6 +9,7 @@ import ConfigManager from 'browser/main/lib/ConfigManager'
 
 const { remote } = require('electron')
 const { Menu, MenuItem, dialog } = remote
+const { ipcRenderer } = electron
 
 function sortByCreatedAt (a, b) {
   return new Date(b.createdAt) - new Date(a.createdAt)
@@ -46,6 +47,8 @@ class NoteList extends React.Component {
     ee.on('list:next', this.selectNextNoteHandler)
     ee.on('list:prior', this.selectPriorNoteHandler)
     ee.on('list:focus', this.focusHandler)
+    var self = this;
+    ipcRenderer.on('ipc-open-note', function (event, uniqueKey) { self.showNote(uniqueKey); });
   }
 
   componentWillReceiveProps (nextProps) {
@@ -64,6 +67,8 @@ class NoteList extends React.Component {
     ee.off('list:next', this.selectNextNoteHandler)
     ee.off('list:prior', this.selectPriorNoteHandler)
     ee.off('list:focus', this.focusHandler)
+    var self = this;
+    ipcRenderer.removeListener('ipc-open-note', function (event, uniqueKey) { self.showNote(uniqueKey); });
   }
 
   componentDidUpdate (prevProps) {
@@ -220,6 +225,20 @@ class NoteList extends React.Component {
       : []
   }
 
+  showNote (uniqueKey) {
+    let { router } = this.context;
+    let { location } = this.props;
+
+    //TODO : check if note matching this uniqueKey exists
+
+    router.push({
+      pathname: location.pathname,
+      query: {
+        key: uniqueKey
+      }
+    });
+  }
+  
   handleNoteClick (e, uniqueKey) {
     let { router } = this.context
     let { location } = this.props

--- a/lib/main-app.js
+++ b/lib/main-app.js
@@ -13,6 +13,9 @@ var ipcServer = null
 var mainWindow = null
 var finderWindow = null
 
+var shouldOpenUrl = false;
+var urlToOpen = '';
+
 var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
   if (mainWindow) {
     if (process.platform === 'win32') {
@@ -97,6 +100,22 @@ function spawnFinder () {
   })
 }
 
+function openURL (url) {
+  //verify that url matches boostnote custom url scheme
+  let boostnoteUrlScheme = 'boost';
+  let urlPrefix = boostnoteUrlScheme + '://';
+  if (url.substring(0, urlPrefix.length) != urlPrefix) return;
+
+  //extract note uniqueKey from url
+  let uniqueKey = url.substring(urlPrefix.length, url.length);
+  //DEBUG : const uniqueKey
+  //let uniqueKey = 'd10cfc66ee6219028db8-4e35671f4545a6da975b'; //dri note uniqueKey
+  //let uniqueKey = '32e4d3ba364e2d9e0f58-dbb26b49dd71c3e353c4'; //Welcome note uniqueKey
+
+  //send message to NoteList to show note corresponding to uniqueKey
+  mainWindow.webContents.send('ipc-open-note', uniqueKey);
+}
+
 app.on('ready', function () {
   mainWindow = require('./main-window')
 
@@ -128,7 +147,24 @@ app.on('ready', function () {
   checkUpdate()
   ipcServer = require('./ipcServer')
   ipcServer.server.start()
+  
+  mainWindow.webContents.on('did-finish-load', function () {
+    //if app was launched with open-url
+    if (shouldOpenUrl) {
+      openURL(urlToOpen);
+      shouldOpenUrl = false;
+    }
+  });
 })
+
+//Listen to custom protocol incoming messages (if app not started, called before ready event)
+app.on('open-url', function (event, url) {
+  event.preventDefault();
+  //open URL if app ready - if not it means app was closed when URL was clicked. URL will be opened once app has fully loaded (webContents did-finish-load).
+  if (app.isReady()) openURL(url);
+  else { shouldOpenUrl = true; urlToOpen = url; }
+
+});
 
 module.exports = app
 


### PR DESCRIPTION
This allows to open a specific note in Boostnote knowing its `uniqueKey` thanks to the custom URL scheme feature, ex [boost://d10cfc66ee6219028db8-4e35671f4545a6da975b](boost://d10cfc66ee6219028db8-4e35671f4545a6da975b).

I works only on macOS ([electron](https://github.com/electron/electron) does not yet support custom URL schemes on other platforms AFAIK).

It should work whether app is already launched or not.

The URL scheme I chose for Boostnote is `boost://` but can easily be replaced.

For it to work, app `Info.plist` needs to be updated to add required keys :

```
<key>CFBundleURLTypes</key>
<array>
    <dict>
        <key>CFBundleURLName</key>
        <string>Boostnote</string>
        <key>CFBundleURLSchemes</key>
        <array>
            <string>boost</string>
        </array>
    </dict>
</array>
<key>NSUIElement</key>
<true>
</true>
```

This can automatically done with [electron-packager](https://github.com/electron-userland/electron-packager) by adding `protocol` and `protocol-name` parameters.

However Boostnote uses [grunt](https://github.com/gruntjs/grunt) for building and unfortunately grunt electron-packager integration [grunt-electron-installer](https://github.com/electron-archive/grunt-electron-installer) does not support `protocol` and `protocol-name` parameters (not among the several configuration settings supported : https://github.com/electron-archive/grunt-electron-installer#configuring). I still did try to add them to the `gruntfile.js` but with no luck (keys are not inserted into app `Info.plist`) : 

```
      case 'osx':
        Object.assign(opts, {
          platform: 'darwin',
          icon: path.join(__dirname, 'resources/app.icns'),
          'app-category-type': 'public.app-category.developer-tools',
          protocols: {
            name: 'boostnote',
            schemes: 'boost'
          }
        })
```

Please find below a script to compile and package the app without `grunt` (run it with Boostnote source dir as argument) :


```
#!/bin/sh

BOOSTNOTE_SOURCE_ROOT_DIR="$1"

#register node bin  path (using nvm)
NVM_DIR=~/.nvm
NVM_SCRIPT=/usr/local/opt/nvm/nvm.sh
source $NVM_SCRIPT

#compile
NODE_ENV=production \
BABEL_ENV=production \
$BOOSTNOTE_SOURCE_ROOT_DIR'/node_modules/.bin/webpack' \
--config webpack-production.config.js

#package (electron packager installed globally)
electron-packager $BOOSTNOTE_SOURCE_ROOT_DIR Boostnote \
--platform=darwin \
--version='1.2.8' \
--out=$BOOSTNOTE_SOURCE_ROOT_DIR'/dist' \
--overwrite \
--icon=$BOOSTNOTE_SOURCE_ROOT_DIR'/resources/app.icns' \
--arch=x64 \
--app-version='0.7.2' \
--app-bundle-id='com.maisin.boost' \
--asar=false \
--prune=true \
--overwrite=true \
--app-category-type='public.app-category.developer-tools' \
--ignore='/node_modules\/ace-builds\/(?!src-min)|node_modules\/ace-builds\/(?=src-min-noconflict)|node_modules\/devicon\/icons|dist|^\/browser|^\/secret|\.babelrc|\.gitignore|^\/\.gitmodules|^\/gruntfile|^\/readme.md|^\/webpack|^\/appdmg\.json|^\/node_modules\/grunt/' \
--protocol=boost \
--protocol-name=Boostnote
```

*Note : modify script with correct [node](https://github.com/nodejs/node) path if not using [nvm](https://github.com/creationix/nvm) or if using a different path. My setup is macOS 10.12 and nvm installed via [homebrew](https://github.com/Homebrew/brew)*.