### PR TITLE
Feature: Toggle Fullscreen mode

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -155,15 +155,15 @@ var view = {
     {
       label: 'Toggle Full Screen',
       accelerator: (() => {
-        if (process.platform === 'darwin') return 'Ctrl+Command+F';
-        return 'F11';
+        if (process.platform === 'darwin') return 'Ctrl+Command+F'
+        return 'F11'
       })(),
       click: (item, focusedWindow) => {
         if (focusedWindow) {
-          focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
-          focusedWindow.send('window:fullscreen', { state: focusedWindow.isFullScreen() });
+          focusedWindow.setFullScreen(!focusedWindow.isFullScreen())
+          focusedWindow.send('window:fullscreen', { state: focusedWindow.isFullScreen() })
         }
-      },
+      }
     },
     {
       label: 'Reload',

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -153,6 +153,19 @@ var view = {
   label: 'View',
   submenu: [
     {
+      label: 'Toggle Full Screen',
+      accelerator: (() => {
+        if (process.platform === 'darwin') return 'Ctrl+Command+F';
+        return 'F11';
+      })(),
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+          focusedWindow.send('window:fullscreen', { state: focusedWindow.isFullScreen() });
+        }
+      },
+    },
+    {
       label: 'Reload',
       accelerator: 'CmdOrCtrl+R',
       click: function () {

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -156,6 +156,7 @@ var view = {
       label: 'Toggle Full Screen',
       accelerator: macOS ? 'Control+Command+F' : 'F11',
       click: (item, focusedWindow) => {
+        // item is not used
         if (focusedWindow) {
           focusedWindow.setFullScreen(!focusedWindow.isFullScreen())
           focusedWindow.send('window:fullscreen', { state: focusedWindow.isFullScreen() })

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -154,10 +154,7 @@ var view = {
   submenu: [
     {
       label: 'Toggle Full Screen',
-      accelerator: (() => {
-        if (process.platform === 'darwin') return 'Ctrl+Command+F'
-        return 'F11'
-      })(),
+      accelerator: macOS ? 'Control+Command+F' : 'F11',
       click: (item, focusedWindow) => {
         if (focusedWindow) {
           focusedWindow.setFullScreen(!focusedWindow.isFullScreen())


### PR DESCRIPTION
Hello!
Now it's possible to toggle the app in and out of the fullscreen mode just by pressing the <kbd>F11</kbd> key on Windows/Linux and <kbd>Command</kbd> + <kbd>F</kbd> on MacOS! Feel free to modify the key combinations if needed!

![fullscreen-feature-screen](https://cloud.githubusercontent.com/assets/12670537/25315471/e0bc45e0-285d-11e7-8366-0c3eff4332a8.png)

🚀 Tested on Windows 10 Pro, Linux Ubuntu 16.04 & Mac OS Sierra!

🔧 Solves partially issues #151 & #94 

📷 Here is an in action gif running the windows build!

![2017-04-23_18-36-21](https://cloud.githubusercontent.com/assets/12670537/25315627/d7142f50-2860-11e7-81a8-038b534c40c4.gif)

Start taking notes distraction free! 🎉 