### PR TITLE
Fixes npm task bacause oh-my-cdn is removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "start": "electron ./index.js",
     "hot": "electron ./index.js --hot",
     "webpack": "webpack-dev-server --hot --inline --config webpack.config.js",
-    "postinstall": "npm run vendor",
-    "vendor": "oh-my-cdn",
     "compile": "grunt compile",
     "test": "PWD=$(pwd) NODE_ENV=test ava"
   },


### PR DESCRIPTION
Hello, I got an error on `npm i`

```
[ Boostnote 11:17 ]% npm i                                                     [master]

> boost@0.8.0 postinstall /Users/ryouta/Boostnote_repo/Boostnote
> npm run vendor


> boost@0.8.0 vendor /Users/ryouta/Boostnote_repo/Boostnote
> oh-my-cdn

oh-my-cdn.json doesn't exist.

npm ERR! Darwin 15.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "vendor"
npm ERR! node v4.4.1
npm ERR! npm  v3.10.9
npm ERR! code ELIFECYCLE
npm ERR! boost@0.8.0 vendor: `oh-my-cdn`
npm ERR! Exit status 1
```

According to https://github.com/BoostIO/Boostnote/commit/76508fbc3b0fca931257376c0af44a26c7db614d, oh-my-cdn is removed.

refs: https://github.com/BoostIO/Boostnote/issues/140