### PR TITLE
double click on tab to rename

### DIFF
--- a/browser/components/SnippetTab.js
+++ b/browser/components/SnippetTab.js
@@ -96,6 +96,7 @@ class SnippetTab extends React.Component {
         {!this.state.isRenaming
           ? <button styleName='button'
             onClick={(e) => this.handleClick(e)}
+            onDoubleClick={(e) => this.handleRenameClick(e)}
             onContextMenu={(e) => this.handleContextMenu(e)}
           >
             {snippet.name.trim().length > 0


### PR DESCRIPTION
Double click is more convenient i guess. When opening a new snippet, the first thing i have to do is rename the first tab, thus rename is always the thing need to be done first and with the current flow, i have to right click, select rename, which is slow