### PR TITLE
Fix the behavior of a feature which locks the editor

### DIFF
--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -82,7 +82,7 @@ class MarkdownEditor extends React.Component {
           this.refs.code.blur()
           this.refs.preview.focus()
         }
-        eventEmitter.emit('topbar:showlockbutton')
+        eventEmitter.emit('topbar:togglelockbutton')
       })
     }
   }
@@ -99,7 +99,7 @@ class MarkdownEditor extends React.Component {
         this.refs.preview.focus()
         this.refs.preview.scrollTo(cursorPosition.line)
       })
-      eventEmitter.emit('topbar:showlockbutton')
+      eventEmitter.emit('topbar:togglelockbutton')
     }
   }
 
@@ -115,7 +115,7 @@ class MarkdownEditor extends React.Component {
       }, () => {
         this.refs.code.focus()
       })
-      eventEmitter.emit('topbar:showlockbutton')
+      eventEmitter.emit('topbar:togglelockbutton')
     }
   }
 
@@ -152,7 +152,7 @@ class MarkdownEditor extends React.Component {
     } else {
       this.refs.code.focus()
     }
-    eventEmitter.emit('topbar:showlockbutton')
+    eventEmitter.emit('topbar:togglelockbutton')
   }
 
   reload () {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -82,7 +82,7 @@ class MarkdownEditor extends React.Component {
           this.refs.code.blur()
           this.refs.preview.focus()
         }
-        eventEmitter.emit('topbar:togglelockbutton')
+        eventEmitter.emit('topbar:togglelockbutton', this.state.status)
       })
     }
   }
@@ -99,7 +99,7 @@ class MarkdownEditor extends React.Component {
         this.refs.preview.focus()
         this.refs.preview.scrollTo(cursorPosition.line)
       })
-      eventEmitter.emit('topbar:togglelockbutton')
+      eventEmitter.emit('topbar:togglelockbutton', this.state.status)
     }
   }
 
@@ -115,7 +115,7 @@ class MarkdownEditor extends React.Component {
       }, () => {
         this.refs.code.focus()
       })
-      eventEmitter.emit('topbar:togglelockbutton')
+      eventEmitter.emit('topbar:togglelockbutton', this.state.status)
     }
   }
 
@@ -152,7 +152,7 @@ class MarkdownEditor extends React.Component {
     } else {
       this.refs.code.focus()
     }
