### PR TITLE
Fix a bug due to event handler of before-quit on update

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -49,7 +49,12 @@ if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') 
   })
 
   app.on('before-quit', function (e) {
-    config.set('windowsize', mainWindow.getBounds())
+    try {
+      config.set('windowsize', mainWindow.getBounds())
+    } catch (e) {
+      // ignore any errors because an error occurs only on update
+      // refs: https://github.com/BoostIO/Boostnote/issues/243
+    }
     mainWindow.removeAllListeners()
   })
 } else {


### PR DESCRIPTION
For now, I'd like to suggest ignoring any errors at `config.set('windowsize', mainWindow.getBounds())`. I checked this code behaviors as expected.
https://github.com/BoostIO/Boostnote/issues/243