### PR TITLE
iss #758 Add InfoButton and InfoPanel in Trash

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -297,6 +297,18 @@ class MarkdownNoteDetail extends React.Component {
       </div>
       <div styleName='info-right'>
         <TrashButton onClick={(e) => this.handleTrashButtonClick(e)} />
+        <InfoButton
+          onClick={(e) => this.handleInfoButtonClick(e)}
+        />
+        <InfoPanel
+          storageName={currentOption.storage.name}
+          folderName={currentOption.folder.name}
+          noteLink={`[${note.title}](${location.query.key})`}
+          updatedAt={formatDate(note.updatedAt)}
+          createdAt={formatDate(note.createdAt)}
+          exportAsMd={this.exportAsMd}
+          exportAsTxt={this.exportAsTxt}
+        />
       </div>
     </div>
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -556,6 +556,18 @@ class SnippetNoteDetail extends React.Component {
       </div>
       <div styleName='info-right'>
         <TrashButton onClick={(e) => this.handleTrashButtonClick(e)} />
+        <InfoButton
+          onClick={(e) => this.handleInfoButtonClick(e)}
+        />
+        <InfoPanel
+          storageName={currentOption.storage.name}
+          folderName={currentOption.folder.name}
+          noteLink={`[${note.title}](${location.query.key})`}
+          updatedAt={formatDate(note.updatedAt)}
+          createdAt={formatDate(note.createdAt)}
+          exportAsMd={this.showWarning}
+          exportAsTxt={this.showWarning}
+        />
       </div>
     </div>
 


### PR DESCRIPTION
# context
It's difficult to know where the origin folder of a note is.

# before
No InfoButton
![image](https://user-images.githubusercontent.com/11307908/28994241-0f20060e-7a04-11e7-82ef-760421be44bc.png)

# after
![image](https://user-images.githubusercontent.com/11307908/28994245-2890ad8c-7a04-11e7-9bbb-9ac209cba224.png)


# ref
https://github.com/BoostIO/Boostnote/issues/758