### PR TITLE
dragged svg file is turns not into xml text

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -69,7 +69,8 @@ export default class CodeEditor extends React.Component {
         'Cmd-T': function (cm) {
           // Do nothing
         }
-      }
+      },
+      dragDrop: false
     })
 
     this.setMode(this.props.mode)

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -55,6 +55,7 @@ export default class CodeEditor extends React.Component {
       indentWithTabs: this.props.indentType !== 'space',
       keyMap: this.props.keyMap,
       inputStyle: 'textarea',
+      dragDrop: false,
       extraKeys: {
         Tab: function (cm) {
           if (cm.somethingSelected()) cm.indentSelection('add')
@@ -69,8 +70,7 @@ export default class CodeEditor extends React.Component {
         'Cmd-T': function (cm) {
           // Do nothing
         }
-      },
-      dragDrop: false
+      }
     })
 
     this.setMode(this.props.mode)


### PR DESCRIPTION
I solved #329 
## Before
When I drag svg file to markdown editor, its path and its xml data is entered in editor. Also its path is not display its image data.
![svgbugg](https://cloud.githubusercontent.com/assets/14838850/24069071/3f39b5e6-0be2-11e7-85d3-2d0f0ac27506.gif)

## After
When I drag svg file markdown editor, its path is entered in editor. Its xml data is not entered in editor. Also, its image data is displayed in preview.
![svg_error](https://cloud.githubusercontent.com/assets/14838850/24069078/8c86f0f2-0be2-11e7-88c0-337e1089cb29.gif)

### further
Also, This pull request can solve the bug which is to display image data in full screen which is dragged to markdown preview.