-    eventEmitter.emit('topbar:togglelockbutton')
+    eventEmitter.emit('topbar:togglelockbutton', this.state.status)
   }
 
   reload () {

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -281,7 +281,7 @@ class MarkdownNoteDetail extends React.Component {
                   onFocus={(e) => this.handleFocus(e)}
                   onMouseDown={(e) => this.handleLockButtonMouseDown(e)}
                 >
-                  <i className={faClassName}/>
+                  <i className={faClassName} styleName='lock-button'/>
                   <span styleName='control-lockButton-tooltip'>
                   {this.state.isLocked ? 'Unlock' : 'Lock'}
                   </span>

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -230,8 +230,9 @@ class MarkdownNoteDetail extends React.Component {
     if (e.keyCode === 27) this.handleDeleteCancelButtonClick(e)
   }
 
-  handleToggleLockButton () {
-    if (this.props.config.editor.switchPreview === 'BLUR' && this.refs.content.state.status === 'CODE') {
+  handleToggleLockButton (event, noteStatus) {
+    // first argument event is not used
+    if (this.props.config.editor.switchPreview === 'BLUR' && noteStatus === 'CODE') {
       this.setState({isLockButtonShown: true})
     } else {
       this.setState({isLockButtonShown: false})

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -31,7 +31,7 @@ class MarkdownNoteDetail extends React.Component {
     }
     this.dispatchTimer = null
 
-    this.showLockButton = this.handleShowLockButton.bind(this)
+    this.toggleLockButton = this.handleToggleLockButton.bind(this)
   }
 
   focus () {
@@ -39,7 +39,7 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   componentDidMount () {
-    ee.on('topbar:showlockbutton', this.showLockButton)
+    ee.on('topbar:togglelockbutton', this.toggleLockButton)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -59,7 +59,7 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   componentDidUnmount () {
-    ee.off('topbar:lock', this.showLockButton)
+    ee.off('topbar:togglelockbutton', this.toggleLockButton)
   }
 
   findTitle (value) {
@@ -230,7 +230,7 @@ class MarkdownNoteDetail extends React.Component {
     if (e.keyCode === 27) this.handleDeleteCancelButtonClick(e)
   }
 
-  handleShowLockButton () {
+  handleToggleLockButton () {
     this.setState({editorStatus: this.refs.content.state.status})
   }
 

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -290,7 +290,7 @@ class MarkdownNoteDetail extends React.Component {
                 this.state.isLockButtonShown ? lockButtonComponent : ''
               )
             })()}
-            <button styleName='info-right-button'
+            <button styleName='control-trashButton'
               onClick={(e) => this.handleContextButtonClick(e)}
             >
               <svg height="17px" id="Capa_1" style={{"enableBackground":"new 0 0 753.23 753.23"}} width="17px" version="1.1" viewBox="0 0 753.23 753.23" x="0px" y="0px" xmlSpace="preserve">

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -219,6 +219,7 @@ class MarkdownNoteDetail extends React.Component {
     e.preventDefault()
     ee.emit('editor:lock')
     this.setState({ isLocked: !this.state.isLocked })
+    if (this.state.isLocked) this.focus()
   }
 
   getToggleLockButton () {

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -276,11 +276,14 @@ class MarkdownNoteDetail extends React.Component {
             {(() => {
               const faClassName=`fa ${this.getToggleLockButton()}`
               const lockButtonComponent =
-                <button styleName='info-right-button'
+                <button styleName='control-lockButton'
                   onFocus={(e) => this.handleFocus(e)}
                   onMouseDown={(e) => this.handleLockButtonMouseDown(e)}
                 >
                   <i className={faClassName}/>
+                  <span styleName='control-lockButton-tooltip'>
+                  {this.state.isLocked ? 'Unlock' : 'Lock'}
+                  </span>
                 </button>
               return (
                 this.state.isLockButtonShown ? lockButtonComponent : ''

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -26,7 +26,7 @@ class MarkdownNoteDetail extends React.Component {
         title: '',
         content: ''
       }, props.note),
-      editorStatus: false,
+      isLockButtonShown: false,
       isLocked: false
     }
     this.dispatchTimer = null
@@ -231,7 +231,11 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleToggleLockButton () {
-    this.setState({editorStatus: this.refs.content.state.status})
+    if (this.refs.content.state.status === 'CODE') {
+      this.setState({isLockButtonShown: true})
+    } else {
+      this.setState({isLockButtonShown: false})
+    }
   }
 
   handleFocus (e) {
@@ -279,7 +283,7 @@ class MarkdownNoteDetail extends React.Component {
                   <i className={faClassName}/>
                 </button>
               return (
-                this.state.editorStatus === 'CODE' ? lockButtonComponent : ''
+                this.state.isLockButtonShown ? lockButtonComponent : ''
               )
             })()}
             <button styleName='info-right-button'

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -231,7 +231,7 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleToggleLockButton () {
-    if (this.refs.content.state.status === 'CODE') {
+    if (this.props.config.editor.switchPreview === 'BLUR' && this.refs.content.state.status === 'CODE') {
       this.setState({isLockButtonShown: true})
     } else {
       this.setState({isLockButtonShown: false})

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -76,17 +76,9 @@ body[data-theme="dark"]
 
   .control-lockButton
     colorDarkTopBarButton()
-    border-color $ui-dark-borderColor
-    &:active
-      border-color $ui-dark-button--active-backgroundColor
 
   .control-lockButton-tooltip
     darkTooltip()
 
   .control-trashButton
     colorDarkTopBarButton()
-    border-color $ui-dark-borderColor
-    &:active
-      border-color $ui-dark-button--focus-borderColor
-    &:focus
-      border-color $ui-button--focus-borderColor

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -77,7 +77,6 @@ body[data-theme="dark"]
   .control-lockButton
     colorDarkTopBarButton()
     border-color $ui-dark-borderColor
-    background-color $ui-dark-noteList-backgroundColor
     &:active
       border-color $ui-dark-button--active-backgroundColor
 
@@ -87,7 +86,6 @@ body[data-theme="dark"]
   .control-trashButton
     colorDarkTopBarButton()
     border-color $ui-dark-borderColor
-    background-color $ui-dark-noteList-backgroundColor
     &:active
       border-color $ui-dark-button--focus-borderColor
     &:focus

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -13,22 +13,7 @@
   padding-bottom 3px
 
 .control-lockButton
-  width 34px
-  height 34px
-  border-radius 17px
-  font-size 14px
-  margin 13px 7px
-  padding-top 7px
-  border none
-  color $ui-button-color
-  fill $ui-button-color
-  background-color transparent
-  &:active
-    border-color $ui-button--active-backgroundColor
-  &:hover
-    background-color $ui-button--hover-backgroundColor
-    .control-lockButton-tooltip
-      opacity 1
+  topBarButtonLight()
 
 .control-lockButton-tooltip
   tooltip()
@@ -44,19 +29,7 @@
 
 .control-trashButton
   float right
-  width 34px
-  height 34px
-  border-radius 17px
-  font-size 14px
-  margin 13px 7px
-  padding-top 7px 
-  border none
-  color $ui-button-color
-  fill $ui-button-color
-  background-color transparent
-  &:hover
-    opacity 1
-    background-color $ui-button--hover-backgroundColor
+  topBarButtonLight()
 
 .body
   absolute left right
@@ -75,10 +48,10 @@ body[data-theme="dark"]
     box-shadow none
 
   .control-lockButton
-    colorDarkTopBarButton()
+    topBarButtonDark()
 
   .control-lockButton-tooltip
     darkTooltip()
 
   .control-trashButton
-    colorDarkTopBarButton()
+    topBarButtonDark()

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -22,8 +22,10 @@
   background-color transparent
   &:active
     border-color $ui-button--active-backgroundColor
-  &:hover .control-lockButton-tooltip
-    opacity 1
+  &:hover
+    background-color $ui-button--hover-backgroundColor
+    .control-lockButton-tooltip
+      opacity 1
 
 .control-lockButton-tooltip
   tooltip()

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -39,6 +39,22 @@
   opacity 0
   transition 0.1s
 
+.control-trashButton
+  float right
+  width 34px
+  height 34px
+  border-radius 17px
+  font-size 14px
+  margin 13px 7px
+  padding-top 7px 
+  border none
+  color $ui-button-color
+  fill $ui-button-color
+  background-color transparent
+  &:hover
+    opacity 1
+    background-color $ui-button--hover-backgroundColor
+
 .body
   absolute left right
   left $note-detail-left-margin
@@ -64,3 +80,11 @@ body[data-theme="dark"]
 
   .control-lockButton-tooltip
     darkTooltip()
+
+  .control-trashButton
+    navDarkButtonColor()
+    border-color $ui-dark-borderColor
+    &:active
+      border-color $ui-dark-button--focus-borderColor
+    &:focus
+      border-color $ui-button--focus-borderColor

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -9,6 +9,34 @@
   background-color $ui-noteDetail-backgroundColor
   box-shadow $note-detail-box-shadow
 
+.control-lockButton
+  width 34px
+  height 34px
+  border-radius 17px
+  font-size 14px
+  margin 13px 7px
+  padding-top 7px
+  border none
+  color $ui-button-color
+  fill $ui-button-color
+  background-color transparent
+  &:active
+    border-color $ui-button--active-backgroundColor
+  &:hover .control-lockButton-tooltip
+    opacity 1
+
+.control-lockButton-tooltip
+  tooltip()
+  position fixed
+  pointer-events none
+  top 50px
+  z-index 200
+  padding 5px
+  line-height normal
+  border-radius 2px
+  opacity 0
+  transition 0.1s
+
 .body
   absolute left right
   left $note-detail-left-margin
@@ -24,3 +52,13 @@ body[data-theme="dark"]
     border-color $ui-dark-borderColor
     background-color $ui-dark-noteDetail-backgroundColor
     box-shadow none
+
+  .control-lockButton
+    colorDarkDefaultButton()
+    border-color $ui-dark-borderColor
+    background-color $ui-dark-noteList-backgroundColor
+    &:active
+      border-color $ui-dark-button--active-backgroundColor
+
+  .control-lockButton-tooltip
+    darkTooltip()

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -9,6 +9,9 @@
   background-color $ui-noteDetail-backgroundColor
   box-shadow $note-detail-box-shadow
 
+.lock-button
+  padding-bottom 3px
+
 .control-lockButton
   width 34px
   height 34px

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -75,7 +75,7 @@ body[data-theme="dark"]
     box-shadow none
 
   .control-lockButton
-    colorDarkDefaultButton()
+    colorDarkTopBarButton()
     border-color $ui-dark-borderColor
     background-color $ui-dark-noteList-backgroundColor
     &:active
@@ -85,8 +85,9 @@ body[data-theme="dark"]
     darkTooltip()
 
   .control-trashButton
-    navDarkButtonColor()
+    colorDarkTopBarButton()
     border-color $ui-dark-borderColor
+    background-color $ui-dark-noteList-backgroundColor
     &:active
       border-color $ui-dark-button--focus-borderColor
     &:focus

--- a/browser/main/Detail/NoteDetailInfo.styl
+++ b/browser/main/Detail/NoteDetailInfo.styl
@@ -54,22 +54,6 @@ $info-margin-under-border = 27px
   bottom 1px
   padding-left 30px
 
-.info-right-button
-  width 34px
-  height 34px
-  border-radius 17px
-  font-size 14px
-  margin 13px 7px
-  padding-top 7px 
-  border none
-  color $ui-button-color
-  fill $ui-button-color
-  background-color transparent
-  &:hover
-    opacity 1
-    background-color $ui-button--hover-backgroundColor
-
-
 body[data-theme="dark"]
   .info
     border-color $ui-dark-borderColor
@@ -89,11 +73,3 @@ body[data-theme="dark"]
 
   .info-right
     background-color $ui-dark-noteDetail-backgroundColor
-
-  .info-right-button
-    navDarkButtonColor()
-    border-color $ui-dark-borderColor
-    &:active
-      border-color $ui-dark-button--focus-borderColor
-    &:focus
-      border-color $ui-button--focus-borderColor

--- a/browser/main/Detail/NoteDetailInfo.styl
+++ b/browser/main/Detail/NoteDetailInfo.styl
@@ -38,7 +38,7 @@ $info-margin-under-border = 27px
   margin 13px 2px
   padding 0
   border-radius 17px
-  &:hover .info-right-button-tooltip
+  &:hover .info-left-button-tooltip
     opacity 1
   &:focus
     border-color $ui-favorite-star-button-color

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -547,7 +547,7 @@ class SnippetNoteDetail extends React.Component {
             />
           </div>
           <div styleName='info-right'>
-            <button styleName='info-right-button'
+            <button styleName='control-trashButton'
               onClick={(e) => this.handleContextButtonClick(e)}
             >
               <svg height="17px" id="Capa_1" style={{"enableBackground":"new 0 0 753.23 753.23"}} width="17px" version="1.1" viewBox="0 0 753.23 753.23" x="0px" y="0px" xmlSpace="preserve">

--- a/browser/main/Detail/SnippetNoteDetail.styl
+++ b/browser/main/Detail/SnippetNoteDetail.styl
@@ -112,8 +112,3 @@ body[data-theme="dark"]
 
   .control-trashButton
     colorDarkTopBarButton()
-    border-color $ui-dark-borderColor
-    &:active
-      border-color $ui-dark-button--focus-borderColor
-    &:focus
-      border-color $ui-button--focus-borderColor

--- a/browser/main/Detail/SnippetNoteDetail.styl
+++ b/browser/main/Detail/SnippetNoteDetail.styl
@@ -70,19 +70,7 @@
 
 .control-trashButton
   float right
-  width 34px
-  height 34px
-  border-radius 17px
-  font-size 14px
-  margin 13px 7px
-  padding-top 7px 
-  border none
-  color $ui-button-color
-  fill $ui-button-color
-  background-color transparent
-  &:hover
-    opacity 1
-    background-color $ui-button--hover-backgroundColor
+  topBarButtonLight()
 
 body[data-theme="dark"]
   .root
@@ -111,4 +99,4 @@ body[data-theme="dark"]
       border-color $ui-dark-borderColor
 
   .control-trashButton
-    colorDarkTopBarButton()
+    topBarButtonDark()

--- a/browser/main/Detail/SnippetNoteDetail.styl
+++ b/browser/main/Detail/SnippetNoteDetail.styl
@@ -68,6 +68,22 @@
     &:active .update-icon
       color white
 
+.control-trashButton
+  float right
+  width 34px
+  height 34px
+  border-radius 17px
+  font-size 14px
+  margin 13px 7px
+  padding-top 7px 
+  border none
+  color $ui-button-color
+  fill $ui-button-color
+  background-color transparent
+  &:hover
+    opacity 1
+    background-color $ui-button--hover-backgroundColor
+
 body[data-theme="dark"]
   .root
     border-color $ui-dark-borderColor
@@ -93,3 +109,11 @@ body[data-theme="dark"]
   .override
     button
       border-color $ui-dark-borderColor
+
+  .control-trashButton
+    colorDarkTopBarButton()
+    border-color $ui-dark-borderColor
+    &:active
+      border-color $ui-dark-button--focus-borderColor
+    &:focus
+      border-color $ui-button--focus-borderColor

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -194,7 +194,6 @@ navDarkButtonColor()
 colorDarkTopBarButton()
   border-color $ui-dark-borderColor
   color $ui-dark-topbar-button-color
-  background-color $dark-default-button-background
   &:hover
     background-color $dark-default-button-background--hover
   &:active

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -151,6 +151,7 @@ $ui-dark-button--active-color = white
 $ui-dark-button--active-backgroundColor = #6AA5E9
 $ui-dark-button--hover-backgroundColor = lighten($ui-dark-backgroundColor, 10%)
 $ui-dark-button--focus-borderColor = lighten(#369DCD, 25%)
+$ui-dark-topbar-button-color = #939395
 
 $dark-default-button-background = $ui-dark-backgroundColor
 $dark-default-button-background--hover = $ui-dark-button--hover-backgroundColor
@@ -189,6 +190,16 @@ navDarkButtonColor()
   &:active:hover
     background-color $ui-dark-button--active-backgroundColor
     color $ui-dark-button--active-color
+
+colorDarkTopBarButton()
+  border-color $ui-dark-borderColor
+  color $ui-dark-topbar-button-color
+  background-color $dark-default-button-background
+  &:hover
+    background-color $dark-default-button-background--hover
+  &:active
+  &:active:hover
+    background-color $ui-dark-button--active-backgroundColor
 
 $ui-dark-tooltip-text-color = white
 $ui-dark-tooltip-backgroundColor = alpha(#444, 70%)

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -139,6 +139,24 @@ modal()
   border-radius $modal-border-radius
   box-shadow 2px 2px 10px gray
 
+topBarButtonLight()
+  width 34px
+  height 34px
+  border-radius 17px
+  font-size 14px
+  margin 13px 7px
+  padding-top 7px
+  border none
+  color $ui-button-color
+  fill $ui-button-color
+  background-color transparent
+  &:active
+    border-color $ui-button--active-backgroundColor
+  &:hover
+    background-color $ui-button--hover-backgroundColor
+    .control-lockButton-tooltip
+      opacity 1
+
 // Dark theme
 $ui-dark-borderColor = lighten(#21252B, 20%)
 $ui-dark-backgroundColor = #1D1D1D
@@ -191,7 +209,7 @@ navDarkButtonColor()
     background-color $ui-dark-button--active-backgroundColor
     color $ui-dark-button--active-color
 
-colorDarkTopBarButton()
+topBarButtonDark()
   border-color $ui-dark-borderColor
   color $ui-dark-topbar-button-color
   &:hover

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -197,8 +197,11 @@ colorDarkTopBarButton()
   &:hover
     background-color $dark-default-button-background--hover
   &:active
+    border-color $ui-dark-button--focus-borderColor
   &:active:hover
     background-color $ui-dark-button--active-backgroundColor
+  &:focus
+    border-color $ui-button--focus-borderColor
 
 $ui-dark-tooltip-text-color = white
 $ui-dark-tooltip-backgroundColor = alpha(#444, 70%)


### PR DESCRIPTION
A feature what lock the editor behaves incorrectly.

![f69baab1241f83c80ff89ea3412813f0](https://cloud.githubusercontent.com/assets/11307908/24069565/1dd4e616-0b68-11e7-9f80-e7d75b934c2f.gif)

Sometimes, even the lock is opened, the editor keeps its mode when I move another item. Thus I fixed it.