### PR TITLE
added fullscreen button for notes and snippets

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -29,7 +29,14 @@ class MarkdownNoteDetail extends React.Component {
         content: ''
       }, props.note),
       isLockButtonShown: false,
-      isLocked: false
+      isLocked: false,
+      fullScreen: {
+        status: false,
+        oldState: {
+          nd : 0,
+          mb : 0
+        }
+      }
     }
     this.dispatchTimer = null
 

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -29,7 +29,14 @@ class MarkdownNoteDetail extends React.Component {
         content: ''
       }, props.note),
       isLockButtonShown: false,
-      isLocked: false
+      isLocked: false,
+      fullScreen: {
+        status: false,
+        oldState: {
+          nd : 0,
+          mb : 0
+        }
+      }
     }
     this.dispatchTimer = null
 
@@ -193,6 +200,34 @@ class MarkdownNoteDetail extends React.Component {
     }
   }
 
+  handleFullScreenButton (e) {
+
+    this.state.fullScreen.status = !this.state.fullScreen.status
+    const noteDetail = document.querySelector(".NoteDetail")
+    const mainBody = document.querySelector(".Main__body___browser-main-")
+    const sliderRight = document.querySelector(".Main__slider-right___browser-main-")
+    const slider = document.querySelector(".Main__slider___browser-main-")
+
+    if(this.state.fullScreen.status) {
+
+      this.state.fullScreen.oldState.nd = noteDetail.style.left
+      this.state.fullScreen.oldState.mb = mainBody.style.left
+      noteDetail.style.left = "0px"
+      mainBody.style.left = "0px"
+      sliderRight.style.display = 'none'
+      slider.style.display = 'none'
+
+    }else {
+
+      noteDetail.style.left = this.state.fullScreen.oldState.nd
+      mainBody.style.left = this.state.fullScreen.oldState.mb
+      sliderRight.style.display = 'block'
+      slider.style.display = 'block'
+
+    }
+
+  }
+
   handleLockButtonMouseDown (e) {
     e.preventDefault()
     ee.emit('editor:lock')
@@ -283,6 +318,11 @@ class MarkdownNoteDetail extends React.Component {
                   </g>
                 </g>
               </svg>
+            </button>
+            <button styleName='control-fullScreenButton'
+              onMouseDown={(e) => this.handleFullScreenButton(e)}
+            >
+              <i className={'fa fa-arrows-alt'} styleName='fullScreen-button' />
             </button>
           </div>
         </div>

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -29,10 +29,7 @@ class MarkdownNoteDetail extends React.Component {
         content: ''
       }, props.note),
       isLockButtonShown: false,
-      isLocked: false,
-      fullScreen: false,
-      widthOfNoteDetail: 0,
-      widthOfMainBody: 0
+      isLocked: false
     }
     this.dispatchTimer = null
 
@@ -197,25 +194,7 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleFullScreenButton (e) {
-    this.setState({ fullScreen: !this.state.fullScreen }, () => {
-      const noteDetail = document.querySelector('.NoteDetail')
-      const mainBody = document.querySelector('#main-body')
-      const sliderRight = document.querySelector('#slider-right')
-      const sliderLeft = document.querySelector('#slider-left')
-      if (this.state.fullScreen) {
-        this.state.widthOfNoteDetail = noteDetail.style.left
-        this.state.widthOfMainBody = mainBody.style.left
-        noteDetail.style.left = '0px'
-        mainBody.style.left = '0px'
-        sliderRight.style.display = 'none'
-        sliderLeft.style.display = 'none'
-      } else {
-        noteDetail.style.left = this.state.widthOfNoteDetail
-        mainBody.style.left = this.state.widthOfMainBody
-        sliderRight.style.display = 'block'
-        sliderLeft.style.display = 'block'
-      }
-    })
+    ee.emit('editor:fullscreen')
   }
 
   handleLockButtonMouseDown (e) {

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -30,13 +30,9 @@ class MarkdownNoteDetail extends React.Component {
       }, props.note),
       isLockButtonShown: false,
       isLocked: false,
