### PR TITLE
Multiple key mapping on Preview

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -39,10 +39,10 @@ class NoteList extends React.Component {
       this.refs.list.focus()
     }
 
+    this.hotkey = props.config.hotkey
+
     this.state = {
     }
-
-    this.shortcutKey = props.config.preview.shortcutKey
   }
 
   componentDidMount () {
@@ -161,43 +161,43 @@ class NoteList extends React.Component {
   }
 
   handleNoteListKeyDown (e) {
-    this.shortcutKey.keyPressed[e.key] = true
-    let isShortcutKey = (e) => { return this.shortcutKey.keyPressed[e] }
+    this.hotkey.keyPressed[e.key] = true
+    let isShortcutKey = (e) => { return this.hotkey.keyPressed[e] }
     if (e.metaKey || e.ctrlKey) return true
 
-    if (this.shortcutKey.createNote.every(isShortcutKey)) {
+    if (this.hotkey.createNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('top:new-note')
-      this.shortcutKey.createNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
+      this.hotkey.createNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
     }
 
-    if (this.shortcutKey.deleteNote.every(isShortcutKey)) {
+    if (this.hotkey.deleteNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('detail:delete')
-      this.shortcutKey.deleteNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
+      this.hotkey.deleteNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
     }
 
-    if (this.shortcutKey.focusNote.every(isShortcutKey)) {
+    if (this.hotkey.focusNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('detail:focus')
-      this.shortcutKey.focusNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
+      this.hotkey.focusNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
     }
 
-    if (this.shortcutKey.priorNote.every(isShortcutKey)) {
+    if (this.hotkey.priorNote.every(isShortcutKey)) {
       e.preventDefault()
       this.selectPriorNote()
-      this.shortcutKey.priorNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
+      this.hotkey.priorNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
     }
 
-    if (this.shortcutKey.nextNote.every(isShortcutKey)) {
+    if (this.hotkey.nextNote.every(isShortcutKey)) {
       e.preventDefault()
       this.selectNextNote()
-      this.shortcutKey.nextNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
+      this.hotkey.nextNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
     }
   }
 
   handleNoteListKeyUp (e) {
-    this.shortcutKey.keyPressed[e.key] = false
+    this.hotkey.keyPressed[e.key] = false
   }
 
   getNotes () {

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -161,32 +161,43 @@ class NoteList extends React.Component {
   }
 
   handleNoteListKeyDown (e) {
+    this.shortcutKey.keyPressed[e.key] = true
+    let isShortcutKey = (e) => { return this.shortcutKey.keyPressed[e] }
     if (e.metaKey || e.ctrlKey) return true
 
-    if (e.key === this.shortcutKey.createNote && !e.shiftKey) {
+    if (this.shortcutKey.createNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('top:new-note')
+      this.shortcutKey.createNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
     }
 
-    if (e.key === this.shortcutKey.deleteNote) {
+    if (this.shortcutKey.deleteNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('detail:delete')
+      this.shortcutKey.deleteNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
     }
 
-    if (e.key === this.shortcutKey.focusNote) {
+    if (this.shortcutKey.focusNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('detail:focus')
+      this.shortcutKey.focusNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
     }
 
-    if (e.key === this.shortcutKey.priorNote) {
+    if (this.shortcutKey.priorNote.every(isShortcutKey)) {
       e.preventDefault()
       this.selectPriorNote()
+      this.shortcutKey.priorNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
     }
 
-    if (e.key === this.shortcutKey.nextNote) {
+    if (this.shortcutKey.nextNote.every(isShortcutKey)) {
       e.preventDefault()
       this.selectNextNote()
+      this.shortcutKey.nextNote.forEach((el) => {this.shortcutKey.keyPressed[el] = false})
     }
+  }
+
+  handleNoteListKeyUp (e) {
+    this.shortcutKey.keyPressed[e.key] = false
   }
 
   getNotes () {
@@ -393,6 +404,7 @@ class NoteList extends React.Component {
           ref='list'
           tabIndex='-1'
           onKeyDown={(e) => this.handleNoteListKeyDown(e)}
+          onKeyUp={(e) => this.handleNoteListKeyUp(e)}
         >
           {noteList}
         </div>

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -161,43 +161,43 @@ class NoteList extends React.Component {
   }
 
   handleNoteListKeyDown (e) {
-    this.hotkey.keyPressed[e.key] = true
-    let isShortcutKey = (e) => { return this.hotkey.keyPressed[e] }
+    this.hotkey.noteHandlerKey.keyPressed[e.key] = true
+    let isShortcutKey = (el) => { return this.hotkey.noteHandlerKey.keyPressed[el] }
     if (e.metaKey || e.ctrlKey) return true
 
-    if (this.hotkey.createNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.createNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('top:new-note')
-      this.hotkey.createNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
+      this.hotkey.noteHandlerKey.createNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.deleteNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.deleteNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('detail:delete')
-      this.hotkey.deleteNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
+      this.hotkey.noteHandlerKey.deleteNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.focusNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.focusNote.every(isShortcutKey)) {
       e.preventDefault()
       ee.emit('detail:focus')
-      this.hotkey.focusNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
+      this.hotkey.noteHandlerKey.focusNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.priorNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.priorNote.every(isShortcutKey)) {
       e.preventDefault()
       this.selectPriorNote()
-      this.hotkey.priorNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
+      this.hotkey.noteHandlerKey.priorNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.nextNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.nextNote.every(isShortcutKey)) {
       e.preventDefault()
       this.selectNextNote()
-      this.hotkey.nextNote.forEach((el) => {this.hotkey.keyPressed[el] = false})
+      this.hotkey.noteHandlerKey.nextNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
   }
 
   handleNoteListKeyUp (e) {
-    this.hotkey.keyPressed[e.key] = false
+    this.hotkey.noteHandlerKey.keyPressed[e.key] = false
   }
 
   getNotes () {

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -41,6 +41,8 @@ class NoteList extends React.Component {
 
     this.state = {
     }
+
+    this.shortcutKey = props.config.preview.shortcutKey
   }
 
   componentDidMount () {
@@ -161,27 +163,27 @@ class NoteList extends React.Component {
   handleNoteListKeyDown (e) {
     if (e.metaKey || e.ctrlKey) return true
 
-    if (e.keyCode === 65 && !e.shiftKey) {
+    if (e.key === this.shortcutKey.createNote && !e.shiftKey) {
       e.preventDefault()
       ee.emit('top:new-note')
     }
 
-    if (e.keyCode === 68) {
+    if (e.key === this.shortcutKey.deleteNote) {
       e.preventDefault()
       ee.emit('detail:delete')
     }
 
-    if (e.keyCode === 69) {
+    if (e.key === this.shortcutKey.focusNote) {
       e.preventDefault()
       ee.emit('detail:focus')
     }
 
-    if (e.keyCode === 38) {
+    if (e.key === this.shortcutKey.priorNote) {
       e.preventDefault()
       this.selectPriorNote()
     }
 
-    if (e.keyCode === 40) {
+    if (e.key === this.shortcutKey.nextNote) {
       e.preventDefault()
       this.selectNextNote()
     }

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -162,34 +162,34 @@ class NoteList extends React.Component {
 
   handleNoteListKeyDown (e) {
     this.hotkey.noteHandlerKey.keyPressed[e.key] = true
-    let isShortcutKey = (el) => { return this.hotkey.noteHandlerKey.keyPressed[el] }
+    let isNoteHandlerKey = (el) => { return this.hotkey.noteHandlerKey.keyPressed[el] }
     if (e.metaKey || e.ctrlKey) return true
 
-    if (this.hotkey.noteHandlerKey.createNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.createNote.every(isNoteHandlerKey)) {
       e.preventDefault()
       ee.emit('top:new-note')
       this.hotkey.noteHandlerKey.createNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.noteHandlerKey.deleteNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.deleteNote.every(isNoteHandlerKey)) {
       e.preventDefault()
       ee.emit('detail:delete')
       this.hotkey.noteHandlerKey.deleteNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.noteHandlerKey.focusNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.focusNote.every(isNoteHandlerKey)) {
       e.preventDefault()
       ee.emit('detail:focus')
       this.hotkey.noteHandlerKey.focusNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.noteHandlerKey.priorNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.priorNote.every(isNoteHandlerKey)) {
       e.preventDefault()
       this.selectPriorNote()
       this.hotkey.noteHandlerKey.priorNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})
     }
 
-    if (this.hotkey.noteHandlerKey.nextNote.every(isShortcutKey)) {
+    if (this.hotkey.noteHandlerKey.nextNote.every(isNoteHandlerKey)) {
       e.preventDefault()
       this.selectNextNote()
       this.hotkey.noteHandlerKey.nextNote.forEach((el) => {this.hotkey.noteHandlerKey.keyPressed[el] = false})

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -16,7 +16,13 @@ export const DEFAULT_CONFIG = {
   listStyle: 'DEFAULT', // 'DEFAULT', 'SMALL'
   hotkey: {
     toggleFinder: OSX ? 'Cmd + Alt + S' : 'Super + Alt + S',
-    toggleMain: OSX ? 'Cmd + Alt + L' : 'Super + Alt + E'
+    toggleMain: OSX ? 'Cmd + Alt + L' : 'Super + Alt + E',
+    keyPressed: [],
+    createNote: ['a'],
+    deleteNote: ['d'],
+    focusNote: ['e'],
+    priorNote: ['ArrowUp'],
+    nextNote: ['ArrowDown']
   },
   ui: {
     theme: 'default',
@@ -35,15 +41,7 @@ export const DEFAULT_CONFIG = {
     fontSize: '14',
     fontFamily: 'Lato',
     codeBlockTheme: 'elegant',
-    lineNumber: true,
-    shortcutKey: {
-      keyPressed: [],
-      deleteNote: ['d'],
-      createNote: ['a'],
-      focusNote: ['e'],
-      priorNote: ['ArrowUp'],
-      nextNote: ['ArrowDown']
-    }
+    lineNumber: true
   }
 }
 

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -35,7 +35,14 @@ export const DEFAULT_CONFIG = {
     fontSize: '14',
     fontFamily: 'Lato',
     codeBlockTheme: 'elegant',
-    lineNumber: true
+    lineNumber: true,
+    shortcutKey: {
+      deleteNote: 'd',
+      createNote: 'a',
+      focusNote: 'e',
+      priorNote: 'ArrowDown',
+      nextNote: 'ArrowUp'
+    }
   }
 }
 

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -37,11 +37,12 @@ export const DEFAULT_CONFIG = {
     codeBlockTheme: 'elegant',
     lineNumber: true,
     shortcutKey: {
-      deleteNote: 'd',
-      createNote: 'a',
-      focusNote: 'e',
-      priorNote: 'ArrowDown',
-      nextNote: 'ArrowUp'
+      keyPressed: [],
+      deleteNote: ['d'],
+      createNote: ['a'],
+      focusNote: ['e'],
+      priorNote: ['ArrowUp'],
+      nextNote: ['ArrowDown']
     }
   }
 }

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -17,12 +17,14 @@ export const DEFAULT_CONFIG = {
   hotkey: {
     toggleFinder: OSX ? 'Cmd + Alt + S' : 'Super + Alt + S',
     toggleMain: OSX ? 'Cmd + Alt + L' : 'Super + Alt + E',
-    keyPressed: [],
-    createNote: ['a'],
-    deleteNote: ['d'],
-    focusNote: ['e'],
-    priorNote: ['ArrowUp'],
-    nextNote: ['ArrowDown']
+    noteHandlerKey: {
+      keyPressed: [],
+      createNote: ['a'],
+      deleteNote: ['d'],
+      focusNote: ['e'],
+      priorNote: ['ArrowUp'],
+      nextNote: ['ArrowDown']
+    }
   },
   ui: {
     theme: 'default',


### PR DESCRIPTION
#Hi,

to handle https://github.com/BoostIO/Boostnote/issues/226, we need to implement multiple key recognition first. And I'd like to discuss based on source code.

On this PR, when I want to delete a note by `Delete` key, I change `config.hotkey.createNote` from `d` to `Delete`.

By the way, I switched `e.keyCode` to` e.key` because `e.keyCode` is a deprecated API. refs: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent

Finally, I'm not sure I wrote a good code thus you can ask anything.