### PR TITLE
Fixes the theme of code block by codemirror

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -184,7 +184,7 @@ export default class MarkdownPreview extends React.Component {
   }
 
   setCodeTheme (theme) {
-    theme = consts.THEMES.some((_theme) => _theme === theme)
+    theme = consts.THEMES.some((_theme) => _theme === theme) && theme !== 'default'
       ? theme
       : 'elegant'
     this.getWindow().document.getElementById('codeTheme').href = `${appPath}/node_modules/codemirror/theme/${theme}.css`

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -186,7 +186,7 @@ export default class MarkdownPreview extends React.Component {
   setCodeTheme (theme) {
     theme = consts.THEMES.some((_theme) => _theme === theme)
       ? theme
-      : 'default'
+      : 'elegant'
     this.getWindow().document.getElementById('codeTheme').href = `${appPath}/node_modules/codemirror/theme/${theme}.css`
   }
 

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -34,7 +34,7 @@ export const DEFAULT_CONFIG = {
   preview: {
     fontSize: '14',
     fontFamily: 'Lato',
-    codeBlockTheme: 'xcode',
+    codeBlockTheme: 'elegant',
     lineNumber: true
   }
 }


### PR DESCRIPTION
Hello, I get an error on loading css in preview code block like this picture below.

```
file:///Applications/Boostnote.app/Contents/Resources/app/node_modules/codemirror/theme/default.css Failed to load resource: net::ERR_FILE_NOT_FOUND
```

![2017-01-07 22 47 13](https://cloud.githubusercontent.com/assets/11307908/21742134/b3536686-d52b-11e6-947f-deec38cfdca3.png)

It means default.css is not available. Thus I tried to fix it. Then I found the default theme `xcode` is no longer available too. Perhaps the theme `elegant` is the most similar to previous one (I attach Screen Shot below).

![2017-01-07 23 09 08](https://cloud.githubusercontent.com/assets/11307908/21742271/8d79dda2-d52e-11e6-90f3-059135baccd7.png)

Please point out if I am wrong.