-      fullScreen: {
-        status: false,
-        oldState: {
-          nd : 0,
-          mb : 0
-        }
-      }
+      fullScreen: false,
+      widthOfNoteDetail: 0,
+      widthOfMainBody: 0
     }
     this.dispatchTimer = null
 
@@ -201,31 +197,27 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleFullScreenButton (e) {
+    const currentScreenState = !Object.assign({}, this.state).fullScreen
+    this.setState({ fullScreen: currentScreenState })
 
-    this.state.fullScreen.status = !this.state.fullScreen.status
-    const noteDetail = document.querySelector(".NoteDetail")
-    const mainBody = document.querySelector(".Main__body___browser-main-")
-    const sliderRight = document.querySelector(".Main__slider-right___browser-main-")
-    const slider = document.querySelector(".Main__slider___browser-main-")
+    const noteDetail = document.querySelector('.NoteDetail')
+    const mainBody = document.querySelector('#main-body')
+    const sliderRight = document.querySelector('#slider-right')
+    const sliderLeft = document.querySelector('#slider-left')
 
-    if(this.state.fullScreen.status) {
-
-      this.state.fullScreen.oldState.nd = noteDetail.style.left
-      this.state.fullScreen.oldState.mb = mainBody.style.left
-      noteDetail.style.left = "0px"
-      mainBody.style.left = "0px"
+    if (currentScreenState) {
+      this.state.widthOfNoteDetail = noteDetail.style.left
+      this.state.widthOfMainBody = mainBody.style.left
+      noteDetail.style.left = '0px'
+      mainBody.style.left = '0px'
       sliderRight.style.display = 'none'
-      slider.style.display = 'none'
-
-    }else {
-
-      noteDetail.style.left = this.state.fullScreen.oldState.nd
-      mainBody.style.left = this.state.fullScreen.oldState.mb
+      sliderLeft.style.display = 'none'
+    } else {
+      noteDetail.style.left = this.state.widthOfNoteDetail
+      mainBody.style.left = this.state.widthOfMainBody
       sliderRight.style.display = 'block'
-      slider.style.display = 'block'
-
+      sliderLeft.style.display = 'block'
     }
-
   }
 
   handleLockButtonMouseDown (e) {

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -197,27 +197,25 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleFullScreenButton (e) {
-    const currentScreenState = !Object.assign({}, this.state).fullScreen
-    this.setState({ fullScreen: currentScreenState })
-
-    const noteDetail = document.querySelector('.NoteDetail')
-    const mainBody = document.querySelector('#main-body')
-    const sliderRight = document.querySelector('#slider-right')
-    const sliderLeft = document.querySelector('#slider-left')
-
-    if (currentScreenState) {
-      this.state.widthOfNoteDetail = noteDetail.style.left
-      this.state.widthOfMainBody = mainBody.style.left
-      noteDetail.style.left = '0px'
-      mainBody.style.left = '0px'
-      sliderRight.style.display = 'none'
-      sliderLeft.style.display = 'none'
-    } else {
-      noteDetail.style.left = this.state.widthOfNoteDetail
-      mainBody.style.left = this.state.widthOfMainBody
-      sliderRight.style.display = 'block'
-      sliderLeft.style.display = 'block'
-    }
+    this.setState({ fullScreen: !this.state.fullScreen }, () => {
+      const noteDetail = document.querySelector('.NoteDetail')
+      const mainBody = document.querySelector('#main-body')
+      const sliderRight = document.querySelector('#slider-right')
+      const sliderLeft = document.querySelector('#slider-left')
+      if (this.state.fullScreen) {
+        this.state.widthOfNoteDetail = noteDetail.style.left
+        this.state.widthOfMainBody = mainBody.style.left
+        noteDetail.style.left = '0px'
+        mainBody.style.left = '0px'
+        sliderRight.style.display = 'none'
+        sliderLeft.style.display = 'none'
+      } else {
+        noteDetail.style.left = this.state.widthOfNoteDetail
+        mainBody.style.left = this.state.widthOfMainBody
+        sliderRight.style.display = 'block'
+        sliderLeft.style.display = 'block'
+      }
+    })
   }
 
   handleLockButtonMouseDown (e) {
@@ -314,7 +312,7 @@ class MarkdownNoteDetail extends React.Component {
             <button styleName='control-fullScreenButton'
               onMouseDown={(e) => this.handleFullScreenButton(e)}
             >
-              <i className={'fa fa-arrows-alt'} styleName='fullScreen-button' />
+              <i className='fa fa-arrows-alt' styleName='fullScreen-button' />
             </button>
           </div>
         </div>

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -30,13 +30,9 @@ class MarkdownNoteDetail extends React.Component {
       }, props.note),
       isLockButtonShown: false,
       isLocked: false,
-      fullScreen: {
-        status: false,
-        oldState: {
-          nd : 0,
-          mb : 0
-        }
-      }
+      fullScreen: false,
+      widthOfNoteDetail: 0,
+      widthOfMainBody: 0
     }
     this.dispatchTimer = null
 

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -29,10 +29,7 @@ class MarkdownNoteDetail extends React.Component {
         content: ''
       }, props.note),
       isLockButtonShown: false,
-      isLocked: false,
-      fullScreen: false,
-      widthOfNoteDetail: 0,
-      widthOfMainBody: 0
+      isLocked: false
     }
     this.dispatchTimer = null
 

