### PR TITLE
fix: #288 Fixed Snippet tabs overwriting other tabs when closed

### DIFF
--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -250,16 +250,20 @@ class SnippetNoteDetail extends React.Component {
   }
 
   deleteSnippetByIndex (index) {
-    let snippets = this.state.note.snippets.slice()
-    snippets.splice(index, 1)
-    this.state.note.snippets = snippets
-    let snippetIndex = this.state.snippetIndex >= snippets.length
-      ? snippets.length - 1
-      : this.state.snippetIndex
-    this.setState({
-      note: this.state.note,
-      snippetIndex
-    }, () => {
+    const computeNextStateAfterDeletion = (index) => () => {
+      const snippets = this.state.note.snippets.slice()
+      snippets.splice(index, 1)
+      const snippetIndex = this.state.snippetIndex >= snippets.length
+        ? snippets.length - 1
+        : this.state.snippetIndex
+      return {
+        note: {
+          snippets
+        },
+        snippetIndex
+      }
+    }
+    this.setState(computeNextStateAfterDeletion(index), () => {
       this.save()
     })
   }


### PR DESCRIPTION
I also replaced the let with const because that is best practices. If the variable shape does not change it should be a const[ant]