### PR TITLE
Fix the screen become black on closing Boostnote when a state of Boostnote is fullscreen on mac

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -40,12 +40,20 @@ mainWindow.webContents.sendInputEvent({
 
 if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') {
   mainWindow.on('close', function (e) {
+    e.preventDefault()
     if (process.platform === 'win32') {
       mainWindow.minimize()
     } else {
-      mainWindow.hide()
+      if(mainWindow.isFullScreen()){
+        mainWindow.once('leave-full-screen', function () {
+          mainWindow.hide()
+        })
+        mainWindow.setFullScreen(false)
+      }
+      else{
+        mainWindow.hide()
+      }
     }
-    e.preventDefault()
   })
 
   app.on('before-quit', function (e) {

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -44,13 +44,12 @@ if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') 
     if (process.platform === 'win32') {
       mainWindow.minimize()
     } else {
-      if(mainWindow.isFullScreen()){
+      if (mainWindow.isFullScreen()) {
         mainWindow.once('leave-full-screen', function () {
           mainWindow.hide()
         })
         mainWindow.setFullScreen(false)
-      }
-      else{
+      } else {
         mainWindow.hide()
       }
     }


### PR DESCRIPTION
I fixed it. But I don't have any ways to check the behavior of windows or Linux. Someone, please help me.

![2b93d78c673a56aa189ded5cfc05f316](https://cloud.githubusercontent.com/assets/11307908/24186076/c8292306-0e93-11e7-90e2-2ba650f32ed2.gif)

https://github.com/BoostIO/Boostnote/issues/332#issuecomment-288311835