### PR TITLE
Fix viriables for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ matrix:
   include:
     - os: osx
       install:
-        - 'if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-TRAVIS_BRANCH} = "master" ]]; then yarn; fi'
+        - 'if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} = "master" ]]; then yarn; fi'
       node_js:
         - 'stable'
         - 'lts/*'
       script:
-        - 'if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-TRAVIS_BRANCH} = "master" && ${TRAVIS_NODE_VERSION} = "stable" ]]; then
+        - 'if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} = "master" && ${TRAVIS_NODE_VERSION} = "stable" ]]; then
              npm run lint;
              npm run test;
              ./script/e2e-runner.sh;
@@ -20,4 +20,4 @@ matrix:
       script:
         - 'npm run lint'
         - 'npm run test'
-        - 'if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-TRAVIS_BRANCH} = "master" && ${TRAVIS_NODE_VERSION} = "stable" ]]; then ./script/e2e-runner.sh; fi'
+        - 'if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} = "master" && ${TRAVIS_NODE_VERSION} = "stable" ]]; then ./script/e2e-runner.sh; fi'


### PR DESCRIPTION
I fixed this issue: Spectron doesn't run even master branch because there's no `$` before variables.