### PR TITLE
Bring back support for markdown checkbox

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -56,6 +56,7 @@ md.use(math, {
     return output
   }
 })
+md.use(require('markdown-it-checkbox'))
 md.use(require('markdown-it-footnote'))
 // Override task item
 md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {


### PR DESCRIPTION
I want support for checkboxes in markdown. I noticed that the package `markdown-it-checkbox` is already in packages.json, so I did a little digging to figure out when/where/why it disappeared. 
I found this commit, but couldn't figure out the reasoning behind removing the plugin, so I am providing a PR to insert it back in.
https://github.com/BoostIO/Boostnote/commit/c6eff157dee6671a3c484f41e0a3aae428930db6#diff-9f5682dd5df751e3be2bb1d16f40f84f