### PR TITLE
iss #727 fix incorrect encoding in link

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -159,7 +159,8 @@ function strip (input) {
 const markdown = {
   render: function markdown (content) {
     if (!_.isString(content)) content = ''
-    return md.render(content)
+    const renderedContent = md.render(content)
+    return md.normalizeLinkText(renderedContent)
   },
   strip
 }


### PR DESCRIPTION
# context
The path of dropped images was broken on account of `markdownit.render()`. It encodes `\` as `%5C` so it does not work fine in windows.

# before
There's an unexpected decode such as `C:%5CUsers%5Ckazup%5CBoostnote%5Cimages%5C2zyil22t058nnrk9.png`

![image](https://user-images.githubusercontent.com/11307908/28559023-b2298b80-714f-11e7-8ef7-741ef6681e66.png)


# after
it does not encode `src` of `img`.
![image](https://user-images.githubusercontent.com/11307908/28558977-763e2770-714f-11e7-8f61-ff3e4aa86422.png)
