### PR TITLE
Change to create a new directory when storage/images does not exist

### DIFF
--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -22,7 +22,9 @@ function copyImage (filePath, storageKey) {
       const imageExt = path.extname(filePath)
       const imageName = Math.random().toString(36).slice(-16)
       const basename = `${imageName}${imageExt}`
-      const outputImage = fs.createWriteStream(path.join(targetStorage.path, 'images', basename))
+      const imageDir = path.join(targetStorage.path, 'images')
+      if (!fs.existsSync(imageDir)) fs.mkdirSync(imageDir)
+      const outputImage = fs.createWriteStream(path.join(imageDir, basename))
       inputImage.pipe(outputImage)
       resolve(`${targetStorage.path}/images/${basename}`)
     } catch (e) {


### PR DESCRIPTION
### before
It **didn't** create a new directory for a dropped image.

### after
It creates a new directory for a dropped image.