### PR TITLE
Decodes HTML entity in code area

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -219,7 +219,7 @@ export default class MarkdownPreview extends React.Component {
       let syntax = CodeMirror.findModeByName(el.className)
       if (syntax == null) syntax = CodeMirror.findModeByName('Plain Text')
       CodeMirror.requireMode(syntax.mode, () => {
-        let content = el.innerHTML
+        let content = decodeHTMLEntities(el.innerHTML)
         el.innerHTML = ''
         el.parentNode.className += ` cm-s-${codeBlockTheme} CodeMirror`
         CodeMirror.runMode(content, syntax.mime, el, {


### PR DESCRIPTION
Hello, I find a bug in code area on writing HTML entity. They would not be decoded.

![2017-01-08 12 28 36](https://cloud.githubusercontent.com/assets/11307908/21747072/58b3eae8-d59e-11e6-999a-7e6c860a55a8.png)

And I added encode, it works fine like below.

![2017-01-08 12 36 13](https://cloud.githubusercontent.com/assets/11307908/21747094/108e51d0-d59f-11e6-9817-f417147c2f24.png)
