### PR TITLE
refs #224 Fixes the style of folder-list

### DIFF
--- a/browser/components/StorageItem.styl
+++ b/browser/components/StorageItem.styl
@@ -39,6 +39,8 @@
   border-width 0 0 0 3px
   border-style solid
   border-color transparent
+  overflow hidden
+  text-overflow ellipsis
 
 .folderList-item-noteCount
   float right


### PR DESCRIPTION
Hi, I fixed https://github.com/BoostIO/Boostnote/pull/224

![2017-01-11 10 24 08](https://cloud.githubusercontent.com/assets/11307908/21831589/1e753746-d7e8-11e6-80a8-7afcb8cf737d.png)