### PR TITLE
Replace cm searchbox to official search addon

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -57,7 +57,6 @@ export default class CodeEditor extends React.Component {
       keyMap: this.props.keyMap,
       inputStyle: 'textarea',
       dragDrop: false,
-      searchbox: true,
       extraKeys: {
         Tab: function (cm) {
           const cursor = cm.getCursor()

--- a/lib/main.html
+++ b/lib/main.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../node_modules/font-awesome/css/font-awesome.min.css" media="screen" charset="utf-8">
   <link rel="shortcut icon" href="../resources/favicon.ico">
   <link rel="stylesheet" href="../node_modules/codemirror/lib/codemirror.css">
+  <link rel="stylesheet" href="../node_modules/codemirror/addon/dialog/dialog.css">
   <title>Boostnote</title>
 
   <style>
@@ -64,8 +65,12 @@
 
   <script src="../node_modules/codemirror/addon/edit/continuelist.js"></script>
 
-  <script src="../node_modules/cm-searchbox/lib/searchbox.js"></script>
+  <script src="../node_modules/codemirror/addon/search/search.js"></script>
   <script src="../node_modules/codemirror/addon/search/searchcursor.js"></script>
+  <script src="../node_modules/codemirror/addon/scroll/annotatescrollbar.js"></script>
+  <script src="../node_modules/codemirror/addon/search/matchesonscrollbar.js"></script>
+  <script src="../node_modules/codemirror/addon/search/jump-to-line.js"></script>
+  <script src="../node_modules/codemirror/addon/dialog/dialog.js"></script>
 
   <script src="../node_modules/raphael/raphael.min.js"></script>
   <script src="../node_modules/flowchart.js/release/flowchart.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@rokt33r/season": "^5.3.0",
     "aws-sdk": "^2.48.0",
     "aws-sdk-mobile-analytics": "^0.9.2",
-    "cm-searchbox": "^1.0.8",
     "codemirror": "^5.19.0",
     "electron-config": "^0.2.1",
     "electron-gh-releases": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,6 @@ clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
-cm-searchbox@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/cm-searchbox/-/cm-searchbox-1.0.8.tgz#76d6712b1f1b6c378a4d4eecaa9213ca60ce9999"
-
 co-with-promise@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co-with-promise/-/co-with-promise-4.6.0.tgz#413e7db6f5893a60b942cf492c4bec93db415ab7"


### PR DESCRIPTION
I want to replace `cm-searchbox` to the official search addon because it's very hard to customize.

### Pros
* Easy to maintain
* Easy to customize
* Officially supported

### Cons
* Unintuitive behavior

## ScreenShots
![screen shot 2017-07-09 at 22 49 18](https://user-images.githubusercontent.com/11307908/27994418-f3ba4110-64f8-11e7-8712-f167b9cdcbdd.png)

And vim-search is available (Look at the bottom of CodeEditor).
![screen shot 2017-07-09 at 22 49 26](https://user-images.githubusercontent.com/11307908/27994420-f792dff4-64f8-11e7-8358-e80600158124.png)
