### PR TITLE
If there is no tag, narrow the width of NoteList.

### DIFF
--- a/browser/components/NoteItem.styl
+++ b/browser/components/NoteItem.styl
@@ -83,7 +83,6 @@ $control-height = 30px
   position relative
   bottom 0px
   margin-top 2px
-  height 20px
   font-size 12px
   line-height 20px
   overflow ellipsis
@@ -93,6 +92,7 @@ $control-height = 30px
   flex 1
   overflow ellipsis
   line-height 20px
+  padding-top 2px
   padding-left 2px
 
 .item-bottom-tagList-item


### PR DESCRIPTION
<img width="274" alt="screen shot 0029-05-22 at 8 14 23 pm" src="https://cloud.githubusercontent.com/assets/8602615/26305682/4a19f6ac-3f2b-11e7-818d-5f943bd9ece0.png">
