### PR TITLE
Randomize the image name when it's dropped

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -193,7 +193,7 @@ export default class CodeEditor extends React.Component {
     const filename = path.basename(imagePath)
 
     copyImage(imagePath, this.props.storageKey).then((imagePathInTheStorage) => {
-      const imageMd = `![${encodeURI(filename)}](${imagePathInTheStorage})`
+      const imageMd = `![${filename}](${imagePathInTheStorage})`
       this.insertImageMd(imageMd)
     })
   }

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -19,10 +19,12 @@ function copyImage (filePath, storageKey) {
       const targetStorage = storage
 
       const inputImage = fs.createReadStream(filePath)
-      const imageName = path.basename(filePath)
-      const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', imageName))
+      const imageExt = path.extname(filePath)
+      const imageName = Math.random().toString(36).slice(-16)
+      const basename = `${imageName}${imageExt}`
+      const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', basename))
       inputImage.pipe(outputImage)
-      resolve(`${encodeURI(targetStorage.path)}/images/${encodeURI(imageName)}`)
+      resolve(`${encodeURI(targetStorage.path)}/images/${encodeURI(basename)}`)
     } catch (e) {
       return reject(e)
     }

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -24,7 +24,7 @@ function copyImage (filePath, storageKey) {
       const basename = `${imageName}${imageExt}`
       const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', basename))
       inputImage.pipe(outputImage)
-      resolve(`${encodeURI(targetStorage.path)}/images/${encodeURI(basename)}`)
+      resolve(`${targetStorage.path}/images/${basename}`)
     } catch (e) {
       return reject(e)
     }


### PR DESCRIPTION
![screen shot 2017-06-28 at 13 07 34](https://user-images.githubusercontent.com/11307908/27620209-f3465eac-5c02-11e7-99b7-edbb19dbdd86.png)

I changed an image name to a random string to avoid duplication when it's dropped. And remove `encodeURI()`.

```
## before
![file%20name.jpg](/Users/asmsuechan/Boostnote/images/filename.jpg)

## after
![file name.jpg](/Users/asmsuechan/Boostnote/images/skgvvqw0ozbprpb9.jpg)
```

`%20` changes to ` ` and `filename` changes to `skgvvqw0ozbprpb9`.

ref: https://github.com/BoostIO/Boostnote/issues/652