### PR TITLE
Enable lock in MarkdownEditor

### DIFF
--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -19,13 +19,11 @@ class MarkdownEditor extends React.Component {
     }
 
     this.lockEditorCode = () => this.handleLockEditor()
-    this.getEditorStatus = () => this.handleGetEditorStatus()
   }
 
   componentDidMount () {
     this.value = this.refs.code.value
     eventEmitter.on('editor:lock', this.lockEditorCode)
-    eventEmitter.on('editor:status', this.getEditorStatus)
   }
 
   componentDidUpdate () {
@@ -41,7 +39,6 @@ class MarkdownEditor extends React.Component {
   componentWillUnmount () {
     this.cancelQueue()
     eventEmitter.off('editor:lock', this.lockEditorCode)
-    eventEmitter.off('editor:status', this.getEditorStatus)
   }
 
   queueRendering (value) {
@@ -94,6 +91,7 @@ class MarkdownEditor extends React.Component {
       this.setState({
         status: 'PREVIEW'
       }, () => {
+        eventEmitter.emit('topbar:lock')
         this.refs.preview.focus()
         this.refs.preview.scrollTo(cursorPosition.line)
       })
@@ -143,6 +141,7 @@ class MarkdownEditor extends React.Component {
       this.setState({
         status: 'CODE'
       }, () => {
+        eventEmitter.emit('topbar:lock')
         this.refs.code.focus()
       })
     } else {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -15,7 +15,7 @@ class MarkdownEditor extends React.Component {
       status: 'PREVIEW',
       renderValue: props.value,
       keyPressed: {},
-      locked: false
+      isLocked: false
     }
 
     this.lockEditorCode = () => this.handleLockEditor()
@@ -74,18 +74,17 @@ class MarkdownEditor extends React.Component {
       }, () => {
         if (newStatus === 'CODE') {
           this.refs.code.focus()
-          eventEmitter.emit('topbar:lock')
         } else {
           this.refs.code.blur()
           this.refs.preview.focus()
-          eventEmitter.emit('topbar:lock')
         }
+        eventEmitter.emit('topbar:showlockbutton')
       })
     }
   }
 
   handleBlur (e) {
-    if (this.state.locked) return
+    if (this.state.isLocked) return
     this.setState({ keyPressed: [] })
     let { config } = this.props
     if (config.editor.switchPreview === 'BLUR') {
@@ -95,8 +94,8 @@ class MarkdownEditor extends React.Component {
       }, () => {
         this.refs.preview.focus()
         this.refs.preview.scrollTo(cursorPosition.line)
-        eventEmitter.emit('topbar:lock')
       })
+      eventEmitter.emit('topbar:showlockbutton')
     }
   }
 
@@ -111,8 +110,8 @@ class MarkdownEditor extends React.Component {
         status: 'CODE'
       }, () => {
         this.refs.code.focus()
-        eventEmitter.emit('topbar:lock')
       })
+      eventEmitter.emit('topbar:showlockbutton')
     }
   }
 
@@ -144,13 +143,12 @@ class MarkdownEditor extends React.Component {
       this.setState({
         status: 'CODE'
       }, () => {
-        eventEmitter.emit('topbar:lock')
         this.refs.code.focus()
       })
     } else {
-      eventEmitter.emit('topbar:lock')
       this.refs.code.focus()
     }
+    eventEmitter.emit('topbar:showlockbutton')
   }
 
   reload () {
@@ -165,7 +163,7 @@ class MarkdownEditor extends React.Component {
     })
     this.setState({ keyPressed })
     let isNoteHandlerKey = (el) => { return this.state.keyPressed[el] }
-    if (!this.state.locked && this.state.status === 'CODE' && this.escapeFromEditor.every(isNoteHandlerKey)) {
+    if (!this.state.isLocked && this.state.status === 'CODE' && this.escapeFromEditor.every(isNoteHandlerKey)) {
       document.activeElement.blur()
     }
   }
@@ -178,7 +176,7 @@ class MarkdownEditor extends React.Component {
   }
 
   handleLockEditor () {
-    this.setState({ locked: !this.state.locked })
+    this.setState({ isLocked: !this.state.isLocked })
   }
 
   render () {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -74,9 +74,11 @@ class MarkdownEditor extends React.Component {
       }, () => {
         if (newStatus === 'CODE') {
           this.refs.code.focus()
+          eventEmitter.emit('topbar:lock')
         } else {
           this.refs.code.blur()
           this.refs.preview.focus()
+          eventEmitter.emit('topbar:lock')
         }
       })
     }
