### PR TITLE
#225 Problem with scrollbar in dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/*
 /compiled
 /secret
 *.log
+.idea

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import _ from 'lodash'
+import {enhanceWithScrollbars} from '../lib/codemirrorScrollbars'
 import CodeMirror from 'codemirror'
 import path from 'path'
 
@@ -45,8 +46,10 @@ export default class CodeEditor extends React.Component {
 
   componentDidMount () {
     this.value = this.props.value
-    this.editor = CodeMirror(this.refs.root, {
+      enhanceWithScrollbars(CodeMirror)
+      this.editor = CodeMirror(this.refs.root, {
       value: this.props.value,
+      scrollbarStyle: 'simple',
       lineNumbers: true,
       lineWrapping: true,
       theme: this.props.theme,

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -221,7 +221,10 @@ class MarkdownEditor extends React.Component {
         onKeyDown={(e) => this.handleKeyDown(e)}
         onKeyUp={(e) => this.handleKeyUp(e)}
       >
-        <CodeEditor styleName='codeEditor'
+        <CodeEditor styleName={this.state.status === 'CODE'
+		        ? 'codeEditor'
+		        : 'codeEditor--hide'
+          }
           ref='code'
           mode='GitHub Flavored Markdown'
           value={value}

--- a/browser/components/MarkdownEditor.styl
+++ b/browser/components/MarkdownEditor.styl
@@ -4,20 +4,24 @@
 .codeEditor
   absolute top bottom left right
 
+.hide
+  z-index 0
+  opacity 0
+  pointer-events none
+
 .codeEditor--hide
   @extend .codeEditor
+  @extend .hide
 
 .preview
   display block
   absolute top bottom left right
   z-index 100
-  background-color white
+  background-color transparent
   height 100%
   width 100%
 
 .preview--hide
   @extend .preview
-  z-index 0
-  opacity 0
-  pointer-events none
+  @extend .hide
 

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import markdown from 'browser/lib/markdown'
 import _ from 'lodash'
 import CodeMirror from 'codemirror'
+import {enhanceWithScrollbars} from '../lib/codemirrorScrollbars'
 import consts from 'browser/lib/consts'
 import Raphael from 'raphael'
 import flowchart from 'flowchart'
@@ -260,6 +261,7 @@ export default class MarkdownPreview extends React.Component {
       : 'default'
 
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('.code code'), (el) => {
+      enhanceWithScrollbars(CodeMirror);
       let syntax = CodeMirror.findModeByName(el.className)
       if (syntax == null) syntax = CodeMirror.findModeByName('Plain Text')
       CodeMirror.requireMode(syntax.mode, () => {
@@ -267,6 +269,7 @@ export default class MarkdownPreview extends React.Component {
         el.innerHTML = ''
         el.parentNode.className += ` cm-s-${codeBlockTheme} CodeMirror`
         CodeMirror.runMode(content, syntax.mime, el, {
+          scrollbarStyle: 'simple',
           tabSize: indentSize
         })
       })

--- a/browser/lib/codemirrorScrollbars.js
+++ b/browser/lib/codemirrorScrollbars.js
@@ -1,0 +1,161 @@
+import './codemirrorScrollbars.styl'
+
+export const enhanceWithScrollbars = (CodeMirror) => {
+	if (!CodeMirror) return
+
+	class Bar {
+		constructor(codeMirror, cls, orientation, scroll) {
+			this.codeMirror = codeMirror
+			this.orientation = orientation
+			this.scroll = scroll
+			this.screen = this.total = this.size = 1
+			this.pos = 0
+			this.start = 0
+			this.minButtonSize = 10
+
+			this.node = document.createElement("div")
+			this.node.className = cls + "-" + orientation
+			this.inner = this.node.appendChild(document.createElement("div"))
+
+			this.handleMouseDown = this.handleMouseDown.bind(this)
+			this.handleClick = this.handleClick.bind(this)
+			this.handleOnWheel = this.handleOnWheel.bind(this)
+			this.done = this.done.bind(this)
+			this.move = this.move.bind(this)
+			this.update = this.update.bind(this)
+
+			CodeMirror.on(this.inner, "mousedown", this.handleMouseDown)
+			CodeMirror.on(this.node, "click", this.handleClick)
+			CodeMirror.on(this.node, "mousewheel", this.handleOnWheel)
+			CodeMirror.on(this.node, "DOMMouseScroll", this.handleOnWheel)
+		}
+
+		handleOnWheel(e) {
+			const moved = this.codeMirror.wheelEventPixels(e)[this.orientation == "horizontal" ? "x" : "y"]
+			const oldPos = this.pos
+			this.moveTo(this.pos + moved)
+			if (this.pos != oldPos) this.codeMirror.e_preventDefault(e)
+		}
+
+		handleClick(e) {
+			this.codeMirror.e_preventDefault(e)
+			const innerBox = this.inner.getBoundingClientRect()
+			let where
+			if (this.orientation == "horizontal")
+				where = e.clientX < innerBox.left ? -1 : e.clientX > innerBox.right ? 1 : 0
+			else
+				where = e.clientY < innerBox.top ? -1 : e.clientY > innerBox.bottom ? 1 : 0
+			this.moveTo(this.pos + where * this.screen)
+		}
+
+		done() {
+			this.codeMirror.off(document, "mousemove", this.move)
+			this.codeMirror.off(document, "mouseup", this.done)
+		}
+
+		move(e) {
+			const axis = this.orientation == "horizontal" ? "pageX" : "pageY"
+			if (e.which != 1) return this.done()
+			this.moveTo(this.startpos + (e[axis] - this.start) * (this.total / this.size))
+		}
+
+		handleMouseDown(e) {
+			if (e.which != 1) return
+			const axis = this.orientation == "horizontal" ? "pageX" : "pageY"
+			this.start = e[axis]
+			this.startpos = this.pos;
+			this.codeMirror.e_preventDefault(e)
+			this.codeMirror.on(document, "mousemove", this.move)
+			this.codeMirror.on(document, "mouseup", this.done)
+		}
+
+		setPos(pos, force) {
+			if (pos < 0) pos = 0
+			if (pos > this.total - this.screen) pos = this.total - this.screen
+			if (!force && pos == this.pos) return false
+			this.pos = pos
+			this.inner.style[this.orientation == "horizontal" ? "left" : "top"] =
+					(pos * (this.size / this.total)) + "px"
+			return true
+		}
+
+		moveTo(pos) {
+			if (this.setPos(pos)) this.scroll(pos, this.orientation)
+		}
+
+		update(scrollSize, clientSize, barSize) {
+			const sizeChanged = this.screen != clientSize || this.total != scrollSize || this.size != barSize
+			if (sizeChanged) {
+				this.screen = clientSize
+				this.total = scrollSize
+				this.size = barSize
+			}
+
+			let buttonSize = this.screen * (this.size / this.total)
+			if (buttonSize < this.minButtonSize) {
+				this.size -= this.minButtonSize - buttonSize
+				buttonSize = this.minButtonSize
+			}
+			this.inner.style[this.orientation == "horizontal" ? "width" : "height"] =
+					buttonSize + "px"
+			this.setPos(this.pos, sizeChanged)
+		}
+	}
+
+	class SimpleScrollbars {
+		constructor(codeMirror, cls, place, scroll) {
+			this.addClass = cls;
+			this.horiz = new Bar(codeMirror, cls, "horizontal___browser-lib-", scroll);
+			place(this.horiz.node);
+			this.vert = new Bar(codeMirror, cls, "vertical___browser-lib-", scroll);
+			place(this.vert.node);
+			this.width = null;
+			this.update = this.update.bind(this);
+		}
+
+		update(measure) {
+			if (this.width == null) {
+				const style = window.getComputedStyle ? window.getComputedStyle(this.horiz.node) : this.horiz.node.currentStyle
+				if (style) this.width = parseInt(style.height)
+			}
+			const width = this.width || 0
+
+			const needsH = measure.scrollWidth > measure.clientWidth + 1
+			const needsV = measure.scrollHeight > measure.clientHeight + 1
+			this.vert.node.style.display = needsV ? "block" : "none"
+			this.horiz.node.style.display = needsH ? "block" : "none"
+
+			if (needsV) {
+				this.vert.update(measure.scrollHeight, measure.clientHeight,
+						measure.viewHeight - (needsH ? width : 0))
+				this.vert.node.style.bottom = needsH ? width + "px" : "0"
+			}
+			if (needsH) {
+				this.horiz.update(measure.scrollWidth, measure.clientWidth,
+						measure.viewWidth - (needsV ? width : 0) - measure.barLeft)
+				this.horiz.node.style.right = needsV ? width + "px" : "0"
+				this.horiz.node.style.left = measure.barLeft + "px"
+			}
+
+			return {right: needsV ? width : 0, bottom: needsH ? width : 0}
+		}
+
+		setScrollTop(pos) {
+			this.vert.setPos(pos)
+		}
+
+		setScrollLeft(pos) {
+			this.horiz.setPos(pos)
+		}
+
+		clear() {
+			const parent = this.horiz.node.parentNode
+			parent.removeChild(this.horiz.node)
+			parent.removeChild(this.vert.node)
+		}
+	}
+
+	CodeMirror.scrollbarModel.simple = function (place, scroll) {
+		return new SimpleScrollbars(CodeMirror, "codemirrorScrollbars__CodeMirror-simplescroll", place, scroll);
+	};
+};

--- a/browser/lib/codemirrorScrollbars.styl
+++ b/browser/lib/codemirrorScrollbars.styl
@@ -1,0 +1,30 @@
+.CodeMirror-simplescroll-horizontal div, .CodeMirror-simplescroll-vertical div
+  position absolute
+  background #ccc
+  -moz-box-sizing border-box
+  box-sizing border-box
+  border 1px solid #bbb
+  border-radius 2px
+
+.CodeMirror-simplescroll-horizontal, .CodeMirror-simplescroll-vertical
+  position absolute
+  z-index 6
+  background transparent
+
+.CodeMirror-simplescroll-horizontal
+  bottom 0
+  left 0
+  height 6px
+
+  div
+    bottom 0
+    height 100%
+
+.CodeMirror-simplescroll-vertical
+  right 0
+  top 0
+  width 6px
+
+  div
+    right 0
+    width 100%

--- a/browser/lib/codemirrorScrollbars.styl
+++ b/browser/lib/codemirrorScrollbars.styl
@@ -1,7 +1,6 @@
 .CodeMirror-simplescroll-horizontal div, .CodeMirror-simplescroll-vertical div
   position absolute
   background #ccc
-  -moz-box-sizing border-box
   box-sizing border-box
   border 1px solid #bbb
   border-radius 2px

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -35,6 +35,22 @@ $ui-tooltip-button-backgroundColor = #D1D1D1
 $ui-tooltip-button--hover-backgroundColor = lighten(#D1D1D1, 30%)
 $ui-tooltip-font-size = 12px
 
+::-webkit-scrollbar
+  height 6px
+  width 6px
+  background transparent
+
+::-webkit-scrollbar-thumb
+  background #ccc
+  -moz-box-sizing border-box
+  box-sizing border-box
+  border 1px solid #bbb
+  border-radius 2px
+
+::-webkit-scrollbar-corner
+  background transparent
+
+
 tooltip()
   background-color $ui-tooltip-backgroundColor = alpha(#444, 70%)
   color $ui-tooltip-text-color = white

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -42,7 +42,6 @@ $ui-tooltip-font-size = 12px
 
 ::-webkit-scrollbar-thumb
   background #ccc
-  -moz-box-sizing border-box
   box-sizing border-box
   border 1px solid #bbb
   border-radius 2px


### PR DESCRIPTION
Changes:
- fix for showing code editor and preview in same time; 
- code editor enhance with custom scrollbars;
- custom styles for scrollbars;
- gitignore .idea folder;

This PR also contain changes from PR #535. They are required for properly displaying scrollbar styles for editor and preview. 
Below are images with new scrollbar style in app, I think they looks good in both dark and light app theme and also code editor themes as well. Scrollbar styles could easily be changed by changing css - for whole app and for codemirror.

![1](https://cloud.githubusercontent.com/assets/2607232/25918278/2bf6d8fc-35cb-11e7-9b01-ad318d6780b3.JPG)
![2](https://cloud.githubusercontent.com/assets/2607232/25918279/2bf6c13c-35cb-11e7-9b45-b69c821c929d.JPG)
![3](https://cloud.githubusercontent.com/assets/2607232/25918281/2bf8c720-35cb-11e7-85fb-dae6f4cfa1c3.JPG)
![4](https://cloud.githubusercontent.com/assets/2607232/25918282/2bf93fa2-35cb-11e7-9062-f1fb9a4c1009.JPG)
![5](https://cloud.githubusercontent.com/assets/2607232/25918280/2bf7ab92-35cb-11e7-80dc-5508f6dcbf25.JPG)
