### PR TITLE
Fix the design of li

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -243,6 +243,10 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.body.setAttribute('data-theme', theme)
     this.refs.root.contentWindow.document.body.innerHTML = markdown.render(value)
 
+    _.forEach(this.refs.root.contentWindow.document.querySelectorAll('.taskListItem'), (el) => {
+      el.parentNode.parentNode.style.listStyleType = 'none'
+    })
+
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('a'), (el) => {
       el.addEventListener('click', this.anchorClickHandler)
     })

--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -182,8 +182,18 @@ ul
     list-style-type circle
     &>li>ul
       list-style-type square
-ul.markdownIt-TOC, ul.markdownIt-TOC ul
-  list-style-type none
+ul.markdownIt-TOC
+  list-style-type decimal
+  background-color #ffffff
+  padding-top 10px
+  padding-bottom 10px
+  ul
+    list-style-type none
+  a
+    text-decoration none
+    color #000000
+  a:hover
+    color #2bac8f
 ol
   list-style-type decimal
   padding-left 2em


### PR DESCRIPTION
* fix the design of li (deletion of '・' in front of the checkbox content)
* fix the design of markdown-it-TOC
## before
![screen shot 2017-03-10 at 09 58 30](https://cloud.githubusercontent.com/assets/11307908/23806856/31248e60-0578-11e7-8564-d6b87660a58e.png)

## after
![screen shot 2017-03-09 at 13 01 57](https://cloud.githubusercontent.com/assets/11307908/23770697/f3dd0eba-04c8-11e7-8cd9-0c32fe75e018.png)