--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -31,6 +31,10 @@
   float right
   topBarButtonLight()
 
+.control-fullScreenButton
+  float right
+  topBarButtonLight()
+
 .body
   absolute left right
   left $note-detail-left-margin
@@ -54,4 +58,7 @@ body[data-theme="dark"]
     darkTooltip()
 
   .control-trashButton
+    topBarButtonDark()
+
+  .control-fullScreenButton
     topBarButtonDark()

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -51,7 +51,6 @@ class SnippetNoteDetail extends React.Component {
       fullScreen: false,
       widthOfNoteDetail: 0,
       widthOfMainBody: 0
-
     }
   }
 
@@ -192,27 +191,25 @@ class SnippetNoteDetail extends React.Component {
   }
 
   handleFullScreenButton (e) {
-    const currentScreenState = !Object.assign({}, this.state).fullScreen
-    this.setState({ fullScreen: currentScreenState })
-
-    const noteDetail = document.querySelector('.NoteDetail')
-    const mainBody = document.querySelector('#main-body')
-    const sliderRight = document.querySelector('#slider-right')
-    const sliderLeft = document.querySelector('#slider-left')
-
-    if (currentScreenState) {
-      this.state.widthOfNoteDetail = noteDetail.style.left
-      this.state.widthOfMainBody = mainBody.style.left
-      noteDetail.style.left = '0px'
-      mainBody.style.left = '0px'
-      sliderRight.style.display = 'none'
-      sliderLeft.style.display = 'none'
-    } else {
-      noteDetail.style.left = this.state.widthOfNoteDetail
-      mainBody.style.left = this.state.widthOfMainBody
-      sliderRight.style.display = 'block'
-      sliderLeft.style.display = 'block'
-    }
+    this.setState({ fullScreen: !this.state.fullScreen }, () => {
+      const noteDetail = document.querySelector('.NoteDetail')
+      const mainBody = document.querySelector('#main-body')
+      const sliderRight = document.querySelector('#slider-right')
+      const sliderLeft = document.querySelector('#slider-left')
+      if (this.state.fullScreen) {
+        this.state.widthOfNoteDetail = noteDetail.style.left
+        this.state.widthOfMainBody = mainBody.style.left
+        noteDetail.style.left = '0px'
+        mainBody.style.left = '0px'
+        sliderRight.style.display = 'none'
+        sliderLeft.style.display = 'none'
+      } else {
+        noteDetail.style.left = this.state.widthOfNoteDetail
+        mainBody.style.left = this.state.widthOfMainBody
+        sliderRight.style.display = 'block'
+        sliderLeft.style.display = 'block'
+      }
+    })
   }
 
   handleTabPlusButtonClick (e) {
@@ -555,7 +552,7 @@ class SnippetNoteDetail extends React.Component {
             <button styleName='control-fullScreenButton'
               onMouseDown={(e) => this.handleFullScreenButton(e)}
             >
-              <i className={'fa fa-arrows-alt'} styleName='fullScreen-button' />
+              <i className='fa fa-arrows-alt' styleName='fullScreen-button' />
             </button>
           </div>
         </div>

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -47,10 +47,7 @@ class SnippetNoteDetail extends React.Component {
         description: ''
       }, props.note, {
         snippets: props.note.snippets.map((snippet) => Object.assign({}, snippet))
-      }),
-      fullScreen: false,
-      widthOfNoteDetail: 0,
-      widthOfMainBody: 0
+      })
     }
   }
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -47,7 +47,15 @@ class SnippetNoteDetail extends React.Component {
         description: ''
       }, props.note, {
         snippets: props.note.snippets.map((snippet) => Object.assign({}, snippet))
-      })
+      }),
+      fullScreen: {
+        status: false,
+        oldState: {
+          nd : 0,
+          mb : 0
+        }
+      }
+
     }
   }
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -47,7 +47,15 @@ class SnippetNoteDetail extends React.Component {
         description: ''
       }, props.note, {
         snippets: props.note.snippets.map((snippet) => Object.assign({}, snippet))
-      })
+      }),
+      fullScreen: {
+        status: false,
+        oldState: {
+          nd : 0,
+          mb : 0
+        }
+      }
+
     }
   }
 
