### PR TITLE
Dropping images into CodeEditor

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -163,6 +163,18 @@ export default class CodeEditor extends React.Component {
     this.editor.setCursor(cursor)
   }
 
+  handleDrop (e) {
+    e.preventDefault()
+    let path = e.dataTransfer.files[0].path
+    let filename = path.match(".+/(.+?)\.[a-z]+([\?#;].*)?$")[1]
+    let imageMd = "![" + filename + "](" + path + ")"
+    this.insertImage(this.editor.getInputField(), imageMd)
+  }
+
+  insertImage (textarea, imageMd) {
+    textarea.value = textarea.value.substr(0, textarea.selectionStart) + imageMd + textarea.value.substr(textarea.selectionEnd)
+  }
+
   render () {
     let { className, fontFamily, fontSize } = this.props
     fontFamily = _.isString(fontFamily) && fontFamily.length > 0
@@ -180,6 +192,7 @@ export default class CodeEditor extends React.Component {
           fontFamily: fontFamily.join(', '),
           fontSize: fontSize
         }}
+        onDrop={(e) => this.handleDrop(e)}
       />
     )
   }

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import _ from 'lodash'
 import CodeMirror from 'codemirror'
+import path from 'path'
 
 CodeMirror.modeURL = '../node_modules/codemirror/mode/%N/%N.js'
 
@@ -163,15 +164,16 @@ export default class CodeEditor extends React.Component {
     this.editor.setCursor(cursor)
   }
 
-  handleDrop (e) {
+  handleDropImage (e) {
     e.preventDefault()
-    let path = e.dataTransfer.files[0].path
-    let filename = path.match(".+/(.+?)\.[a-z]+([\?#;].*)?$")[1]
-    let imageMd = "![" + filename + "](" + path + ")"
-    this.insertImage(this.editor.getInputField(), imageMd)
+    let imagePath = e.dataTransfer.files[0].path
+    let filename = path.basename(imagePath)
+    let imageMd = `![${filename}](${imagePath})`
+    this.insertImage(imageMd)
   }
 
-  insertImage (textarea, imageMd) {
+  insertImage (imageMd) {
+    const textarea = this.editor.getInputField()
     textarea.value = textarea.value.substr(0, textarea.selectionStart) + imageMd + textarea.value.substr(textarea.selectionEnd)
   }
 
@@ -192,7 +194,7 @@ export default class CodeEditor extends React.Component {
           fontFamily: fontFamily.join(', '),
           fontSize: fontSize
         }}
-        onDrop={(e) => this.handleDrop(e)}
+        onDrop={(e) => this.handleDropImage(e)}
       />
     )
   }


### PR DESCRIPTION
Hi, I enabled to drop images into CodeEditor like this:
![c9b06a9475a795acdd70320159b5a5f1](https://cloud.githubusercontent.com/assets/11307908/22072909/33bd8c16-dde7-11e6-8529-7131e309a655.gif)

Next, to handle broken link, I should implement saving images into a directory for boostnote.