### PR TITLE
Added Table of Contents and two small bug fixes

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -54,7 +54,6 @@ body
   font-family helvetica, arial, sans-serif
   line-height 1.6
   overflow-x hidden
-  user-select all
   background-color $ui-noteDetail-backgroundColor
   .katex
     font 400 1.2em 'KaTeX_Main'

--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -78,7 +78,6 @@ body
 li
   label.taskListItem
     margin-left -2em
-    background-color white
 div.math-rendered
   text-align center
 .math-failed

--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -183,6 +183,8 @@ ul
     list-style-type circle
     &>li>ul
       list-style-type square
+ul.markdownIt-TOC, ul.markdownIt-TOC ul
+  list-style-type none
 ol
   list-style-type decimal
   padding-left 2em

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -1,6 +1,7 @@
 import markdownit from 'markdown-it'
 import emoji from 'markdown-it-emoji'
 import math from '@rokt33r/markdown-it-math'
+import tocAndAnchor from "markdown-it-toc-and-anchor"
 import _ from 'lodash'
 
 const katex = window.katex
@@ -35,6 +36,9 @@ var md = markdownit({
 })
 md.use(emoji, {
   shortcuts: {}
+})
+md.use(tocAndAnchor, {
+  anchorLink: false
 })
 md.use(math, {
   inlineRenderer: function (str) {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "markdown-it-checkbox": "^1.1.0",
     "markdown-it-emoji": "^1.1.1",
     "markdown-it-footnote": "^3.0.0",
+    "markdown-it-toc-and-anchor": "^4.1.1",
     "md5": "^2.0.0",
     "mixpanel": "^0.4.1",
     "moment": "^2.10.3",


### PR DESCRIPTION
This pull request contains a feature, that allows the use of a table of contents inside the markdown by typing `@[TOC]`. That uses the `markdown-it-toc-and-anchor` project from the nodejs repository.
This allows a simple ToC creation, where a click onto it, automatically moves the view to the selected item.

<img width="254" alt="screen shot 2017-03-04 at 18 49 00" src="https://cloud.githubusercontent.com/assets/14364148/23580920/4f9503dc-010b-11e7-9629-1f422aa1a63f.png">

This also fixes two bugs.
 - background color of the `taskListItem` is now transparent instead of white in the light theme (looks a lot better now)
 - a bug is fixed, that would select the whole text, every time one tries to select or switches between editor and preview the whole preview text would be selected. This made the selection of small text parts impossible



Thanks