### PR TITLE
Fix incorrect tag completion in code block

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -24,6 +24,21 @@ function decodeHTMLEntities (text) {
   return text
 }
 
+function encodeHTMLEntities (text) {
+  var entities = [
+    ['\'', 'apos'],
+    ['&', 'amp'],
+    ['<', 'lt'],
+    ['>', 'gt']
+  ]
+
+  for (var i = 0, max = entities.length; i < max; ++i) {
+    text = text.replace(entities[i][0], '&' + entities[i][1] + ';')
+  }
+
+  return text
+}
+
 const { remote } = require('electron')
 const { app } = remote
 const path = require('path')
@@ -241,7 +256,7 @@ export default class MarkdownPreview extends React.Component {
     let { value, theme, indentSize, codeBlockTheme } = this.props
 
     this.refs.root.contentWindow.document.body.setAttribute('data-theme', theme)
-    this.refs.root.contentWindow.document.body.innerHTML = markdown.render(value)
+    this.refs.root.contentWindow.document.body.innerHTML = markdown.render(encodeHTMLEntities(value))
 
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('.taskListItem'), (el) => {
       el.parentNode.parentNode.style.listStyleType = 'none'

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -258,7 +258,15 @@ export default class MarkdownPreview extends React.Component {
     let { value, theme, indentSize, codeBlockTheme } = this.props
 
     this.refs.root.contentWindow.document.body.setAttribute('data-theme', theme)
-    this.refs.root.contentWindow.document.body.innerHTML = markdown.render(encodeHTMLEntities(value))
+
+    const codeBlocks = value.match(/(```)(.|[\n])*?(```)/g)
+    if (codeBlocks.length > 0) {
+      codeBlocks.forEach((codeBlock) => {
+        const encodedCodeBlock = encodeHTMLEntities(codeBlock)
+        value = value.replace(codeBlock, encodedCodeBlock)
+      })
+    }
+    this.refs.root.contentWindow.document.body.innerHTML = markdown.render(value)
 
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('.taskListItem'), (el) => {
       el.parentNode.parentNode.style.listStyleType = 'none'

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -259,7 +259,7 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.body.setAttribute('data-theme', theme)
 
     const codeBlocks = value.match(/(```)(.|[\n])*?(```)/g)
-    if (codeBlocks !== null && codeBlocks.length > 0) {
+    if (codeBlocks !== null) {
       codeBlocks.forEach((codeBlock) => {
         value = value.replace(codeBlock, encodeHTMLEntities(codeBlock))
       })

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -26,7 +26,7 @@ function decodeHTMLEntities (text) {
 }
 
 function encodeHTMLEntities (text) {
-  var entities = [
+  const entities = [
     ['\'', 'apos'],
     ['&', 'amp'],
     ['<', 'lt'],
@@ -34,7 +34,7 @@ function encodeHTMLEntities (text) {
     ['?', '#63']
   ]
 
-  for (var i = 0, max = entities.length; i < max; ++i) {
+  for (let i = 0; i < entities.length; ++i) {
     text = text.replace(entities[i][0], '&' + entities[i][1] + ';')
   }
 

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -34,10 +34,9 @@ function encodeHTMLEntities (text) {
     ['?', '#63']
   ]
 
-  for (let i = 0; i < entities.length; ++i) {
-    text = text.replace(entities[i][0], `&${entities[i][1]};`)
-  }
-
+  entities.forEach((entity) => {
+    text = text.replace(entity[0], `&${entity[1]};`)
+  })
   return text
 }
 

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -35,7 +35,7 @@ function encodeHTMLEntities (text) {
   ]
 
   for (let i = 0; i < entities.length; ++i) {
-    text = text.replace(entities[i][0], '&' + entities[i][1] + ';')
+    text = text.replace(entities[i][0], `&${entities[i][1]};`)
   }
 
   return text

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -260,7 +260,7 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.body.setAttribute('data-theme', theme)
 
     const codeBlocks = value.match(/(```)(.|[\n])*?(```)/g)
-    if (codeBlocks.length > 0) {
+    if (codeBlocks !== null && codeBlocks.length > 0) {
       codeBlocks.forEach((codeBlock) => {
         const encodedCodeBlock = encodeHTMLEntities(codeBlock)
         value = value.replace(codeBlock, encodedCodeBlock)

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -14,7 +14,8 @@ function decodeHTMLEntities (text) {
     ['apos', '\''],
     ['amp', '&'],
     ['lt', '<'],
-    ['gt', '>']
+    ['gt', '>'],
+    ['#63', '?']
   ]
 
   for (var i = 0, max = entities.length; i < max; ++i) {
@@ -29,7 +30,8 @@ function encodeHTMLEntities (text) {
     ['\'', 'apos'],
     ['&', 'amp'],
     ['<', 'lt'],
-    ['>', 'gt']
+    ['>', 'gt'],
+    ['?', '#63']
   ]
 
   for (var i = 0, max = entities.length; i < max; ++i) {

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -8,37 +8,7 @@ import flowchart from 'flowchart'
 import SequenceDiagram from 'js-sequence-diagrams'
 import eventEmitter from 'browser/main/lib/eventEmitter'
 import fs from 'fs'
-
-function decodeHTMLEntities (text) {
-  var entities = [
-    ['apos', '\''],
-    ['amp', '&'],
-    ['lt', '<'],
-    ['gt', '>'],
-    ['#63', '\\?']
-  ]
-
-  for (var i = 0, max = entities.length; i < max; ++i) {
-    text = text.replace(new RegExp('&' + entities[i][0] + ';', 'g'), entities[i][1])
-  }
-
-  return text
-}
-
-function encodeHTMLEntities (text) {
-  const entities = [
-    ['\'', 'apos'],
-    ['&', 'amp'],
-    ['<', 'lt'],
-    ['>', 'gt'],
-    ['\\?', '#63']
-  ]
-
-  entities.forEach((entity) => {
-    text = text.replace(new RegExp(entity[0], 'g'), `&${entity[1]};`)
-  })
-  return text
-}
+import htmlTextHelper from 'browser/lib/htmlTextHelper'
 
 const { remote } = require('electron')
 const { app } = remote
@@ -261,7 +231,7 @@ export default class MarkdownPreview extends React.Component {
     const codeBlocks = value.match(/(```)(.|[\n])*?(```)/g)
     if (codeBlocks !== null) {
       codeBlocks.forEach((codeBlock) => {
-        value = value.replace(codeBlock, encodeHTMLEntities(codeBlock))
+        value = value.replace(codeBlock, htmlTextHelper.encodeEntities(codeBlock))
       })
     }
     this.refs.root.contentWindow.document.body.innerHTML = markdown.render(value)
@@ -286,7 +256,7 @@ export default class MarkdownPreview extends React.Component {
       let syntax = CodeMirror.findModeByName(el.className)
       if (syntax == null) syntax = CodeMirror.findModeByName('Plain Text')
       CodeMirror.requireMode(syntax.mode, () => {
-        let content = decodeHTMLEntities(el.innerHTML)
+        let content = htmlTextHelper.decodeEntities(el.innerHTML)
         el.innerHTML = ''
         el.parentNode.className += ` cm-s-${codeBlockTheme} CodeMirror`
         CodeMirror.runMode(content, syntax.mime, el, {
@@ -304,7 +274,7 @@ export default class MarkdownPreview extends React.Component {
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('.flowchart'), (el) => {
       Raphael.setWindow(this.getWindow())
       try {
-        let diagram = flowchart.parse(decodeHTMLEntities(el.innerHTML))
+        let diagram = flowchart.parse(htmlTextHelper.decodeEntities(el.innerHTML))
         el.innerHTML = ''
         diagram.drawSVG(el, opts)
         _.forEach(el.querySelectorAll('a'), (el) => {
@@ -320,7 +290,7 @@ export default class MarkdownPreview extends React.Component {
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('.sequence'), (el) => {
       Raphael.setWindow(this.getWindow())
       try {
-        let diagram = SequenceDiagram.parse(decodeHTMLEntities(el.innerHTML))
+        let diagram = SequenceDiagram.parse(htmlTextHelper.decodeEntities(el.innerHTML))
         el.innerHTML = ''
         diagram.drawSVG(el, {theme: 'simple'})
         _.forEach(el.querySelectorAll('a'), (el) => {

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -15,7 +15,7 @@ function decodeHTMLEntities (text) {
     ['amp', '&'],
     ['lt', '<'],
     ['gt', '>'],
-    ['#63', '?']
+    ['#63', '\\?']
   ]
 
   for (var i = 0, max = entities.length; i < max; ++i) {
@@ -31,7 +31,7 @@ function encodeHTMLEntities (text) {
     ['&', 'amp'],
     ['<', 'lt'],
     ['>', 'gt'],
-    ['?', '#63']
+    ['\\?', '#63']
   ]
 
   entities.forEach((entity) => {

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -35,7 +35,7 @@ function encodeHTMLEntities (text) {
   ]
 
   entities.forEach((entity) => {
-    text = text.replace(entity[0], `&${entity[1]};`)
+    text = text.replace(new RegExp(entity[0], 'g'), `&${entity[1]};`)
   })
   return text
 }

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -261,8 +261,7 @@ export default class MarkdownPreview extends React.Component {
     const codeBlocks = value.match(/(```)(.|[\n])*?(```)/g)
     if (codeBlocks !== null && codeBlocks.length > 0) {
       codeBlocks.forEach((codeBlock) => {
-        const encodedCodeBlock = encodeHTMLEntities(codeBlock)
-        value = value.replace(codeBlock, encodedCodeBlock)
+        value = value.replace(codeBlock, encodeHTMLEntities(codeBlock))
       })
     }
     this.refs.root.contentWindow.document.body.innerHTML = markdown.render(value)

--- a/browser/lib/htmlTextHelper.js
+++ b/browser/lib/htmlTextHelper.js
@@ -26,7 +26,6 @@ export function decodeEntities (text) {
 export function encodeEntities (text) {
   const entities = [
     ['\'', 'apos'],
-    ['&', 'amp'],
     ['<', 'lt'],
     ['>', 'gt'],
     ['\\?', '#63']

--- a/browser/lib/htmlTextHelper.js
+++ b/browser/lib/htmlTextHelper.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Text trimmer for html.
+ */
+
+/**
+ * @param {string} text
+ * @return {string}
+ */
+
+export function decodeEntities (text) {
+  var entities = [
+    ['apos', '\''],
+    ['amp', '&'],
+    ['lt', '<'],
+    ['gt', '>'],
+    ['#63', '\\?']
+  ]
+
+  for (var i = 0, max = entities.length; i < max; ++i) {
+    text = text.replace(new RegExp(`&${entities[i][0]};`, 'g'), entities[i][1])
+  }
+
+  return text
+}
+
+export function encodeEntities (text) {
+  const entities = [
+    ['\'', 'apos'],
+    ['&', 'amp'],
+    ['<', 'lt'],
+    ['>', 'gt'],
+    ['\\?', '#63']
+  ]
+
+  entities.forEach((entity) => {
+    text = text.replace(new RegExp(entity[0], 'g'), `&${entity[1]};`)
+  })
+  return text
+}
+
+export default {
+  decodeEntities,
+  encodeEntities,
+}

--- a/browser/lib/htmlTextHelper.js
+++ b/browser/lib/htmlTextHelper.js
@@ -39,5 +39,5 @@ export function encodeEntities (text) {
 
 export default {
   decodeEntities,
-  encodeEntities,
+  encodeEntities
 }

--- a/tests/lib/html-text-helper-test.js
+++ b/tests/lib/html-text-helper-test.js
@@ -9,15 +9,15 @@ test('htmlTextHelper#decodeEntities should return encoded text (string)', t => {
   // [input, expected]
   const testCases = [
     ['&lt;a href=', '<a href='],
-    ['var test = &apos;test&apos;', "var test = 'test'"],
-    ['&lt;a href=&apos;https://boostnote.io&apos;&gt;Boostnote', "<a href='https://boostnote.io'>Boostnote"],
-    ["&lt;\\?php\n var = &apos;hoge&apos;;", "<\\?php\n var = 'hoge';"],
-    ["&amp;", "&"],
+    ['var test = &apos;test&apos;', 'var test = \'test\''],
+    ['&lt;a href=&apos;https://boostnote.io&apos;&gt;Boostnote', '<a href=\'https://boostnote.io\'>Boostnote'],
+    ['&lt;\\\\?php\n var = &apos;hoge&apos;;', '<\\\\?php\n var = \'hoge\';'],
+    ['&amp;', '&']
   ]
 
   testCases.forEach(testCase => {
-    const [input, expected] = testCase;
-    t.is(htmlTextHelper.decodeEntities(input), expected, `Test for decodeEntities() input: ${input} expected: ${expected}`);
+    const [input, expected] = testCase
+    t.is(htmlTextHelper.decodeEntities(input), expected, `Test for decodeEntities() input: ${input} expected: ${expected}`)
   })
 })
 
@@ -25,28 +25,28 @@ test('htmlTextHelper#decodeEntities() should return decoded text (string)', t =>
   // [input, expected]
   const testCases = [
     ['<a href=', '&lt;a href='],
-    ["var test = 'test'", 'var test = &apos;test&apos;'],
-    ["<a href='https://boostnote.io'>Boostnote", '&lt;a href=&apos;https://boostnote.io&apos;&gt;Boostnote'],
-    ["<?php\n var = 'hoge';", "&lt;&#63;php\n var = &apos;hoge&apos;;"],
+    ['var test = \'test\'', 'var test = &apos;test&apos;'],
+    ['<a href=\'https://boostnote.io\'>Boostnote', '&lt;a href=&apos;https://boostnote.io&apos;&gt;Boostnote'],
+    ['<?php\n var = \'hoge\';', '&lt;&#63;php\n var = &apos;hoge&apos;;']
   ]
 
   testCases.forEach(testCase => {
-    const [input, expected] = testCase;
-    t.is(htmlTextHelper.encodeEntities(input), expected, `Test for encodeEntities() input: ${input} expected: ${expected}`);
+    const [input, expected] = testCase
+    t.is(htmlTextHelper.encodeEntities(input), expected, `Test for encodeEntities() input: ${input} expected: ${expected}`)
   })
 })
 
 // Integration test
 test(t => {
   const testCases = [
-    "var test = 'test'",
-    "<a href='https://boostnote.io'>Boostnote",
-    "<Component styleName='test' />",
+    'var test = \'test\'',
+    '<a href=\'https://boostnote.io\'>Boostnote',
+    '<Component styleName=\'test\' />'
   ]
 
   testCases.forEach(testCase => {
     const encodedText = htmlTextHelper.encodeEntities(testCase)
     const decodedText = htmlTextHelper.decodeEntities(encodedText)
-    t.is(decodedText, testCase, `Integration test for encodedText() and decodedText()`);
+    t.is(decodedText, testCase, 'Integration test through encodedText() and decodedText()')
   })
 })

--- a/tests/lib/html-text-helper-test.js
+++ b/tests/lib/html-text-helper-test.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Unit test for browser/lib/htmlTextHelper
+ */
+const test = require('ava')
+const htmlTextHelper = require('browser/lib/htmlTextHelper')
+
+// Unit test
+test('htmlTextHelper#decodeEntities should return encoded text (string)', t => {
+  // [input, expected]
+  const testCases = [
+    ['&lt;a href=', '<a href='],
+    ['var test = &apos;test&apos;', "var test = 'test'"],
+    ['&lt;a href=&apos;https://boostnote.io&apos;&gt;Boostnote', "<a href='https://boostnote.io'>Boostnote"],
+    ["&lt;\\?php\n var = &apos;hoge&apos;;", "<\\?php\n var = 'hoge';"],
+    ["&amp;", "&"],
+  ]
+
+  testCases.forEach(testCase => {
+    const [input, expected] = testCase;
+    t.is(htmlTextHelper.decodeEntities(input), expected, `Test for decodeEntities() input: ${input} expected: ${expected}`);
+  })
+})
+
+test('htmlTextHelper#decodeEntities() should return decoded text (string)', t => {
+  // [input, expected]
+  const testCases = [
+    ['<a href=', '&lt;a href='],
+    ["var test = 'test'", 'var test = &apos;test&apos;'],
+    ["<a href='https://boostnote.io'>Boostnote", '&lt;a href=&apos;https://boostnote.io&apos;&gt;Boostnote'],
+    ["<?php\n var = 'hoge';", "&lt;&#63;php\n var = &apos;hoge&apos;;"],
+  ]
+
+  testCases.forEach(testCase => {
+    const [input, expected] = testCase;
+    t.is(htmlTextHelper.encodeEntities(input), expected, `Test for encodeEntities() input: ${input} expected: ${expected}`);
+  })
+})
+
+// Integration test
+test(t => {
+  const testCases = [
+    "var test = 'test'",
+    "<a href='https://boostnote.io'>Boostnote",
+    "<Component styleName='test' />",
+  ]
+
+  testCases.forEach(testCase => {
+    const encodedText = htmlTextHelper.encodeEntities(testCase)
+    const decodedText = htmlTextHelper.decodeEntities(encodedText)
+    t.is(decodedText, testCase, `Integration test for encodedText() and decodedText()`);
+  })
+})


### PR DESCRIPTION
Finally, I fixed this problem which is reported by https://github.com/BoostIO/Boostnote/issues/333 and https://github.com/BoostIO/Boostnote/issues/294.

Before, this code didn't work well in CodeBlock: `<port protcol="tcp" port="10022"/>`

<img width="368" alt="screen shot 2017-03-19 at 14 13 50" src="https://cloud.githubusercontent.com/assets/11307908/24084824/9532e6c6-0cae-11e7-8a63-a445db0d57be.png">


## before
<img width="890" alt="screen shot 2017-03-19 at 14 15 29" src="https://cloud.githubusercontent.com/assets/11307908/24084816/87979cc8-0cae-11e7-81d4-4adb301f312a.png">

## after
<img width="762" alt="screen shot 2017-03-19 at 14 13 54" src="https://cloud.githubusercontent.com/assets/11307908/24084806/722ba320-0cae-11e7-97b2-cc21e3c1746e.png">
