### PR TITLE
Add notification on a copy button clicked

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -286,6 +286,10 @@ export default class MarkdownPreview extends React.Component {
         copyIcon.innerHTML = '<button class="clipboardButton"><svg width="13" height="13" viewBox="0 0 1792 1792" ><path d="M768 1664h896v-640h-416q-40 0-68-28t-28-68v-416h-384v1152zm256-1440v-64q0-13-9.5-22.5t-22.5-9.5h-704q-13 0-22.5 9.5t-9.5 22.5v64q0 13 9.5 22.5t22.5 9.5h704q13 0 22.5-9.5t9.5-22.5zm256 672h299l-299-299v299zm512 128v672q0 40-28 68t-68 28h-960q-40 0-68-28t-28-68v-160h-544q-40 0-68-28t-28-68v-1344q0-40 28-68t68-28h1088q40 0 68 28t28 68v328q21 13 36 28l408 408q28 28 48 76t20 88z"/></svg></button>'
         copyIcon.onclick = (e) => {
           copy(content)
+          this.notify('Saved to Clipboard!', {
+            body: 'Paste it wherever you want!',
+            silent: true
+          })
         }
         el.parentNode.appendChild(copyIcon)
         el.innerHTML = ''
@@ -360,6 +364,13 @@ export default class MarkdownPreview extends React.Component {
   preventImageDroppedHandler (e) {
     e.preventDefault()
     e.stopPropagation()
+  }
+
+  notify (title, options) {
+    if (global.process.platform === 'win32') {
+      options.icon = path.join('file://', global.__dirname, '../../resources/app.png')
+    }
+    return new window.Notification(title, options)
   }
 
   render () {


### PR DESCRIPTION
Show a notification when a copy button, which is in a codeblock, is clicked.

<img width="1113" alt="screen shot 2017-06-12 at 21 52 08" src="https://user-images.githubusercontent.com/11307908/27034643-69cc0a3c-4fb9-11e7-83b8-0a6fde07bceb.png">
