### PR TITLE
ignore # in the code block

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -65,22 +65,16 @@ class MarkdownNoteDetail extends React.Component {
   findTitle (value) {
     let splitted = value.split('\n')
     let title = null
-    let markdownInCode = false
+    let isMarkdownInCode = false
 
     for (let i = 0; i < splitted.length; i++) {
       let trimmedLine = splitted[i].trim()
       if (trimmedLine.match('```')){
-        if (markdownInCode) {
-          markdownInCode = false
-        } else {
-          markdownInCode = true
-        }
+        isMarkdownInCode = !isMarkdownInCode
       } else {
-        if(!markdownInCode) {
-          if (trimmedLine.match(/^# +/)){
-            title = trimmedLine.substring(1, trimmedLine.length).trim()
-            break
-          }
+        if(isMarkdownInCode === false && trimmedLine.match(/^# +/)) {
+          title = trimmedLine.substring(1, trimmedLine.length).trim()
+          break
         }
       }
     }

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -71,8 +71,7 @@ class MarkdownNoteDetail extends React.Component {
       let trimmedLine = splitted[i].trim()
       if (trimmedLine.match('```')){
         isMarkdownInCode = !isMarkdownInCode
-      } else {
-        if(isMarkdownInCode === false && trimmedLine.match(/^# +/)) {
+      } else if (isMarkdownInCode === false && trimmedLine.match(/^# +/)) {
           title = trimmedLine.substring(1, trimmedLine.length).trim()
           break
         }

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -69,12 +69,11 @@ class MarkdownNoteDetail extends React.Component {
 
     for (let i = 0; i < splitted.length; i++) {
       let trimmedLine = splitted[i].trim()
-      if (trimmedLine.match('```')){
+      if (trimmedLine.match('```')) {
         isMarkdownInCode = !isMarkdownInCode
       } else if (isMarkdownInCode === false && trimmedLine.match(/^# +/)) {
-          title = trimmedLine.substring(1, trimmedLine.length).trim()
-          break
-        }
+        title = trimmedLine.substring(1, trimmedLine.length).trim()
+        break
       }
     }
 

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -65,12 +65,23 @@ class MarkdownNoteDetail extends React.Component {
   findTitle (value) {
     let splitted = value.split('\n')
     let title = null
+    let markdownInCode = false
 
     for (let i = 0; i < splitted.length; i++) {
       let trimmedLine = splitted[i].trim()
-      if (trimmedLine.match(/^# .+/)) {
-        title = trimmedLine.substring(1, trimmedLine.length).trim()
-        break
+      if (trimmedLine.match('```')){
+        if (markdownInCode) {
+          markdownInCode = false
+        } else {
+          markdownInCode = true
+        }
+      } else {
+        if(!markdownInCode) {
+          if (trimmedLine.match(/^# +/)){
+            title = trimmedLine.substring(1, trimmedLine.length).trim()
+            break
+          }
+        }
       }
     }
 


### PR DESCRIPTION
I solved the [issue](https://github.com/BoostIO/Boostnote/issues/323#issuecomment-287097442).
## Before
Previously, a character string beginning with '#' in the code block was treated as the title of the markdown note.
<img width="1133" alt="2017-03-17 03 53 24" src="https://cloud.githubusercontent.com/assets/14838850/24013610/50b080f2-0ac5-11e7-8138-baa206b4be23.png">

## After
Currently, strings beginning with '#' in the code block are ignored.
<img width="1136" alt="2017-03-17 03 52 42" src="https://cloud.githubusercontent.com/assets/14838850/24013623/5b4fcb3a-0ac5-11e7-8b98-7771c921a1e5.png">

