### PR TITLE
Image drag fix

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -168,13 +168,13 @@ export default class CodeEditor extends React.Component {
     e.preventDefault()
     let imagePath = e.dataTransfer.files[0].path
     let filename = path.basename(imagePath)
-    let imageMd = `![${filename}](${imagePath})`
+    let imageMd = `![${encodeURI(filename)}](${encodeURI(imagePath)})`
     this.insertImage(imageMd)
   }
 
   insertImage (imageMd) {
-    const textarea = this.editor.getInputField()
-    textarea.value = textarea.value.substr(0, textarea.selectionStart) + imageMd + textarea.value.substr(textarea.selectionEnd)
+    const cm = this.editor
+    cm.setValue(cm.getValue() + imageMd)
   }
 
   render () {


### PR DESCRIPTION
This should fix dragging image into text editor, which wasn't working, and thanks to escaping it now works with files with spaces in name.