### PR TITLE
Fix travis node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+before_install: 'if [[ `npm -v` != 4* ]]; then npm i -g npm@4; fi'
 matrix:
   include:
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+# To fix the npm version in 4.x
+# refs: https://github.com/travis-ci/travis-ci/issues/4653#issuecomment-194051953
 before_install: 'if [[ `npm -v` != 4* ]]; then npm i -g npm@4; fi'
 matrix:
   include:


### PR DESCRIPTION
Fix the version of travis to 4.x to deal with a problem what e2e tests timeout due to updates.

And I confirmed the e2e tests passes.
https://travis-ci.org/asmsuechan/Boostnote/jobs/239005788