### PR TITLE
Change the keymap of Ctrl-U to Ctrl-K

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -192,7 +192,7 @@ const view = {
     },
     {
       label: 'Previous Note',
-      accelerator: 'Control+U',
+      accelerator: 'Control+K',
       click () {
         mainWindow.webContents.send('list:prior')
       }


### PR DESCRIPTION
The reason why `Ctrl-U` is set as a shortcut is that because it conflicts with one of vim-keymaps. Regardless of the escapement, it doesn't work in vim mode. So I change it to `Ctrl-K` because it's more instinctively than the current one. Sadly, even though this PR will be merged, the shortcut for moving an upper note doesn't work on any kind of editor mode.