### PR TITLE
Fixes syntax hilight of inline code on Preview

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -50,6 +50,7 @@ body {
 code {
   font-family: ${codeBlockFontFamily.join(', ')};
   background-color: rgba(0,0,0,0.04);
+  color: #CC305F;
 }
 .lineNumber {
   ${lineNumber && 'display: block !important;'}

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -49,6 +49,7 @@ body {
 }
 code {
   font-family: ${codeBlockFontFamily.join(', ')};
+  background-color: rgba(0,0,0,0.04);
 }
 .lineNumber {
   ${lineNumber && 'display: block !important;'}


### PR DESCRIPTION
Hi, I fixed the bug reported by https://github.com/BoostIO/Boostnote/issues/208.

![2017-01-14 20 46 43](https://cloud.githubusercontent.com/assets/11307908/21954650/b6cee32a-da9a-11e6-9419-b146eb3803ce.png)

![2017-01-14 20 46 54](https://cloud.githubusercontent.com/assets/11307908/21954653/ca9c2048-da9a-11e6-84ab-2a6bceaad6e8.png)

I referenced GitHub for this style.