@@ -185,6 +193,34 @@ class SnippetNoteDetail extends React.Component {
           ee.emit('list:next')
         })
     }
+  }
+
+  handleFullScreenButton (e) {
+
+    this.state.fullScreen.status = !this.state.fullScreen.status
+    const noteDetail = document.querySelector(".NoteDetail")
+    const mainBody = document.querySelector(".Main__body___browser-main-")
+    const sliderRight = document.querySelector(".Main__slider-right___browser-main-")
+    const slider = document.querySelector(".Main__slider___browser-main-")
+
+    if(this.state.fullScreen.status) {
+
+      this.state.fullScreen.oldState.nd = noteDetail.style.left
+      this.state.fullScreen.oldState.mb = mainBody.style.left
+      noteDetail.style.left = "0px"
+      mainBody.style.left = "0px"
+      sliderRight.style.display = 'none'
+      slider.style.display = 'none'
+
+    }else {
+
+      noteDetail.style.left = this.state.fullScreen.oldState.nd
+      mainBody.style.left = this.state.fullScreen.oldState.mb
+      sliderRight.style.display = 'block'
+      slider.style.display = 'block'
+
+    }
+
   }
 
   handleTabPlusButtonClick (e) {
@@ -523,6 +559,11 @@ class SnippetNoteDetail extends React.Component {
                   </g>
                 </g>
               </svg>
+            </button>
+            <button styleName='control-fullScreenButton'
+              onMouseDown={(e) => this.handleFullScreenButton(e)}
+            >
+              <i className={'fa fa-arrows-alt'} styleName='fullScreen-button' />
             </button>
           </div>
         </div>

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -51,7 +51,6 @@ class SnippetNoteDetail extends React.Component {
       fullScreen: false,
       widthOfNoteDetail: 0,
       widthOfMainBody: 0
-
     }
   }
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -48,13 +48,9 @@ class SnippetNoteDetail extends React.Component {
       }, props.note, {
         snippets: props.note.snippets.map((snippet) => Object.assign({}, snippet))
       }),
-      fullScreen: {
-        status: false,
-        oldState: {
-          nd : 0,
-          mb : 0
-        }
-      }
+      fullScreen: false,
+      widthOfNoteDetail: 0,
+      widthOfMainBody: 0
 
     }
   }

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -47,10 +47,7 @@ class SnippetNoteDetail extends React.Component {
         description: ''
       }, props.note, {
         snippets: props.note.snippets.map((snippet) => Object.assign({}, snippet))
-      }),
-      fullScreen: false,
-      widthOfNoteDetail: 0,
-      widthOfMainBody: 0
+      })
     }
   }
 
