### PR TITLE
iss #155 Change defaut font on windows_

### DIFF
--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 
 const OSX = global.process.platform === 'darwin'
+const win = global.process.platform === 'win32'
 const electron = require('electron')
 const { ipcRenderer } = electron
 const consts = require('browser/lib/consts')
@@ -28,14 +29,14 @@ export const DEFAULT_CONFIG = {
     theme: 'base16-light',
     keyMap: 'sublime',
     fontSize: '14',
-    fontFamily: 'Monaco, Consolas',
+    fontFamily: win ? 'Segoe UI' : 'Monaco, Consolas',
     indentType: 'space',
     indentSize: '2',
     switchPreview: 'BLUR' // Available value: RIGHTCLICK, BLUR
   },
   preview: {
     fontSize: '14',
-    fontFamily: 'Lato',
+    fontFamily: win ? 'Segoe UI' : 'Lato',
     codeBlockTheme: 'dracula',
     lineNumber: true
   }


### PR DESCRIPTION
# context
The apostrophe seems something wrong on account of the default font. It is not included in windows by default.

# before
The apostrophe has extra space.
![image](https://user-images.githubusercontent.com/11307908/28557009-ee22a622-7144-11e7-8fda-55da6ac06756.png)

# after
The default font on windows is changed to `Segoe UI` (it's a default font of windows 10).
![image](https://user-images.githubusercontent.com/11307908/28556972-b23c8092-7144-11e7-9796-556a57c9cf38.png)

# note
You have to set `Segou UI` as your font by hand if you custom your UI.

# reference
https://github.com/BoostIO/Boostnote/issues/725