### PR TITLE
Fix a shortcut for deletion

### DIFF
--- a/browser/main/Detail/index.js
+++ b/browser/main/Detail/index.js
@@ -17,7 +17,7 @@ class Detail extends React.Component {
       this.refs.root != null && this.refs.root.focus()
     }
     this.deleteHandler = () => {
-      this.refs.root != null && this.refs.root.handleDeleteMenuClick()
+      this.refs.root != null && this.refs.root.handleDeleteButtonClick()
     }
   }
 


### PR DESCRIPTION
Sadly, I forgot to rename this function name in https://github.com/BoostIO/Boostnote/pull/340 :fearful: Due to this, a bug happens and we cannot use a shortcut for deletion a note. Sorry for inconvenient.

### The error message

```
Uncaught TypeError: o.refs.root.handleDeleteMenuClick is not a function
```

### ENV
* macOS
* Boostnote v0.8.8

![screen shot 2017-04-22 at 15 28 43](https://cloud.githubusercontent.com/assets/11307908/25308819/2db7d306-2772-11e7-9f8e-c7850aeebed9.png)
