### PR TITLE
Make Ctrl-C copy

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -84,7 +84,13 @@ export default class CodeEditor extends React.Component {
         'Cmd-T': function (cm) {
           // Do nothing
         },
-        Enter: 'newlineAndIndentContinueMarkdownList'
+        Enter: 'newlineAndIndentContinueMarkdownList',
+        'Ctrl-C': (cm) => {
+          if (cm.getOption('keyMap').substr(0, 3) === 'vim') {
+            document.execCommand('copy')
+          }
+          return CodeMirror.Pass
+        }
       }
     })
 


### PR DESCRIPTION
I added copy feature into the existing shortcut (C-c). It doesn't prevent the ordinal feature.

ref: https://github.com/BoostIO/Boostnote/issues/646