### PR TITLE
Disable dragging an image to MarkdownPreview and fix the behavior of an image dropped on CodeEditor.

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -166,9 +166,9 @@ export default class CodeEditor extends React.Component {
 
   handleDropImage (e) {
     e.preventDefault()
-    let imagePath = e.dataTransfer.files[0].path
-    let filename = path.basename(imagePath)
-    let imageMd = `![${encodeURI(filename)}](${encodeURI(imagePath)})`
+    const imagePath = e.dataTransfer.files[0].path
+    const filename = path.basename(imagePath)
+    const imageMd = `![${encodeURI(filename)}](${encodeURI(imagePath)})`
     this.insertImage(imageMd)
   }
 

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -173,8 +173,8 @@ export default class CodeEditor extends React.Component {
   }
 
   insertImage (imageMd) {
-    const cm = this.editor
-    cm.setValue(cm.getValue() + imageMd)
+    const textarea = this.editor.getInputField()
+    textarea.value = textarea.value.substr(0, textarea.selectionStart) + imageMd + textarea.value.substr(textarea.selectionEnd)
   }
 
   render () {

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -181,6 +181,8 @@ export default class MarkdownPreview extends React.Component {
 
     this.refs.root.contentWindow.document.addEventListener('mousedown', this.mouseDownHandler)
     this.refs.root.contentWindow.document.addEventListener('mouseup', this.mouseUpHandler)
+    this.refs.root.contentWindow.document.addEventListener('drop', this.preventImageDroppedHandler)
+    this.refs.root.contentWindow.document.addEventListener('dragover', this.preventImageDroppedHandler)
     eventEmitter.on('export:save-text', this.saveAsTextHandler)
     eventEmitter.on('export:save-md', this.saveAsMdHandler)
   }
@@ -189,6 +191,8 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.body.removeEventListener('contextmenu', this.contextMenuHandler)
     this.refs.root.contentWindow.document.removeEventListener('mousedown', this.mouseDownHandler)
     this.refs.root.contentWindow.document.removeEventListener('mouseup', this.mouseUpHandler)
+    this.refs.root.contentWindow.document.removeEventListener('drop', this.preventImageDroppedHandler)
+    this.refs.root.contentWindow.document.removeEventListener('dragover', this.preventImageDroppedHandler)
     eventEmitter.off('export:save-text', this.saveAsTextHandler)
     eventEmitter.off('export:save-md', this.saveAsMdHandler)
   }
@@ -323,6 +327,11 @@ export default class MarkdownPreview extends React.Component {
         break
       }
     }
+  }
+
+  preventImageDroppedHandler(e) {
+    e.preventDefault()
+    e.stopPropagation()
   }
 
   render () {


### PR DESCRIPTION
Disable dragging an image to MarkdownPreview

![f9d80bfce658e2e22edeec15e36bd624](https://cloud.githubusercontent.com/assets/11307908/23130745/f498e3a2-f7ca-11e6-8fa8-52b2ff576359.gif)

And I fixed the behavior of an image dropped to CodeEditor. Please pay attention to the position of the cursor. Even I drop an image to the bottom of CodeEditor, it is pasted at the position of the cursor.

![8e805523e0b8aa7bc935f0332d017880](https://cloud.githubusercontent.com/assets/11307908/23130909/83d86434-f7cb-11e6-8310-81961a6c6b8c.gif)