@@ -191,25 +188,7 @@ class SnippetNoteDetail extends React.Component {
   }
 
   handleFullScreenButton (e) {
-    this.setState({ fullScreen: !this.state.fullScreen }, () => {
-      const noteDetail = document.querySelector('.NoteDetail')
-      const mainBody = document.querySelector('#main-body')
-      const sliderRight = document.querySelector('#slider-right')
-      const sliderLeft = document.querySelector('#slider-left')
-      if (this.state.fullScreen) {
-        this.state.widthOfNoteDetail = noteDetail.style.left
-        this.state.widthOfMainBody = mainBody.style.left
-        noteDetail.style.left = '0px'
-        mainBody.style.left = '0px'
-        sliderRight.style.display = 'none'
-        sliderLeft.style.display = 'none'
-      } else {
-        noteDetail.style.left = this.state.widthOfNoteDetail
-        mainBody.style.left = this.state.widthOfMainBody
-        sliderRight.style.display = 'block'
-        sliderLeft.style.display = 'block'
-      }
-    })
+    ee.emit('editor:fullscreen')
   }
 
   handleTabPlusButtonClick (e) {

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -48,13 +48,9 @@ class SnippetNoteDetail extends React.Component {
       }, props.note, {
         snippets: props.note.snippets.map((snippet) => Object.assign({}, snippet))
       }),
-      fullScreen: {
-        status: false,
-        oldState: {
-          nd : 0,
-          mb : 0
-        }
-      }
+      fullScreen: false,
+      widthOfNoteDetail: 0,
+      widthOfMainBody: 0
 
     }
   }
@@ -196,31 +192,27 @@ class SnippetNoteDetail extends React.Component {
   }
 
   handleFullScreenButton (e) {
+    const currentScreenState = !Object.assign({}, this.state).fullScreen
+    this.setState({ fullScreen: currentScreenState })
 
-    this.state.fullScreen.status = !this.state.fullScreen.status
-    const noteDetail = document.querySelector(".NoteDetail")
-    const mainBody = document.querySelector(".Main__body___browser-main-")
-    const sliderRight = document.querySelector(".Main__slider-right___browser-main-")
-    const slider = document.querySelector(".Main__slider___browser-main-")
+    const noteDetail = document.querySelector('.NoteDetail')
+    const mainBody = document.querySelector('#main-body')
+    const sliderRight = document.querySelector('#slider-right')
+    const sliderLeft = document.querySelector('#slider-left')
 
-    if(this.state.fullScreen.status) {
-
-      this.state.fullScreen.oldState.nd = noteDetail.style.left
-      this.state.fullScreen.oldState.mb = mainBody.style.left
-      noteDetail.style.left = "0px"
-      mainBody.style.left = "0px"
+    if (currentScreenState) {
+      this.state.widthOfNoteDetail = noteDetail.style.left
+      this.state.widthOfMainBody = mainBody.style.left
+      noteDetail.style.left = '0px'
+      mainBody.style.left = '0px'
       sliderRight.style.display = 'none'
-      slider.style.display = 'none'
-
-    }else {
-
-      noteDetail.style.left = this.state.fullScreen.oldState.nd
-      mainBody.style.left = this.state.fullScreen.oldState.mb
+      sliderLeft.style.display = 'none'
+    } else {
+      noteDetail.style.left = this.state.widthOfNoteDetail
+      mainBody.style.left = this.state.widthOfMainBody
       sliderRight.style.display = 'block'
-      slider.style.display = 'block'
-
+      sliderLeft.style.display = 'block'
     }
-
   }
 
   handleTabPlusButtonClick (e) {

--- a/browser/main/Detail/SnippetNoteDetail.styl
+++ b/browser/main/Detail/SnippetNoteDetail.styl
@@ -70,6 +70,10 @@
   float right
   topBarButtonLight()
 
+.control-fullScreenButton
+  float right
+  topBarButtonLight()
+
 body[data-theme="dark"]
   .root
     border-color $ui-dark-borderColor
@@ -101,4 +105,7 @@ body[data-theme="dark"]
         color $ui-dark-text-color
 
   .control-trashButton
+    topBarButtonDark()
+
+  .control-fullScreenButton
     topBarButtonDark()

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -35,7 +35,6 @@ class Main extends React.Component {
     }
 
     this.toggleFullScreen = () => this.handleFullScreenButton()
-
   }
 
   getChildContext () {
@@ -166,7 +165,7 @@ class Main extends React.Component {
     })
   }
 
