### PR TITLE
Add dataApi.copyImage for copying image to boostnote storage on an image dropped into CodeEditor

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -169,17 +169,16 @@ export default class CodeEditor extends React.Component {
     e.preventDefault()
     let imagePath = e.dataTransfer.files[0].path
     let filename = path.basename(imagePath)
-    const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
-    const storagePath = _.find(cachedStorageList, {key: this.props.storageKey})
 
-    copyImage(imagePath, this.props.storageKey)
-    const imageMd = `![${encodeURI(filename)}](${storagePath.path}/images/${encodeURI(filename)})`
-    this.insertImage(imageMd)
+    copyImage(imagePath, this.props.storageKey).then((imagePathInTheStorage) => {
+      let imageMd = `![${encodeURI(filename)}](${imagePathInTheStorage})`
+      this.insertImageMd(imageMd)
+    })
   }
 
-  insertImage (imageMd) {
-    const textarea = this.editor.getInputField()
-    textarea.value = textarea.value.substr(0, textarea.selectionStart) + imageMd + textarea.value.substr(textarea.selectionEnd)
+  insertImageMd (imageMd) {
+    const cm = this.editor
+    cm.setValue(cm.getValue() + imageMd)
   }
 
   render () {

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -167,11 +167,11 @@ export default class CodeEditor extends React.Component {
 
   handleDropImage (e) {
     e.preventDefault()
-    let imagePath = e.dataTransfer.files[0].path
-    let filename = path.basename(imagePath)
+    const imagePath = e.dataTransfer.files[0].path
+    const filename = path.basename(imagePath)
 
     copyImage(imagePath, this.props.storageKey).then((imagePathInTheStorage) => {
-      let imageMd = `![${encodeURI(filename)}](${imagePathInTheStorage})`
+      const imageMd = `![${encodeURI(filename)}](${imagePathInTheStorage})`
       this.insertImageMd(imageMd)
     })
   }

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import _ from 'lodash'
 import CodeMirror from 'codemirror'
 import path from 'path'
+import copyImage from 'browser/main/lib/dataApi/copyImage'
 
 CodeMirror.modeURL = '../node_modules/codemirror/mode/%N/%N.js'
 
@@ -166,9 +167,13 @@ export default class CodeEditor extends React.Component {
 
   handleDropImage (e) {
     e.preventDefault()
-    const imagePath = e.dataTransfer.files[0].path
-    const filename = path.basename(imagePath)
-    const imageMd = `![${encodeURI(filename)}](${encodeURI(imagePath)})`
+    let imagePath = e.dataTransfer.files[0].path
+    let filename = path.basename(imagePath)
+    const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
+    const storagePath = _.find(cachedStorageList, {key: this.props.storageKey})
+
+    copyImage(imagePath, this.props.storageKey)
+    const imageMd = `![${encodeURI(filename)}](${storagePath.path}/images/${encodeURI(filename)})`
     this.insertImage(imageMd)
   }
 

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -180,7 +180,7 @@ class MarkdownEditor extends React.Component {
   }
 
   render () {
-    let { className, value, config } = this.props
+    let { className, value, config, storageKey } = this.props
 
     let editorFontSize = parseInt(config.editor.fontSize, 10)
     if (!(editorFontSize > 0 && editorFontSize < 101)) editorFontSize = 14
@@ -210,6 +210,7 @@ class MarkdownEditor extends React.Component {
           fontSize={editorFontSize}
           indentType={config.editor.indentType}
           indentSize={editorIndentSize}
+          storageKey={storageKey}
           onChange={(e) => this.handleChange(e)}
           onBlur={(e) => this.handleBlur(e)}
         />

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -292,6 +292,7 @@ class MarkdownNoteDetail extends React.Component {
             styleName='body-noteEditor'
             config={config}
             value={this.state.note.content}
+            storageKey={this.state.note.storage}
             onChange={(e) => this.handleChange(e)}
             ignorePreviewPointerEvents={this.props.ignorePreviewPointerEvents}
           />

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -3,6 +3,12 @@ const path = require('path')
 const _ = require('lodash')
 const sander = require('sander')
 
+/**
+ * @description To copy an image and return the path.
+ * @param {String} filePath
+ * @param {String} storageKey
+ * @return {String} an image path
+ */
 function copyImage (filePath, storageKey) {
   const targetStorage = (() => {
     try {

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -4,16 +4,18 @@ const _ = require('lodash')
 const sander = require('sander')
 
 function copyImage (filePath, storageKey) {
-  let targetStorage
-  try {
-    const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
-    if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
+  const targetStorage = (() => {
+    try {
+      const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
+      if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
 
-    targetStorage = _.find(cachedStorageList, {key: storageKey})
-    if (targetStorage == null) throw new Error('Target storage doesn\'t exist.')
-  } catch (e) {
-    return Promise.reject(e)
-  }
+      const storage = _.find(cachedStorageList, {key: storageKey})
+      if (storage == null) throw new Error('Target storage doesn\'t exist.')
+      return storage
+    } catch (e) {
+      return Promise.reject(e)
+    }
+  })()
 
   return new Promise((resolve, reject) => {
     try {

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -10,29 +10,20 @@ const sander = require('sander')
  * @return {String} an image path
  */
 function copyImage (filePath, storageKey) {
-  const targetStorage = (() => {
+  return new Promise((resolve, reject) => {
     try {
       const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
       if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
-
       const storage = _.find(cachedStorageList, {key: storageKey})
-      if (storage == null) throw new Error('Target storage doesn\'t exist.')
-      return storage
-    } catch (e) {
-      return Promise.reject(e)
-    }
-  })()
+      if (storage === undefined) throw new Error('Target storage doesn\'t exist.')
+      const targetStorage = storage
 
-  return new Promise((resolve, reject) => {
-    try {
       const inputImage = fs.createReadStream(filePath)
       const imageName = path.basename(filePath)
-      sander.mkdirSync(`${targetStorage.path}/images`)
       const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', imageName))
       inputImage.pipe(outputImage)
       resolve(`${encodeURI(targetStorage.path)}/images/${encodeURI(imageName)}`)
-    }
-    catch(e) {
+    } catch (e) {
       return reject(e)
     }
   })

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -15,13 +15,19 @@ function copyImage (filePath, storageKey) {
     return Promise.reject(e)
   }
 
-  //return resolveStorageData(targetStorage)
-
-  const inputImage = fs.createReadStream(filePath)
-  const imageName = path.basename(filePath)
-  sander.mkdirSync(`${targetStorage.path}/images`)
-  const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', imageName))
-  inputImage.pipe(outputImage)
+  return new Promise((resolve, reject) => {
+    try {
+      const inputImage = fs.createReadStream(filePath)
+      const imageName = path.basename(filePath)
+      sander.mkdirSync(`${targetStorage.path}/images`)
+      const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', imageName))
+      inputImage.pipe(outputImage)
+      resolve(`${encodeURI(targetStorage.path)}/images/${encodeURI(imageName)}`)
+    }
+    catch(e) {
+      return reject(e)
+    }
+  })
 }
 
 module.exports = copyImage

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -1,0 +1,27 @@
+const fs = require('fs')
+const path = require('path')
+const _ = require('lodash')
+const sander = require('sander')
+
+function copyImage (filePath, storageKey) {
+  let targetStorage
+  try {
+    let cachedStorageList = JSON.parse(localStorage.getItem('storages'))
+    if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
+
+    targetStorage = _.find(cachedStorageList, {key: storageKey})
+    if (targetStorage == null) throw new Error('Target storage doesn\'t exist.')
+  } catch (e) {
+    return Promise.reject(e)
+  }
+
+  //return resolveStorageData(targetStorage)
+
+  const inputImage = fs.createReadStream(filePath)
+  const imageName = path.basename(filePath)
+  sander.mkdirSync(`${targetStorage.path}/images`)
+  const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', imageName))
+  inputImage.pipe(outputImage)
+}
+
+module.exports = copyImage

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -6,7 +6,7 @@ const sander = require('sander')
 function copyImage (filePath, storageKey) {
   let targetStorage
   try {
-    let cachedStorageList = JSON.parse(localStorage.getItem('storages'))
+    const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
     if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
 
     targetStorage = _.find(cachedStorageList, {key: storageKey})


### PR DESCRIPTION
This PR enable that to copy an image when it is dropped into CodeEditor. It means the image is kept into boostnote storage: `~/Boostnote/images/imageName.png`