### PR TITLE
Remove sharp from note hash on list:jump

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -384,10 +384,10 @@ export default class MarkdownPreview extends React.Component {
   }
 
   handlelinkClick (e) {
-    const noteHash = e.target.hash
-    const regexIsNoteLink = /^#(.{20})-(.{20})$/
+    const noteHash = e.target.href.split('/').pop()
+    const regexIsNoteLink = /^(.{20})-(.{20})$/
     if (regexIsNoteLink.test(noteHash)) {
-      eventEmitter.emit('list:jump', noteHash.replace(/^#/, ''))
+      eventEmitter.emit('list:jump', noteHash)
     }
   }
 


### PR DESCRIPTION
I changed the interface of note-links (it's not released, so the change affects almost nothing).

### before
`[this_is_a_note](#dca2bd793a0bbff3e9a4-8384df059a2659082989)`

### after
`[this_is_a_note](dca2bd793a0bbff3e9a4-8384df059a2659082989)`