-  hideLeftLists (noteDetail, mainBody) {
+  hideLeftLists(noteDetail, mainBody) {
     this.state.noteDetailWidth = noteDetail.style.left
     this.state.mainBodyWidth = mainBody.style.left
     noteDetail.style.left = '0px'
@@ -199,7 +198,6 @@ class Main extends React.Component {
         />
         {!config.isSideNavFolded &&
           <div styleName={this.state.isLeftSliderFocused ? 'slider--active' : 'slider'}
-            id='slider-left'
             style={{left: this.state.navWidth}}
             onMouseDown={(e) => this.handleLeftSlideMouseDown(e)}
             draggable='false'
@@ -231,7 +229,6 @@ class Main extends React.Component {
             ])}
           />
           <div styleName={this.state.isRightSliderFocused ? 'slider-right--active' : 'slider-right'}
-            id='slider-right'
             style={{left: this.state.listWidth - 1}}
             onMouseDown={(e) => this.handleRightSlideMouseDown(e)}
             draggable='false'

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -35,6 +35,7 @@ class Main extends React.Component {
     }
 
     this.toggleFullScreen = () => this.handleFullScreenButton()
+
   }
 
   getChildContext () {

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -12,6 +12,7 @@ import ConfigManager from 'browser/main/lib/ConfigManager'
 import modal from 'browser/main/lib/modal'
 import InitModal from 'browser/main/modals/InitModal'
 import mixpanel from 'browser/main/lib/mixpanel'
+import eventEmitter from 'browser/main/lib/eventEmitter'
 
 function focused () {
   mixpanel.track('MAIN_FOCUSED')
@@ -27,8 +28,11 @@ class Main extends React.Component {
       isRightSliderFocused: false,
       listWidth: config.listWidth,
       navWidth: config.navWidth,
-      isLeftSliderFocused: false
+      isLeftSliderFocused: false,
+      fullScreen: false,
     }
+
+    this.fullScreenEditorCode = () => this.handleFullScreenButton()
   }
 
   getChildContext () {
@@ -63,11 +67,13 @@ class Main extends React.Component {
         }
       })
 
+    eventEmitter.on('editor:fullscreen', this.fullScreenEditorCode)
     window.addEventListener('focus', focused)
   }
 
   componentWillUnmount () {
     window.removeEventListener('focus', focused)
+    eventEmitter.off('editor:fullscreen', this.fullScreenEditorCode)
   }
 
   handleLeftSlideMouseDown (e) {
@@ -142,6 +148,24 @@ class Main extends React.Component {
         navWidth: navWidth
       })
     }
