### PR TITLE
Fix noteCount on a note trased

### DIFF
--- a/browser/main/SideNav/StorageItem.js
+++ b/browser/main/SideNav/StorageItem.js
@@ -180,14 +180,20 @@ class StorageItem extends React.Component {
 
   render () {
     let { storage, location, isFolded, data, dispatch } = this.props
-    let { folderNoteMap } = data
+    let { folderNoteMap, trashedSet } = data
     let folderList = storage.folders.map((folder) => {
       let isActive = !!(location.pathname.match(new RegExp('\/storages\/' + storage.key + '\/folders\/' + folder.key)))
       let noteSet = folderNoteMap.get(storage.key + '-' + folder.key)
 
-      let noteCount = noteSet != null
-        ? noteSet.size
-        : 0
+      let noteCount = 0
+      if (noteSet) {
+        let trashedNoteCount = 0
+        const noteKeys = noteSet.map(noteKey => { return noteKey })
+        noteKeys.forEach(noteKey => {
+          if (trashedSet.toJS().some(trashedKey => { return noteKey === trashedKey })) trashedNoteCount++
+        })
+        noteCount = noteSet.size - trashedNoteCount
+      }
       return (
         <StorageItemChild
           key={folder.key}

--- a/browser/main/SideNav/StorageItem.js
+++ b/browser/main/SideNav/StorageItem.js
@@ -189,8 +189,8 @@ class StorageItem extends React.Component {
       if (noteSet) {
         let trashedNoteCount = 0
         const noteKeys = noteSet.map(noteKey => { return noteKey })
-        noteKeys.forEach(noteKey => {
-          if (trashedSet.toJS().some(trashedKey => { return noteKey === trashedKey })) trashedNoteCount++
+        trashedSet.toJS().forEach(trashedKey => {
+          if (noteKeys.some(noteKey => { return noteKey === trashedKey })) trashedNoteCount++
         })
         noteCount = noteSet.size - trashedNoteCount
       }


### PR DESCRIPTION
# context
This is an improvement of `Trash`.

# before
A note counter didn't decrement when the note was trashed.

# after
It works.
![c1a8eabbc5f775dea412f01636150ad9](https://user-images.githubusercontent.com/11307908/28994138-f20c0b46-7a01-11e7-8c75-415fcb924b92.gif)

# ref
https://github.com/BoostIO/Boostnote/issues/757

# note
I assume this logic is not a better way.