### PR TITLE
modify: add more zoom options (140-200%)

### DIFF
--- a/browser/main/StatusBar/index.js
+++ b/browser/main/StatusBar/index.js
@@ -8,7 +8,7 @@ const electron = require('electron')
 const { remote, ipcRenderer } = electron
 const { Menu, MenuItem, dialog } = remote
 
-const zoomOptions = [0.8, 0.9, 1, 1.1, 1.2, 1.3]
+const zoomOptions = [0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
 
 class StatusBar extends React.Component {
   updateApp () {


### PR DESCRIPTION
The current max zoom % (130%) is a bit small on large screen (3840 x 2160, hi-resolution but not so large display etc.).
Probably, it is also related to the default text color (`#939395`) or the font-weight (`normal`) but more zoom % makes text more readable enough.

e.g. 130% (current max zoom, a bit small), 150% (readable), 200% (super readable, a bit large)

See also: https://github.com/BoostIO/Boostnote/issues/31#issuecomment-267843725

![100](https://cloud.githubusercontent.com/assets/1211058/22033037/342fab56-dd2a-11e6-9be3-0f45f0cc7e93.png)
![130](https://cloud.githubusercontent.com/assets/1211058/22033040/3434d9be-dd2a-11e6-9782-e8f7c77c56a3.png)
![150](https://cloud.githubusercontent.com/assets/1211058/22033038/34323768-dd2a-11e6-8179-43921e67aa10.png)
![200](https://cloud.githubusercontent.com/assets/1211058/22033039/3433cdbc-dd2a-11e6-9d72-b99dc3182f1a.png)
![200-2](https://cloud.githubusercontent.com/assets/1211058/22033041/3435dd64-dd2a-11e6-8707-2f68d6ffdbaa.png)