+  }
+
+  handleFullScreenButton (e) {
+    this.setState({ fullScreen: !this.state.fullScreen }, () => {
+      const noteDetail = document.querySelector('.NoteDetail')
+      const mainBody = document.querySelector('#main-body')
+      const sliderRight = document.querySelector('#slider-right')
+      const sliderLeft = document.querySelector('#slider-left')
+      if (this.state.fullScreen) {
+        noteDetail.style.left = '0px'
+        mainBody.style.left = '0px'
+        sliderRight.style.display = 'none'
+        sliderLeft.style.display = 'none'
+      } else {
+        sliderRight.style.display = 'block'
+        sliderLeft.style.display = 'block'
+      }
+    })
   }
 
   render () {

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -165,6 +165,7 @@ class Main extends React.Component {
         />
         {!config.isSideNavFolded &&
           <div styleName={this.state.isLeftSliderFocused ? 'slider--active' : 'slider'}
+            id='slider-left'
             style={{left: this.state.navWidth}}
             onMouseDown={(e) => this.handleLeftSlideMouseDown(e)}
             draggable='false'
@@ -173,6 +174,7 @@ class Main extends React.Component {
           </div>
         }
         <div styleName={config.isSideNavFolded ? 'body--expanded' : 'body'}
+          id='main-body'
           ref='body'
           style={{left: config.isSideNavFolded ? 44 : this.state.navWidth}}
         >
@@ -195,6 +197,7 @@ class Main extends React.Component {
             ])}
           />
           <div styleName={this.state.isRightSliderFocused ? 'slider-right--active' : 'slider-right'}
+            id='slider-right'
             style={{left: this.state.listWidth - 1}}
             onMouseDown={(e) => this.handleRightSlideMouseDown(e)}
             draggable='false'

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -30,6 +30,8 @@ class Main extends React.Component {
       navWidth: config.navWidth,
       isLeftSliderFocused: false,
       fullScreen: false,
+      noteDetailWidth: 0,
+      mainBodyWidth: 0
     }
 
     this.fullScreenEditorCode = () => this.handleFullScreenButton()
@@ -157,11 +159,15 @@ class Main extends React.Component {
       const sliderRight = document.querySelector('#slider-right')
       const sliderLeft = document.querySelector('#slider-left')
       if (this.state.fullScreen) {
+        this.state.noteDetailWidth = noteDetail.style.left
+        this.state.mainBodyWidth = mainBody.style.left
         noteDetail.style.left = '0px'
         mainBody.style.left = '0px'
         sliderRight.style.display = 'none'
         sliderLeft.style.display = 'none'
       } else {
+        noteDetail.style.left = this.state.noteDetailWidth
+        mainBody.style.left = this.state.mainBodyWidth
         sliderRight.style.display = 'block'
         sliderLeft.style.display = 'block'
       }

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -198,6 +198,7 @@ class Main extends React.Component {
         />
         {!config.isSideNavFolded &&
           <div styleName={this.state.isLeftSliderFocused ? 'slider--active' : 'slider'}
+            id='slider-left'
             style={{left: this.state.navWidth}}
             onMouseDown={(e) => this.handleLeftSlideMouseDown(e)}
             draggable='false'
@@ -229,6 +230,7 @@ class Main extends React.Component {
             ])}
           />
           <div styleName={this.state.isRightSliderFocused ? 'slider-right--active' : 'slider-right'}
+            id='slider-right'
             style={{left: this.state.listWidth - 1}}
             onMouseDown={(e) => this.handleRightSlideMouseDown(e)}
             draggable='false'

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -34,7 +34,7 @@ class Main extends React.Component {
       mainBodyWidth: 0
     }
 
-    this.fullScreenEditorCode = () => this.handleFullScreenButton()
+    this.toggleFullScreen = () => this.handleFullScreenButton()
   }
 
   getChildContext () {
@@ -69,13 +69,13 @@ class Main extends React.Component {
         }
       })
 
