### PR TITLE
display percentage of achievement of todo in markdown

### DIFF
--- a/browser/components/TodoListPercentage.styl
+++ b/browser/components/TodoListPercentage.styl
@@ -1,0 +1,13 @@
+.percentageBar
+  position absolute
+  background-color #bcbcbc
+  height 20px
+  width 100%
+
+.progressBar
+  background-color #52d8a5
+  height 20px
+  text-align center
+
+.progressBar p
+  color white

--- a/browser/components/TodolistPercentage.js
+++ b/browser/components/TodolistPercentage.js
@@ -13,12 +13,11 @@ import styles from './TodoListPercentage.styl'
 const TodoListPercentage = ({
   percentageOfTodo
 }) => (
-    <div styleName='percentageBar'
-      style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
+  <div  styleName='percentageBar' style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
     <div styleName='progressBar' style={{ width: percentageOfTodo + '%'}}>
-        <p styleName='percentageText'>{percentageOfTodo + '%'}</p>
-      </div>
+      <p styleName='percentageText'>{percentageOfTodo + '%'}</p>
     </div>
+  </div>
 )
 
 

--- a/browser/components/TodolistPercentage.js
+++ b/browser/components/TodolistPercentage.js
@@ -13,13 +13,12 @@ import styles from './TodoListPercentage.styl'
 const TodoListPercentage = ({
   percentageOfTodo
 }) => (
-  <div  styleName='percentageBar' style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
-    <div styleName='progressBar' style={{ width: percentageOfTodo + '%'}}>
+  <div styleName='percentageBar' style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
+    <div styleName='progressBar' style={{width: percentageOfTodo + '%'}}>
       <p styleName='percentageText'>{percentageOfTodo + '%'}</p>
     </div>
   </div>
 )
-
 
 TodoListPercentage.propTypes = {
   percentageOfTodo: PropTypes.number.isRequired

--- a/browser/components/TodolistPercentage.js
+++ b/browser/components/TodolistPercentage.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Percentage of todo achievement.
+ */
+
+import React, { PropTypes } from 'react'
+import CSSModules from 'browser/lib/CSSModules'
+import styles from './TodoListPercentage.styl'
+
+/**
+ * @param {number} percentageOfTodo
+ */
+
+const TodoListPercentage = ({
+  percentageOfTodo
+}) => (
+    <div styleName='percentageBar'
+      style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
+    <div styleName='progressBar' style={{ width: percentageOfTodo + '%'}}>
+        <p styleName='percentageText'>{percentageOfTodo + '%'}</p>
+      </div>
+    </div>
+)
+
+
+TodoListPercentage.propTypes = {
+  percentageOfTodo: PropTypes.number.isRequired
+}
+
+export default CSSModules(TodoListPercentage, styles)

--- a/browser/components/TodolistPercentage.js
+++ b/browser/components/TodolistPercentage.js
@@ -14,8 +14,8 @@ const TodoListPercentage = ({
   percentageOfTodo
 }) => (
   <div styleName='percentageBar' style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
-    <div styleName='progressBar' style={{width: percentageOfTodo + '%'}}>
-      <p styleName='percentageText'>{percentageOfTodo + '%'}</p>
+    <div styleName='progressBar' style={{width:`${percentageOfTodo}%`}}>
+      <p styleName='percentageText'>{percentageOfTodo}%</p>
     </div>
   </div>
 )

--- a/browser/components/TodolistPercentage.js
+++ b/browser/components/TodolistPercentage.js
@@ -14,7 +14,7 @@ const TodoListPercentage = ({
   percentageOfTodo
 }) => (
   <div styleName='percentageBar' style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
-    <div styleName='progressBar' style={{width:`${percentageOfTodo}%`}}>
+    <div styleName='progressBar' style={{width: `${percentageOfTodo}%`}}>
       <p styleName='percentageText'>{percentageOfTodo}%</p>
     </div>
   </div>

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -103,10 +103,10 @@ class MarkdownNoteDetail extends React.Component {
 
     for (let i = 0; i < splitted.length; i++) {
       let trimmedLine = splitted[i].trim()
-      if (trimmedLine.match(/^- \[\s|x\] ./)) {
+      if (trimmedLine.match(/^[\+\-\*] \[\s|x\] ./)) {
         numberOfTodo++
       }
-      if (trimmedLine.match(/^- \[x\] ./)) {
+      if (trimmedLine.match(/^[\+\-\*] \[x\] ./)) {
         numberOfCompletedTodo++
       }
     }

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -96,20 +96,20 @@ class MarkdownNoteDetail extends React.Component {
     return title
   }
 
-  getPercentageOfCompleteTodo (value) {
-    let splitted = value.split('\n')
+  getPercentageOfCompleteTodo (noteContent) {
+    let splitted = noteContent.split('\n')
     let numberOfTodo = 0
     let numberOfCompletedTodo = 0
 
-    for (let i = 0; i < splitted.length; i++) {
-      let trimmedLine = splitted[i].trim()
+    splitted.forEach((line) => {
+      let trimmedLine = line.trim()
       if (trimmedLine.match(/^[\+\-\*] \[\s|x\] ./)) {
         numberOfTodo++
       }
       if (trimmedLine.match(/^[\+\-\*] \[x\] ./)) {
         numberOfCompletedTodo++
       }
-    }
+    })
 
     return Math.floor(numberOfCompletedTodo / numberOfTodo * 100)
   }

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import CSSModules from 'browser/lib/CSSModules'
 import styles from './MarkdownNoteDetail.styl'
 import MarkdownEditor from 'browser/components/MarkdownEditor'
+import TodoListPercentage from 'browser/components/TodoListPercentage'
 import StarButton from './StarButton'
 import TagSelect from './TagSelect'
 import FolderSelect from './FolderSelect'
@@ -93,6 +94,24 @@ class MarkdownNoteDetail extends React.Component {
     title = markdown.strip(title)
 
     return title
+  }
+
+  getPercentageOfCompleteTodo (value) {
+    let splitted = value.split('\n')
+    let numberOfTodo = 0
+    let numberOfCompletedTodo = 0
+
+    for (let i = 0; i < splitted.length; i++) {
+      let trimmedLine = splitted[i].trim()
+      if (trimmedLine.match(/^- \[\s|x\] ./)) {
+        numberOfTodo++
+      }
+      if (trimmedLine.match(/^- \[x\] ./)) {
+        numberOfCompletedTodo++
+      }
+    }
+
+    return Math.floor(numberOfCompletedTodo / numberOfTodo * 100)
   }
 
   handleChange (e) {
@@ -262,6 +281,9 @@ class MarkdownNoteDetail extends React.Component {
               ref='tags'
               value={this.state.note.tags}
               onChange={(e) => this.handleChange(e)}
+            />
+            <TodoListPercentage
+              percentageOfTodo={this.getPercentageOfCompleteTodo(note.content)}
             />
           </div>
           <div styleName='info-right'>


### PR DESCRIPTION
I heard that There are people who using Boostnote as todo list. So, I made percentage of achievement it visible.

![todolist](https://cloud.githubusercontent.com/assets/14838850/25770777/692fc2ec-3279-11e7-8ddc-f5d43df198c2.gif)
