### PR TITLE
Fix Ctrl + E shortcut on escape from CodeEditor

### DIFF
--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -77,6 +77,7 @@ class MarkdownEditor extends React.Component {
   }
 
   handleBlur (e) {
+    this.setState({ keyPressed: [] })
     let { config } = this.props
     if (config.editor.switchPreview === 'BLUR') {
       let cursorPosition = this.refs.code.editor.getCursor()


### PR DESCRIPTION
Hi, I fixed a reported bug which is escaped on pressed any key in CodeEditor when you focus for editing the note by click.

related: https://github.com/BoostIO/Boostnote/issues/268