### PR TITLE
Change ["title"](note-hash) to [the exact title](note-hash)

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -349,7 +349,7 @@ class MarkdownNoteDetail extends React.Component {
         <InfoPanel
           storageName={currentOption.storage.name}
           folderName={currentOption.folder.name}
-          noteLink={`[title](${location.query.key})`}
+          noteLink={`[${note.title}](${location.query.key})`}
           updatedAt={formatDate(note.updatedAt)}
           createdAt={formatDate(note.createdAt)}
         />

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -588,7 +588,7 @@ class SnippetNoteDetail extends React.Component {
         <InfoPanel
           storageName={currentOption.storage.name}
           folderName={currentOption.folder.name}
-          noteLink={`[title](${location.query.key})`}
+          noteLink={`[${note.title}](${location.query.key})`}
           updatedAt={formatDate(note.updatedAt)}
           createdAt={formatDate(note.createdAt)}
         />


### PR DESCRIPTION
# context
Look at `Note Link` in InfoPanel.

# before
`[title](e9604016f1436fd3a3b4-7da4167bc39895940ddf)`

![image](https://user-images.githubusercontent.com/11307908/28487694-59502c88-6ed1-11e7-911a-d14b1954a467.png)

# after
`[Hamlet](e9604016f1436fd3a3b4-7da4167bc39895940ddf)`
![screen shot 2017-07-22 at 11 30 24](https://user-images.githubusercontent.com/11307908/28487691-3e3ed28c-6ed1-11e7-8558-a29c52e8aab4.png)

# note
If the note is empty, it displays `[](note-hash)`.