### PR TITLE
Fix a bug on click

### DIFF
--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -24,8 +24,9 @@ document.addEventListener('dragover', function (e) {
 })
 
 document.addEventListener('click', function (e) {
-  if (!e.target.className) return
-  const isInfoButton = e.target.className.includes('infoButton')
+  const className = e.target.className
+  if (!className && typeof(className) !== 'string') return
+  const isInfoButton = className.includes('infoButton')
   const isInfoPanel = e.target.offsetParent.className.includes('infoPanel')
   if (isInfoButton || isInfoPanel) return
   const infoPanel = document.querySelector('.infoPanel')

--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -25,7 +25,7 @@ document.addEventListener('dragover', function (e) {
 
 document.addEventListener('click', function (e) {
   const className = e.target.className
-  if (!className && typeof(className) !== 'string') return
+  if (!className && typeof (className) !== 'string') return
   const isInfoButton = className.includes('infoButton')
   const isInfoPanel = e.target.offsetParent.className.includes('infoPanel')
   if (isInfoButton || isInfoPanel) return


### PR DESCRIPTION
# context
An error as follows happens when I clicked `cancel` button on `delete dialog box`.

```
Uncaught TypeError: e.target.className.includes is not a function
```

Although it causes a bug, the application works fine.

# before
![image](https://user-images.githubusercontent.com/11307908/28488924-a2ceac4e-6ef0-11e7-86ee-a511f3f3f32b.png)

# after
The application works fine without the error.