### PR TITLE
Remove a menu which is shown on clicked the trash button

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -181,16 +181,7 @@ class MarkdownNoteDetail extends React.Component {
 
   }
 
-  handleContextButtonClick (e) {
-    let menu = new Menu()
-    menu.append(new MenuItem({
-      label: 'Delete',
-      click: (e) => this.handleDeleteMenuClick(e)
-    }))
-    menu.popup(remote.getCurrentWindow())
-  }
-
-  handleDeleteMenuClick (e) {
+  handleDeleteButtonClick (e) {
     let index = dialog.showMessageBox(remote.getCurrentWindow(), {
       type: 'warning',
       message: 'Delete a note',
@@ -291,7 +282,7 @@ class MarkdownNoteDetail extends React.Component {
               )
             })()}
             <button styleName='control-trashButton'
-              onClick={(e) => this.handleContextButtonClick(e)}
+              onClick={(e) => this.handleDeleteButtonClick(e)}
             >
               <svg height='17px' id='Capa_1' style={{enableBackground: 'new 0 0 753.23 753.23'}} width='17px' version='1.1' viewBox='0 0 753.23 753.23' x='0px' y='0px' xmlSpace='preserve'>
                 <g>

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -189,14 +189,7 @@ class SnippetNoteDetail extends React.Component {
 
   }
 
-  handleContextButtonClick (e) {
-    context.popup([{
-      label: 'Delete',
-      click: (e) => this.handleDeleteMenuClick(e)
-    }])
-  }
-
-  handleDeleteMenuClick (e) {
+  handleDeleteButtonClick (e) {
     let index = dialog.showMessageBox(remote.getCurrentWindow(), {
       type: 'warning',
       message: 'Delete a note',
@@ -546,7 +539,7 @@ class SnippetNoteDetail extends React.Component {
           </div>
           <div styleName='info-right'>
             <button styleName='control-trashButton'
-              onClick={(e) => this.handleContextButtonClick(e)}
+              onClick={(e) => this.handleDeleteButtonClick(e)}
             >
               <svg height='17px' id='Capa_1' style={{enableBackground: 'new 0 0 753.23 753.23'}} width='17px' version='1.1' viewBox='0 0 753.23 753.23' x='0px' y='0px' xmlSpace='preserve'>
                 <g>


### PR DESCRIPTION
Hi. I don't wanna see a menu which contains only `delete`.

## before
![61486667cd2bac636c4f177f8bf786c4](https://cloud.githubusercontent.com/assets/11307908/24083621/9e0fe03a-0c97-11e7-8aee-a43f5096fa2f.gif)

## after
![6fc4b30cd3bf051f4217ef820a21dc45](https://cloud.githubusercontent.com/assets/11307908/24083622/9fcf6396-0c97-11e7-95a0-f83905739c5a.gif)