@@ -91,9 +93,9 @@ class MarkdownEditor extends React.Component {
       this.setState({
         status: 'PREVIEW'
       }, () => {
-        eventEmitter.emit('topbar:lock')
         this.refs.preview.focus()
         this.refs.preview.scrollTo(cursorPosition.line)
+        eventEmitter.emit('topbar:lock')
       })
     }
   }
@@ -109,6 +111,7 @@ class MarkdownEditor extends React.Component {
         status: 'CODE'
       }, () => {
         this.refs.code.focus()
+        eventEmitter.emit('topbar:lock')
       })
     }
   }
@@ -145,6 +148,7 @@ class MarkdownEditor extends React.Component {
         this.refs.code.focus()
       })
     } else {
+      eventEmitter.emit('topbar:lock')
       this.refs.code.focus()
     }
   }

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -26,13 +26,20 @@ class MarkdownNoteDetail extends React.Component {
         title: '',
         content: ''
       }, props.note),
+      isCODE: false,
       locked: false
     }
     this.dispatchTimer = null
+
+    this.showLockButton = () => this.handleShowLockButton()
   }
 
   focus () {
     this.refs.content.focus()
+  }
+
+  componentDidMount () {
+    ee.on('topbar:lock', this.showLockButton)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -49,6 +56,10 @@ class MarkdownNoteDetail extends React.Component {
 
   componentWillUnmount () {
     if (this.saveQueue != null) this.saveNow()
+  }
+
+  componentDidUnmount () {
+    ee.off('topbar:lock', this.showLockButton)
   }
 
   findTitle (value) {
@@ -215,6 +226,10 @@ class MarkdownNoteDetail extends React.Component {
     if (e.keyCode === 27) this.handleDeleteCancelButtonClick(e)
   }
 
+  handleShowLockButton () {
+    this.setState({isCODE: !this.state.isCODE})
+  }
+
   render () {
     let { data, config } = this.props
     let { note } = this.state
@@ -247,10 +262,8 @@ class MarkdownNoteDetail extends React.Component {
           </div>
           <div styleName='info-right'>
             {(() => {
-              // TODO: get a state of MarkdownEditor somehow
-              const editorStatus='CODE'
               let faClassName=`fa ${this.toggleLockButton()}`
-              if (editorStatus === 'CODE') {
+              if (this.state.isCODE) {
                 return(
                   <button styleName='info-right-button'
                     onClick={(e) => this.handleLockButtonClick(e)}

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -26,7 +26,7 @@ class MarkdownNoteDetail extends React.Component {
         title: '',
         content: ''
       }, props.note),
-      isCODE: false,
+      editorStatus: false,
       locked: false
     }
     this.dispatchTimer = null
@@ -213,8 +213,8 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleLockButtonClick () {
-    ee.emit('editor:lock')
     this.focus()
+    ee.emit('editor:lock')
     this.setState({ locked: !this.state.locked })
   }
 
@@ -227,7 +227,11 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleShowLockButton () {
-    this.setState({isCODE: !this.state.isCODE})
+    this.setState({editorStatus: this.refs.content.state.status})
+  }
+
+  handleFocus (e) {
+    this.focus()
   }
 
   render () {
@@ -263,9 +267,10 @@ class MarkdownNoteDetail extends React.Component {
           <div styleName='info-right'>
             {(() => {
               let faClassName=`fa ${this.toggleLockButton()}`
-              if (this.state.isCODE) {
+              if (this.state.editorStatus === 'CODE') {
                 return(
                   <button styleName='info-right-button'
+                    onFocus={(e) => this.handleFocus(e)}
                     onClick={(e) => this.handleLockButtonClick(e)}
                   >
                     <i className={faClassName}/>

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -31,7 +31,7 @@ class MarkdownNoteDetail extends React.Component {
     }
     this.dispatchTimer = null
 
-    this.showLockButton = () => this.handleShowLockButton()
+    this.showLockButton = this.handleShowLockButton.bind(this)
   }
 
   focus () {
@@ -218,7 +218,7 @@ class MarkdownNoteDetail extends React.Component {
     this.setState({ isLocked: !this.state.isLocked })
   }
 
-  toggleLockButton () {
+  getToggleLockButton () {
     return this.state.isLocked ? 'fa-lock' : 'fa-unlock-alt'
   }
 
@@ -266,17 +266,17 @@ class MarkdownNoteDetail extends React.Component {
           </div>
           <div styleName='info-right'>
             {(() => {
-              let faClassName=`fa ${this.toggleLockButton()}`
-              if (this.state.editorStatus === 'CODE') {
-                return(
-                  <button styleName='info-right-button'
-                    onFocus={(e) => this.handleFocus(e)}
-                    onMouseDown={(e) => this.handleLockButtonMouseDown(e)}
-                  >
-                    <i className={faClassName}/>
-                  </button>
-                )
-              }
+              const faClassName=`fa ${this.getToggleLockButton()}`
+              const lockButtonComponent =
+                <button styleName='info-right-button'
+                  onFocus={(e) => this.handleFocus(e)}
+                  onMouseDown={(e) => this.handleLockButtonMouseDown(e)}
+                >
+                  <i className={faClassName}/>
+                </button>
+              return (
+                this.state.editorStatus === 'CODE' ? lockButtonComponent : ''
+              )
             })()}
             <button styleName='info-right-button'
               onClick={(e) => this.handleContextButtonClick(e)}

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -25,7 +25,8 @@ class MarkdownNoteDetail extends React.Component {
       note: Object.assign({
         title: '',
         content: ''
-      }, props.note)
+      }, props.note),
+      locked: false
     }
     this.dispatchTimer = null
   }
@@ -200,6 +201,16 @@ class MarkdownNoteDetail extends React.Component {
     }
   }
 
+  handleLockButtonClick () {
+    ee.emit('editor:lock')
+    this.focus()
+    this.setState({ locked: !this.state.locked })
+  }
+
+  toggleLockButton () {
+    return this.state.locked ? 'fa-lock' : 'fa-unlock-alt'
+  }
+
   handleDeleteKeyDown (e) {
     if (e.keyCode === 27) this.handleDeleteCancelButtonClick(e)
   }
@@ -235,6 +246,20 @@ class MarkdownNoteDetail extends React.Component {
             />
           </div>
           <div styleName='info-right'>
+            {(() => {
+              // TODO: get a state of MarkdownEditor somehow
+              const editorStatus='CODE'
+              let faClassName=`fa ${this.toggleLockButton()}`
+              if (editorStatus === 'CODE') {
+                return(
+                  <button styleName='info-right-button'
+                    onClick={(e) => this.handleLockButtonClick(e)}
+                  >
+                    <i className={faClassName}/>
+                  </button>
+                )
+              }
+            })()}
             <button styleName='info-right-button'
               onClick={(e) => this.handleContextButtonClick(e)}
             >

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -27,7 +27,7 @@ class MarkdownNoteDetail extends React.Component {
         content: ''
       }, props.note),
       editorStatus: false,
-      locked: false
+      isLocked: false
     }
     this.dispatchTimer = null
 
@@ -39,7 +39,7 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   componentDidMount () {
-    ee.on('topbar:lock', this.showLockButton)
+    ee.on('topbar:showlockbutton', this.showLockButton)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -212,14 +212,14 @@ class MarkdownNoteDetail extends React.Component {
     }
   }
 
-  handleLockButtonClick () {
-    this.focus()
+  handleLockButtonMouseDown (e) {
+    e.preventDefault()
     ee.emit('editor:lock')
-    this.setState({ locked: !this.state.locked })
+    this.setState({ isLocked: !this.state.isLocked })
   }
 
   toggleLockButton () {
-    return this.state.locked ? 'fa-lock' : 'fa-unlock-alt'
+    return this.state.isLocked ? 'fa-lock' : 'fa-unlock-alt'
   }
 
   handleDeleteKeyDown (e) {
@@ -271,7 +271,7 @@ class MarkdownNoteDetail extends React.Component {
                 return(
                   <button styleName='info-right-button'
                     onFocus={(e) => this.handleFocus(e)}
-                    onClick={(e) => this.handleLockButtonClick(e)}
+                    onMouseDown={(e) => this.handleLockButtonMouseDown(e)}
                   >
                     <i className={faClassName}/>
                   </button>


### PR DESCRIPTION
Hi, I added a function which keeps Editor mode even though I move to another window.

![pic](https://i.gyazo.com/8adc4a61336fabd2e2434168fa2604d6.gif)

refs: https://github.com/BoostIO/Boostnote/issues/272