### PR TITLE
Make it work on windows

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -285,7 +285,7 @@ export default class MarkdownPreview extends React.Component {
 
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('img'), (el) => {
       if (!/\/:storage/.test(el.src)) return
-      el.src = el.src.replace('/:storage', path.join(storagePath, 'images'))
+      el.src = `file:///${path.join(storagePath, 'images', path.basename(el.src))}`
     })
 
     codeBlockTheme = consts.THEMES.some((_theme) => _theme === codeBlockTheme)


### PR DESCRIPTION
# context
An image path doesn't work on windows.

# before
`file:///C:/Users/kazup/src/Boostnote/libC:\Users\kazup\Boostnote\images/zfod0c0fcw1rwwmi.png`

![image](https://user-images.githubusercontent.com/11307908/28608126-187f0552-721a-11e7-9102-c8babc05f5e3.png)

# after
![image](https://user-images.githubusercontent.com/11307908/28608155-38d20354-721a-11e7-8eff-afa498e0a1f2.png)
