### PR TITLE
Fix typo in InfoTab

### DIFF
--- a/browser/main/modals/PreferencesModal/InfoTab.js
+++ b/browser/main/modals/PreferencesModal/InfoTab.js
@@ -96,7 +96,7 @@ class InfoTab extends React.Component {
         </ul>
         <hr />
         <div styleName='policy'>Data collection policy</div>
-        <p>We collect only the number of DAU for Boostnote and DO NOT COLLECTED any detail information</p>
+        <p>We collect only the number of DAU for Boostnote and DO NOT collect any detail information</p>
         <p>such as your note content. You can see how it works on <a href='https://github.com/BoostIO/Boostnote' onClick={(e) => this.handleLinkClick(e)}>GitHub</a>.</p>
         <p>These data are only used for Boostnote improvements.</p>
         <input onChange={(e) => this.handleConfigChange(e)}


### PR DESCRIPTION
# context
There's a typo in https://github.com/BoostIO/Boostnote/pull/722.

# before
The part of a sentence was `We collect only the number of DAU for Boostnote and DO NOT COLLECTED any detail information`.

# after
`We collect only the number of DAU for Boostnote and DO NOT collect any detail information`