### PR TITLE
Fix dependency type of Spectron module

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "sander": "^0.5.1",
-    "spectron": "^3.6.2",
     "superagent": "^1.2.0",
     "superagent-promise": "^1.0.3"
   },
@@ -114,6 +113,7 @@
     "react-input-autosize": "^1.1.0",
     "react-router": "^2.4.0",
     "react-router-redux": "^4.0.4",
+    "spectron": "^3.6.2",
     "standard": "^8.4.0",
     "style-loader": "^0.12.4",
     "stylus": "^0.52.4",


### PR DESCRIPTION
Spectron is a devDependency so I moved the package there where it belongs. This helps when building from source to reducere the size of the Boostnote package since we do not need Spectron in a production environment.