### PR TITLE
Add Print

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -108,6 +108,7 @@ export default class MarkdownPreview extends React.Component {
     this.checkboxClickHandler = (e) => this.handleCheckboxClick(e)
     this.saveAsTextHandler = () => this.handleSaveAsText()
     this.saveAsMdHandler = () => this.handleSaveAsMd()
+    this.printHandler = () => this.handlePrint()
 
     this.linkClickHandler = this.handlelinkClick.bind(this)
   }
@@ -162,6 +163,10 @@ export default class MarkdownPreview extends React.Component {
     this.exportAsDocument('md')
   }
 
+  handlePrint () {
+    this.refs.root.contentWindow.print()
+  }
+
   exportAsDocument (fileType) {
     const options = {
       filters: [
@@ -198,6 +203,7 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.addEventListener('dragover', this.preventImageDroppedHandler)
     eventEmitter.on('export:save-text', this.saveAsTextHandler)
     eventEmitter.on('export:save-md', this.saveAsMdHandler)
+    eventEmitter.on('print', this.printHandler)
   }
 
   componentWillUnmount () {
@@ -208,6 +214,7 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.removeEventListener('dragover', this.preventImageDroppedHandler)
     eventEmitter.off('export:save-text', this.saveAsTextHandler)
     eventEmitter.off('export:save-md', this.saveAsMdHandler)
+    eventEmitter.off('print', this.printHandler)
   }
 
   componentDidUpdate (prevProps) {

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -107,6 +107,17 @@ const file = {
       type: 'separator'
     },
     {
+      label: 'Print',
+      accelerator: 'CommandOrControl+P',
+      click () {
+        mainWindow.webContents.send('list:isMarkdownNote')
+        mainWindow.webContents.send('print')
+      }
+    },
+    {
+      type: 'separator'
+    },
+    {
       label: 'Delete Note',
       accelerator: macOS ? 'Control+Backspace' : 'Control+Delete',
       click () {


### PR DESCRIPTION
# context
It's easy to export as pdf.

# before
There was no print feature.

# after
![c17f20c6d07a1f126d35d9887b6b4a76](https://user-images.githubusercontent.com/11307908/28821469-80cdef58-76f0-11e7-9eaf-dddea71d3e84.gif)

# note
You can export as pdf through this.