### PR TITLE
add rpm support

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -50,6 +50,25 @@ module.exports = function (grunt) {
         src: path.join(__dirname, 'dist', 'Boostnote-linux-x64'),
         dest: path.join(__dirname, 'dist')
       }
+    },
+    'electron-installer-redhat': {
+      app: {
+        options: {
+          name: 'boostnote',
+          productName: 'Boostnote',
+          genericName: 'Boostnote',
+          productDescription: 'The opensource note app for developer.',
+          arch: 'x86_64',
+          categories: [
+            'Development',
+            'Utility'
+          ],
+          icon: path.join(__dirname, 'resources/app.png'),
+          bin: 'Boostnote'
+        },
+        src: path.join(__dirname, 'dist', 'Boostnote-linux-x64'),
+        dest: path.join(__dirname, 'dist')
+      }
     }
   }
 
@@ -57,6 +76,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-electron-installer')
   if (!WIN) {
     grunt.loadNpmTasks('grunt-electron-installer-debian')
+    grunt.loadNpmTasks('grunt-electron-installer-redhat')
   }
 
   grunt.registerTask('compile', function () {
@@ -244,7 +264,7 @@ module.exports = function (grunt) {
         grunt.task.run(['compile', 'pack:osx', 'codesign', 'create-osx-installer', 'zip:osx'])
         break
       case 'linux':
-        grunt.task.run(['compile', 'pack:linux', 'electron-installer-debian'])
+        grunt.task.run(['compile', 'pack:linux', 'electron-installer-debian', 'electron-installer-redhat'])
         break
     }
   })

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "webpack-dev-server": "^1.12.0"
   },
   "optionalDependencies": {
-    "grunt-electron-installer-debian": "^0.2.0"
+    "grunt-electron-installer-debian": "^0.2.0",
+    "grunt-electron-installer-redhat": "^0.3.1"
   },
   "optional": false,
   "ava": {


### PR DESCRIPTION
Hi, 

I'm usually use Fedora, so I happy if the official rpm  package will be provided in the future.
This PR make it able to build rpm package using [grunt-electron-installer-redhat](https://www.npmjs.com/package/grunt-electron-installer-redhat).

I confirmed with Fedora and Ubuntu that the build will succeed with this change.
[This is Dockerfile I used for test build.](https://gist.github.com/kazuhisya/98e8f480d5edfcf50cc52755c352ebb0) and you can check the details by `docker build` this.

I'd happy it if you could review. Thank you!

Related: #5

Signed-off-by: Kazuhisa Hara <kazuhisya@gmail.com>