### PR TITLE
Change order for AMA event

### DIFF
--- a/browser/main/modals/PreferencesModal/InfoTab.js
+++ b/browser/main/modals/PreferencesModal/InfoTab.js
@@ -34,15 +34,16 @@ class InfoTab extends React.Component {
       amaEnabled: this.state.config.amaEnabled
     }
 
+    if (!newConfig.amaEnabled) {
+      AwsMobileAnalyticsConfig.recordDynamicCustomEvent('DISABLE_AMA')
+    }
+
     ConfigManager.set(newConfig)
 
     store.dispatch({
       type: 'SET_CONFIG',
       config: newConfig
     })
-    if (!newConfig.amaEnabled) {
-      AwsMobileAnalyticsConfig.recordDynamicCustomEvent('DISABLE_AMA')
-    }
   }
 
   render () {


### PR DESCRIPTION
# context
Application tried to send the events after ama turned off thus I could not see them properly.

# before
I could not see the event (`DISABLE_AMA`) in aws console.

# after
I'll see it.