### PR TITLE
Enable to set configs in ~/.boostnoterc

### DIFF
--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -12,6 +12,10 @@ import ConfigManager from 'browser/main/lib/ConfigManager'
 import modal from 'browser/main/lib/modal'
 import InitModal from 'browser/main/modals/InitModal'
 import mixpanel from 'browser/main/lib/mixpanel'
+import RcParser from 'browser/main/lib/RcParser'
+import path from 'path'
+
+const BOOSTNOTERC = '.boostnoterc'
 
 function focused () {
   mixpanel.track('MAIN_FOCUSED')
@@ -64,6 +68,10 @@ class Main extends React.Component {
       })
 
     window.addEventListener('focus', focused)
+
+    const homePath = global.process.env.HOME || global.process.env.USERPROFILE
+    const boostnotercPath = path.join(homePath, BOOSTNOTERC)
+    RcParser.exec(boostnotercPath)
   }
 
   componentWillUnmount () {

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -12,10 +12,6 @@ import ConfigManager from 'browser/main/lib/ConfigManager'
 import modal from 'browser/main/lib/modal'
 import InitModal from 'browser/main/modals/InitModal'
 import mixpanel from 'browser/main/lib/mixpanel'
-import RcParser from 'browser/main/lib/RcParser'
-import path from 'path'
-
-const BOOSTNOTERC = '.boostnoterc'
 
 function focused () {
   mixpanel.track('MAIN_FOCUSED')
@@ -68,10 +64,6 @@ class Main extends React.Component {
       })
 
     window.addEventListener('focus', focused)
-
-    const homePath = global.process.env.HOME || global.process.env.USERPROFILE
-    const boostnotercPath = path.join(homePath, BOOSTNOTERC)
-    RcParser.exec(boostnotercPath)
   }
 
   componentWillUnmount () {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -67,15 +67,7 @@ function get () {
     config = Object.assign({}, DEFAULT_CONFIG, JSON.parse(config))
 
     config = Object.assign({}, DEFAULT_CONFIG, boostnotercConfig)
-    config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, boostnotercConfig.hotkey)
-    config.ui = Object.assign({}, DEFAULT_CONFIG.ui, boostnotercConfig.ui)
-    config.editor = Object.assign({}, DEFAULT_CONFIG.editor, boostnotercConfig.editor)
-    config.preview = Object.assign({}, DEFAULT_CONFIG.preview, boostnotercConfig.preview)
-
-    config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, config.hotkey)
-    config.ui = Object.assign({}, DEFAULT_CONFIG.ui, config.ui)
-    config.editor = Object.assign({}, DEFAULT_CONFIG.editor, config.editor)
-    config.preview = Object.assign({}, DEFAULT_CONFIG.preview, config.preview)
+    config = assignConfigValues(config, boostnotercConfig, config)
 
     if (!validate(config)) throw new Error('INVALID CONFIG')
   } catch (err) {
@@ -136,6 +128,14 @@ function set (updates) {
   ipcRenderer.send('config-renew', {
     config: get()
   })
+}
+
+function assignConfigValues (config, rcConfig, originalConfig) {
+  config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, rcConfig, originalConfig.hotkey)
+  config.ui = Object.assign({}, DEFAULT_CONFIG.ui, rcConfig, originalConfig.ui)
+  config.editor = Object.assign({}, DEFAULT_CONFIG.editor, rcConfig, originalConfig.editor)
+  config.preview = Object.assign({}, DEFAULT_CONFIG.preview, rcConfig, originalConfig.preview)
+  return config
 }
 
 export default {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -68,13 +68,11 @@ function get () {
 
     config = Object.assign({}, DEFAULT_CONFIG, JSON.parse(config))
 
-    if (boostnotercConfig !== undefined) {
-      config = Object.assign({}, DEFAULT_CONFIG, boostnotercConfig)
-      config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, boostnotercConfig.hotkey)
-      config.ui = Object.assign({}, DEFAULT_CONFIG.ui, boostnotercConfig.ui)
-      config.editor = Object.assign({}, DEFAULT_CONFIG.editor, boostnotercConfig.editor)
-      config.preview = Object.assign({}, DEFAULT_CONFIG.preview, boostnotercConfig.preview)
-    }
+    config = Object.assign({}, DEFAULT_CONFIG, boostnotercConfig)
+    config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, boostnotercConfig.hotkey)
+    config.ui = Object.assign({}, DEFAULT_CONFIG.ui, boostnotercConfig.ui)
+    config.editor = Object.assign({}, DEFAULT_CONFIG.editor, boostnotercConfig.editor)
+    config.preview = Object.assign({}, DEFAULT_CONFIG.preview, boostnotercConfig.preview)
 
     config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, config.hotkey)
     config.ui = Object.assign({}, DEFAULT_CONFIG.ui, config.ui)

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -75,11 +75,10 @@ function get () {
       config.preview = Object.assign({}, DEFAULT_CONFIG.preview, boostnotercConfig.preview)
     }
 
