### PR TITLE
Add a shortcut for supporting to input bold

### DIFF
--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -11,7 +11,9 @@ class MarkdownEditor extends React.Component {
 
     this.escapeFromEditor = ['Control', 'w']
 
-    this.supportBold = ['Control', 'b']
+    this.supportMdBold = ['Control', 'b']
+
+    this.supportMdWordBold = ['Control', ':']
 
     this.state = {
       status: 'PREVIEW',
@@ -169,8 +171,11 @@ class MarkdownEditor extends React.Component {
     if (!this.state.isLocked && this.state.status === 'CODE' && this.escapeFromEditor.every(isNoteHandlerKey)) {
       document.activeElement.blur()
     }
-    if (this.supportBold.every(isNoteHandlerKey)) {
+    if (this.supportMdBold.every(isNoteHandlerKey)) {
       this.addMdAndMoveCaretToCenter('****')
+    }
+    if (this.supportMdWordBold.every(isNoteHandlerKey)) {
+      this.addMdBetweenWord('**')
     }
   }
 
@@ -179,6 +184,14 @@ class MarkdownEditor extends React.Component {
     const cmDoc = this.refs.code.editor.getDoc()
     cmDoc.replaceRange(md, currentCaret)
     this.refs.code.editor.setCursor({line: currentCaret.line, ch: currentCaret.ch + md.length/2})
+  }
+
+  addMdBetweenWord (md) {
+    const currentCaret = this.refs.code.editor.getCursor()
+    const word = this.refs.code.editor.findWordAt(currentCaret)
+    const cmDoc = this.refs.code.editor.getDoc()
+    cmDoc.replaceRange(md, word.anchor)
+    cmDoc.replaceRange(md, { line: word.head.line, ch: word.head.ch + md.length })
   }
 
   handleKeyUp (e) {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -160,6 +160,7 @@ class MarkdownEditor extends React.Component {
   }
 
   handleKeyDown(e) {
+    if (this.state.status !== 'CODE') return false
     const keyPressed = Object.assign(this.state.keyPressed, {
       [e.key]: true
     })
@@ -168,7 +169,7 @@ class MarkdownEditor extends React.Component {
     if (!this.state.isLocked && this.state.status === 'CODE' && this.escapeFromEditor.every(isNoteHandlerKey)) {
       document.activeElement.blur()
     }
-    if (this.state.status === 'CODE' && this.supportBold.every(isNoteHandlerKey)) {
+    if (this.supportBold.every(isNoteHandlerKey)) {
       this.addMdAndMoveCaretToCenter('****')
     }
   }

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -179,19 +179,19 @@ class MarkdownEditor extends React.Component {
     }
   }
 
-  addMdAndMoveCaretToCenter (md) {
+  addMdAndMoveCaretToCenter (mdElement) {
     const currentCaret = this.refs.code.editor.getCursor()
     const cmDoc = this.refs.code.editor.getDoc()
-    cmDoc.replaceRange(md, currentCaret)
-    this.refs.code.editor.setCursor({line: currentCaret.line, ch: currentCaret.ch + md.length/2})
+    cmDoc.replaceRange(mdElement, currentCaret)
+    this.refs.code.editor.setCursor({line: currentCaret.line, ch: currentCaret.ch + mdElement.length/2})
   }
 
-  addMdBetweenWord (md) {
+  addMdBetweenWord (mdElement) {
     const currentCaret = this.refs.code.editor.getCursor()
     const word = this.refs.code.editor.findWordAt(currentCaret)
     const cmDoc = this.refs.code.editor.getDoc()
-    cmDoc.replaceRange(md, word.anchor)
-    cmDoc.replaceRange(md, { line: word.head.line, ch: word.head.ch + md.length })
+    cmDoc.replaceRange(mdElement, word.anchor)
+    cmDoc.replaceRange(mdElement, { line: word.head.line, ch: word.head.ch + mdElement.length })
   }
 
   handleKeyUp (e) {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -11,6 +11,8 @@ class MarkdownEditor extends React.Component {
 
     this.escapeFromEditor = ['Control', 'w']
 
+    this.supportBold = ['Control', 'b']
+
     this.state = {
       status: 'PREVIEW',
       renderValue: props.value,
@@ -166,6 +168,16 @@ class MarkdownEditor extends React.Component {
     if (!this.state.isLocked && this.state.status === 'CODE' && this.escapeFromEditor.every(isNoteHandlerKey)) {
       document.activeElement.blur()
     }
+    if (this.state.status === 'CODE' && this.supportBold.every(isNoteHandlerKey)) {
+      this.addMdAndMoveCaretToCenter('****')
+    }
+  }
+
+  addMdAndMoveCaretToCenter (md) {
+    const currentCaret = this.refs.code.editor.getCursor()
+    const cmDoc = this.refs.code.editor.getDoc()
+    cmDoc.replaceRange(md, currentCaret)
+    this.refs.code.editor.setCursor({line: currentCaret.line, ch: currentCaret.ch + md.length/2})
   }
 
   handleKeyUp (e) {


### PR DESCRIPTION
I added a shortcut for inputting `****` and it brings the caret to the center of `****`.

![b397b162808bb03d54c99e5792c782fd](https://cloud.githubusercontent.com/assets/11307908/23175621/5f7ddb7c-f8a3-11e6-83e5-13b927a7c33d.gif)
