### PR TITLE
Make image path relative

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -192,8 +192,8 @@ export default class CodeEditor extends React.Component {
     const imagePath = e.dataTransfer.files[0].path
     const filename = path.basename(imagePath)
 
-    copyImage(imagePath, this.props.storageKey).then((imagePathInTheStorage) => {
-      const imageMd = `![${filename}](${imagePathInTheStorage})`
+    copyImage(imagePath, this.props.storageKey).then((imagePath) => {
+      const imageMd = `![${filename}](${path.join('/:storage', imagePath)})`
       this.insertImageMd(imageMd)
     })
   }

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -4,6 +4,7 @@ import styles from './MarkdownEditor.styl'
 import CodeEditor from 'browser/components/CodeEditor'
 import MarkdownPreview from 'browser/components/MarkdownPreview'
 import eventEmitter from 'browser/main/lib/eventEmitter'
+const _ = require('lodash')
 
 class MarkdownEditor extends React.Component {
   constructor (props) {
@@ -213,6 +214,11 @@ class MarkdownEditor extends React.Component {
     let previewStyle = {}
     if (this.props.ignorePreviewPointerEvents) previewStyle.pointerEvents = 'none'
 
+    const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
+    if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
+    const storage = _.find(cachedStorageList, {key: storageKey})
+    if (storage === undefined) throw new Error('Target storage doesn\'t exist.')
+
     return (
       <div className={className == null
           ? 'MarkdownEditor'
@@ -260,6 +266,7 @@ class MarkdownEditor extends React.Component {
           onMouseUp={(e) => this.handlePreviewMouseUp(e)}
           onMouseDown={(e) => this.handlePreviewMouseDown(e)}
           onCheckboxClick={(e) => this.handleCheckboxClick(e)}
+          storagePath={storage.path}
         />
       </div>
     )

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -255,7 +255,7 @@ export default class MarkdownPreview extends React.Component {
       el.removeEventListener('click', this.linkClickHandler)
     })
 
-    let { value, theme, indentSize, codeBlockTheme } = this.props
+    let { value, theme, indentSize, codeBlockTheme, storagePath } = this.props
 
     this.refs.root.contentWindow.document.body.setAttribute('data-theme', theme)
 
@@ -281,6 +281,11 @@ export default class MarkdownPreview extends React.Component {
 
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('a'), (el) => {
       el.addEventListener('click', this.linkClickHandler)
+    })
+
+    _.forEach(this.refs.root.contentWindow.document.querySelectorAll('img'), (el) => {
+      if (!/\/:storage/.test(el.src)) return
+      el.src = el.src.replace('/:storage', path.join(storagePath, 'images'))
     })
 
     codeBlockTheme = consts.THEMES.some((_theme) => _theme === codeBlockTheme)
@@ -412,5 +417,6 @@ MarkdownPreview.propTypes = {
   onMouseUp: PropTypes.func,
   onMouseDown: PropTypes.func,
   className: PropTypes.string,
-  value: PropTypes.string
+  value: PropTypes.string,
+  storagePath: PropTypes.string
 }

--- a/browser/finder/NoteDetail.js
+++ b/browser/finder/NoteDetail.js
@@ -106,6 +106,11 @@ class NoteDetail extends React.Component {
     let editorIndentSize = parseInt(config.editor.indentSize, 10)
     if (!(editorFontSize > 0 && editorFontSize < 132)) editorIndentSize = 4
 
+    const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
+    if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
+    const storage = _.find(cachedStorageList, {key: note.storage})
+    if (storage === undefined) throw new Error('Target storage doesn\'t exist.')
+
     if (note.type === 'SNIPPET_NOTE') {
       let tabList = note.snippets.map((snippet, index) => {
         let isActive = this.state.snippetIndex === index
@@ -192,6 +197,7 @@ class NoteDetail extends React.Component {
         lineNumber={config.preview.lineNumber}
         indentSize={editorIndentSize}
         value={note.content}
+        storagePath={storage.path}
       />
     )
   }

--- a/browser/main/lib/dataApi/copyImage.js
+++ b/browser/main/lib/dataApi/copyImage.js
@@ -26,7 +26,7 @@ function copyImage (filePath, storageKey) {
       if (!fs.existsSync(imageDir)) fs.mkdirSync(imageDir)
       const outputImage = fs.createWriteStream(path.join(imageDir, basename))
       inputImage.pipe(outputImage)
-      resolve(`${targetStorage.path}/images/${basename}`)
+      resolve(basename)
     } catch (e) {
       return reject(e)
     }


### PR DESCRIPTION
# context
I made the path of a dropped image relative.

# before
The path of a dropped images was an absolute path such as `/Users/asmsuechan/Boostnote/images/aaaaaaaaaaaa.png`.

# after
`/:storage/aaaaaaaaaaaaaa.png` works now.

![00be270d78ed9b3632159f76e8f8fcc2](https://user-images.githubusercontent.com/11307908/28604301-9d9ad844-7204-11e7-9b28-c37648773f12.gif)