-    eventEmitter.on('editor:fullscreen', this.fullScreenEditorCode)
+    eventEmitter.on('editor:fullscreen', this.toggleFullScreen)
     window.addEventListener('focus', focused)
   }
 
   componentWillUnmount () {
     window.removeEventListener('focus', focused)
-    eventEmitter.off('editor:fullscreen', this.fullScreenEditorCode)
+    eventEmitter.off('editor:fullscreen', this.toggleFullScreen)
   }
 
   handleLeftSlideMouseDown (e) {
@@ -156,22 +156,25 @@ class Main extends React.Component {
     this.setState({ fullScreen: !this.state.fullScreen }, () => {
       const noteDetail = document.querySelector('.NoteDetail')
       const mainBody = document.querySelector('#main-body')
-      const sliderRight = document.querySelector('#slider-right')
-      const sliderLeft = document.querySelector('#slider-left')
+
       if (this.state.fullScreen) {
-        this.state.noteDetailWidth = noteDetail.style.left
-        this.state.mainBodyWidth = mainBody.style.left
-        noteDetail.style.left = '0px'
-        mainBody.style.left = '0px'
-        sliderRight.style.display = 'none'
-        sliderLeft.style.display = 'none'
+        this.hideLeftLists(noteDetail, mainBody)
       } else {
-        noteDetail.style.left = this.state.noteDetailWidth
-        mainBody.style.left = this.state.mainBodyWidth
-        sliderRight.style.display = 'block'
-        sliderLeft.style.display = 'block'
+        this.showLeftLists(noteDetail, mainBody)
       }
     })
+  }
+
+  hideLeftLists(noteDetail, mainBody) {
+    this.state.noteDetailWidth = noteDetail.style.left
+    this.state.mainBodyWidth = mainBody.style.left
+    noteDetail.style.left = '0px'
+    mainBody.style.left = '0px'
+  }
+
+  showLeftLists(noteDetail, mainBody) {
+    noteDetail.style.left = this.state.noteDetailWidth
+    mainBody.style.left = this.state.mainBodyWidth
   }
 
   render () {
@@ -195,7 +198,6 @@ class Main extends React.Component {
         />
         {!config.isSideNavFolded &&
           <div styleName={this.state.isLeftSliderFocused ? 'slider--active' : 'slider'}
-            id='slider-left'
             style={{left: this.state.navWidth}}
             onMouseDown={(e) => this.handleLeftSlideMouseDown(e)}
             draggable='false'
@@ -227,7 +229,6 @@ class Main extends React.Component {
             ])}
           />
           <div styleName={this.state.isRightSliderFocused ? 'slider-right--active' : 'slider-right'}
-            id='slider-right'
             style={{left: this.state.listWidth - 1}}
             onMouseDown={(e) => this.handleRightSlideMouseDown(e)}
             draggable='false'

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -165,7 +165,7 @@ class Main extends React.Component {
     })
   }
 
-  hideLeftLists(noteDetail, mainBody) {
+  hideLeftLists (noteDetail, mainBody) {
     this.state.noteDetailWidth = noteDetail.style.left
     this.state.mainBodyWidth = mainBody.style.left
     noteDetail.style.left = '0px'

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -165,14 +165,14 @@ class Main extends React.Component {
     })
   }
 
-  hideLeftLists(noteDetail, mainBody) {
+  hideLeftLists (noteDetail, mainBody) {
     this.state.noteDetailWidth = noteDetail.style.left
     this.state.mainBodyWidth = mainBody.style.left
     noteDetail.style.left = '0px'
     mainBody.style.left = '0px'
   }
 
-  showLeftLists(noteDetail, mainBody) {
+  showLeftLists (noteDetail, mainBody) {
     noteDetail.style.left = this.state.noteDetailWidth
     mainBody.style.left = this.state.mainBodyWidth
   }

--- a/browser/main/Main.styl
+++ b/browser/main/Main.styl
@@ -13,10 +13,12 @@
   absolute top bottom
   top -2px
   width 0
+  z-index 0
 
 .slider-right
   @extend .slider
   width 1px
+  z-index 0
 
 .slider--active
   @extend .slider


### PR DESCRIPTION
(#547)

allows user to hide the sidebars for fullscreen editing, there is an expand button next to the trash ca., You press it to expand to fullscreen and go back to your old view. Images added below.

I have never used this stack before so I don't quite fully understand react+redux so the code falls back to the dom to edit the divs.

Anyone point me in the right direction to clean the handleFullScreenButton() call?

I would want a hide() function on certain react components? For I could just call those like
 
``` javascript
handleFullScreenButton (e) {
// somehow have access to these objects?
if(this.state.fullScreen.status) {
    noteDetail.hide()
    mainBody.hide()
    sliderRight.hide()
    slider.hide()
else {
    noteDetail.show()
    mainBody.show()
    sliderRight.show()
    slider.show()
}
}
```

![before](https://cloud.githubusercontent.com/assets/1581329/26525409/6b61fac8-431b-11e7-9c5f-8bd7a26f634c.PNG)
![after](https://cloud.githubusercontent.com/assets/1581329/26525408/6b609822-431b-11e7-9262-f8028fb0621c.PNG)
