### PR TITLE
Fix inseration position

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -199,8 +199,9 @@ export default class CodeEditor extends React.Component {
   }
 
   insertImageMd (imageMd) {
+    const textarea = this.editor.getInputField()
     const cm = this.editor
-    cm.setValue(cm.getValue() + imageMd)
+    textarea.value = `${textarea.value.substr(0, textarea.selectionStart)}${imageMd}${textarea.value.substr(textarea.selectionEnd)}`
   }
 
   render () {


### PR DESCRIPTION
# context
The image link was inserted at the bottom of the note when you dropped an image on `CodeEditor`. So I changed it because it's not obviously intuitive.

# before
It was inserted at the bottom of the note.
![39fa9bdef3c2cf0edf1785dd41d66f48](https://user-images.githubusercontent.com/11307908/28489199-cbb2b860-6ef7-11e7-8416-c0904cf4852d.gif)

# after
It is inserted the position of your carret.
![c15f7c4319bbe2a1d27df786a871cb7b](https://user-images.githubusercontent.com/11307908/28489201-d8e0c89c-6ef7-11e7-91ef-5922b3c4b9a1.gif)

# ref
https://github.com/BoostIO/Boostnote/pull/293