### PR TITLE
Fix a bug which is not showing dialog when user tries to export a snippet

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -332,7 +332,8 @@ class NoteList extends React.Component {
       dialog.showMessageBox(remote.getCurrentWindow(), {
         type: 'warning',
         message: 'Sorry!',
-        detail: 'md/text import is available only a markdown note.'
+        detail: 'md/text import is available only a markdown note.',
+        buttons: ['OK', 'Cancel']
       })
     }
   }


### PR DESCRIPTION
### before
![screen shot 2017-06-07 at 15 23 23](https://user-images.githubusercontent.com/11307908/26864908-634dd8ca-4b95-11e7-84c6-1fadf907f25e.png)

### after
![screen shot 2017-06-07 at 15 23 47](https://user-images.githubusercontent.com/11307908/26864913-66160b86-4b95-11e7-910a-385435faf776.png)
