### PR TITLE
Fix new line problem in list and task list

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -83,37 +83,7 @@ export default class CodeEditor extends React.Component {
         'Cmd-T': function (cm) {
           // Do nothing
         },
-        Enter: (cm) => {
-          const cursor = cm.getCursor()
-          const line = cm.getLine(cursor.line)
-          let bulletType
-          if (line.trim().startsWith('- ')) {
-            bulletType = 1 // dash
-          } else if (line.trim().startsWith('* ')) {
-            bulletType = 2 // star
-          } else if (line.trim().startsWith('+ ')) {
-            bulletType = 3 // plus
-          } else {
-            bulletType = 0 // not a bullet
-          }
-          const numberedListRegex = /^(\d+)\. .+/
-          const match = line.trim().match(numberedListRegex)
-          if (bulletType !== 0 || match) {
-            cm.execCommand('newlineAndIndent')
-            const range = {line: cursor.line + 1, ch: cm.getLine(cursor.line + 1).length}
-            if (match) {
-              cm.replaceRange((parseInt(match[1]) + 1) + '. ', range)
-            } else if (bulletType === 1) {
-              cm.replaceRange('- ', range)
-            } else if (bulletType === 2) {
-              cm.replaceRange('* ', range)
-            } else if (bulletType === 3) {
-              cm.replaceRange('+ ', range)
-            }
-          } else {
-            cm.execCommand('newlineAndIndent')
-          }
-        }
+        Enter: 'newlineAndIndentContinueMarkdownList'
       }
     })
 


### PR DESCRIPTION
Hello. I changed the code to use `newlineAndIndentContinueMarkdownList` which is defined in `node_module/codemirror/addon/edit/continuelist.js`of library named`codemirror`. It'll fix the new line issues in list and task list. 

This will cover these issues in [List of the requested features](https://github.com/BoostIO/Boostnote/wiki/List-of-the-requested-features#markdown-note)
- [ ] Remove last list item when Enter pressed on empty list item. [#42](https://github.com/BoostIO/Boostnote/issues/42)
- [ ] Task list should append - [ ] instead of - when Enter pressed.


### Before
![before](https://cloud.githubusercontent.com/assets/14093971/25037864/936c5902-2136-11e7-98aa-15e96fac8d60.gif)
### After
![after](https://cloud.githubusercontent.com/assets/14093971/25037865/95c803f4-2136-11e7-92a4-17df7656d44e.gif)