-    config = Object.assign(config, DEFAULT_CONFIG, config)
-    config.hotkey = Object.assign(config, DEFAULT_CONFIG.hotkey, config.hotkey)
-    config.ui = Object.assign(config, DEFAULT_CONFIG.ui, config.ui)
-    config.editor = Object.assign(config, DEFAULT_CONFIG.editor, config.editor)
-    config.preview = Object.assign(config, DEFAULT_CONFIG.preview, config.preview)
+    config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, config.hotkey)
+    config.ui = Object.assign({}, DEFAULT_CONFIG.ui, config.ui)
+    config.editor = Object.assign({}, DEFAULT_CONFIG.editor, config.editor)
+    config.preview = Object.assign({}, DEFAULT_CONFIG.preview, config.preview)
 
     if (!validate(config)) throw new Error('INVALID CONFIG')
   } catch (err) {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -1,9 +1,13 @@
 import _ from 'lodash'
+import RcParser from 'browser/main/lib/RcParser'
 
 const OSX = global.process.platform === 'darwin'
 const electron = require('electron')
 const { ipcRenderer } = electron
 const consts = require('browser/lib/consts')
+const path = require('path')
+const fs = require('fs')
+const BOOSTNOTERC = '.boostnoterc'
 
 let isInitialized = false
 
@@ -58,11 +62,25 @@ function get () {
   let config = window.localStorage.getItem('config')
 
   try {
+    const homePath = global.process.env.HOME || global.process.env.USERPROFILE
+    const boostnotercPath = path.join(homePath, BOOSTNOTERC)
+    const boostnotercConfig = RcParser.parse(boostnotercPath)
+
     config = Object.assign({}, DEFAULT_CONFIG, JSON.parse(config))
-    config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, config.hotkey)
-    config.ui = Object.assign({}, DEFAULT_CONFIG.ui, config.ui)
-    config.editor = Object.assign({}, DEFAULT_CONFIG.editor, config.editor)
-    config.preview = Object.assign({}, DEFAULT_CONFIG.preview, config.preview)
+
+    if (boostnotercConfig !== undefined) {
+      config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, boostnotercConfig.hotkey)
+      config.ui = Object.assign({}, DEFAULT_CONFIG.ui, boostnotercConfig.ui)
+      config.editor = Object.assign({}, DEFAULT_CONFIG.editor, boostnotercConfig.editor)
+      config.preview = Object.assign({}, DEFAULT_CONFIG.preview, boostnotercConfig.preview)
+    }
+
+    config = Object.assign(config, DEFAULT_CONFIG, config)
+    config.hotkey = Object.assign(config, DEFAULT_CONFIG.hotkey, config.hotkey)
+    config.ui = Object.assign(config, DEFAULT_CONFIG.ui, config.ui)
+    config.editor = Object.assign(config, DEFAULT_CONFIG.editor, config.editor)
+    config.preview = Object.assign(config, DEFAULT_CONFIG.preview, config.preview)
+
     if (!validate(config)) throw new Error('INVALID CONFIG')
   } catch (err) {
     console.warn('Boostnote resets the malformed configuration.')

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -62,9 +62,7 @@ function get () {
   let config = window.localStorage.getItem('config')
 
   try {
-    const homePath = global.process.env.HOME || global.process.env.USERPROFILE
-    const boostnotercPath = path.join(homePath, BOOSTNOTERC)
-    const boostnotercConfig = RcParser.parse(boostnotercPath)
+    const boostnotercConfig = RcParser.parse()
 
     config = Object.assign({}, DEFAULT_CONFIG, JSON.parse(config))
 

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -69,6 +69,7 @@ function get () {
     config = Object.assign({}, DEFAULT_CONFIG, JSON.parse(config))
 
     if (boostnotercConfig !== undefined) {
+      config = Object.assign({}, DEFAULT_CONFIG, boostnotercConfig)
       config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, boostnotercConfig.hotkey)
       config.ui = Object.assign({}, DEFAULT_CONFIG.ui, boostnotercConfig.ui)
       config.editor = Object.assign({}, DEFAULT_CONFIG.editor, boostnotercConfig.editor)

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 const path = require('path')
 const sander = require('sander')
 
@@ -7,6 +9,15 @@ function parse (boostnotercPath) {
   return config
 }
 
+function exec (boostnotercPath) {
+  const config = this.parse(boostnotercPath)
+  if (config.execs === undefined) return
+  _.forEach(config.execs, (exec) => {
+    eval(exec)
+  })
+}
+
 export default {
-  parse
+  parse,
+  exec
 }

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,0 +1,12 @@
+const path = require('path')
+const sander = require('sander')
+
+function parse (boostnotercPath) {
+  if (!sander.existsSync(boostnotercPath)) return
+  let config = JSON.parse(sander.readFileSync(boostnotercPath).toString())
+  return config
+}
+
+export default {
+  parse
+}

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 const path = require('path')
 const sander = require('sander')
 
@@ -9,15 +7,6 @@ function parse (boostnotercPath) {
   return config
 }
 
-function exec (boostnotercPath) {
-  const config = this.parse(boostnotercPath)
-  if (config.execs === undefined) return
-  _.forEach(config.execs, (exec) => {
-    eval(exec)
-  })
-}
-
 export default {
-  parse,
-  exec
+  parse
 }

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,7 +1,11 @@
 import path from 'path'
 import sander from 'sander'
 
-function parse (boostnotercPath) {
+function parse () {
+  const BOOSTNOTERC = '.boostnoterc'
+  const homePath = global.process.env.HOME || global.process.env.USERPROFILE
+  const boostnotercPath = path.join(homePath, BOOSTNOTERC)
+
   if (!sander.existsSync(boostnotercPath)) return {}
   return JSON.parse(sander.readFileSync(boostnotercPath).toString())
 }

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,5 +1,5 @@
-const path = require('path')
-const sander = require('sander')
+import path from 'path'
+import sander from 'sander'
 
 function parse (boostnotercPath) {
   if (!sander.existsSync(boostnotercPath)) return {}

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -2,9 +2,8 @@ const path = require('path')
 const sander = require('sander')
 
 function parse (boostnotercPath) {
-  if (!sander.existsSync(boostnotercPath)) return
-  let config = JSON.parse(sander.readFileSync(boostnotercPath).toString())
-  return config
+  if (!sander.existsSync(boostnotercPath)) return {}
+  return JSON.parse(sander.readFileSync(boostnotercPath).toString())
 }
 
 export default {


### PR DESCRIPTION
Hi, I added a function to enable to set configs in `~/.boostnoterc`. The priority of reading order is `LocalStorage` first, `~/.boostnoterc` second. And the reason why I created `RcParser` is because I'd like to add a function which enables to use `plugin`.

### refs
https://github.com/BoostIO/Boostnote/issues/302