### PR TITLE
add todo percentage in item list

### DIFF
--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react'
 import { isArray } from 'lodash'
 import CSSModules from 'browser/lib/CSSModules'
-import { getTodoState } from 'browser/lib/getTodoState'
+import { getTodoStatus } from 'browser/lib/getTodoStatus'
 import styles from './NoteItem.styl'
 import TodoProcess from './TodoProcess'
 
@@ -79,7 +79,7 @@ const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleDragStar
         </div>
       </div>
       {note.type === 'MARKDOWN_NOTE'
-        ? <TodoProcess todoState={getTodoState(note.content)} />
+        ? <TodoProcess todoStatus={getTodoStatus(note.content)} />
         : ''
       }
     </div>

--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -4,7 +4,9 @@
 import React, { PropTypes } from 'react'
 import { isArray } from 'lodash'
 import CSSModules from 'browser/lib/CSSModules'
+import { getTodoState } from 'browser/lib/getTodoState'
 import styles from './NoteItem.styl'
+import TodoProcess from './TodoProcess'
 
 /**
  * @description Tag element component.
@@ -76,6 +78,10 @@ const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleDragStar
           }
         </div>
       </div>
+      {note.type === 'MARKDOWN_NOTE'
+        ? <TodoProcess todoState={getTodoState(note.content)} />
+        : ''
+      }
     </div>
   </div>
 )

--- a/browser/components/NoteItem.styl
+++ b/browser/components/NoteItem.styl
@@ -39,6 +39,7 @@ $control-height = 30px
 .item-wrapper
   padding 15px 0
   border-bottom $ui-border
+  position relative
 
 .item--active
   @extend .item

--- a/browser/components/NoteItemSimple.styl
+++ b/browser/components/NoteItemSimple.styl
@@ -48,6 +48,7 @@ $control-height = 30px
   overflow ellipsis
   color $ui-inactive-text-color
   border-bottom $ui-border
+  position relative
 
 .item-simple-title-icon
   font-size 12px

--- a/browser/components/TodoProcess.js
+++ b/browser/components/TodoProcess.js
@@ -7,7 +7,7 @@ import CSSModules from 'browser/lib/CSSModules'
 import styles from './TodoProcess.styl'
 
 const TodoProcess = ({
-  todoState: {
+  todoStatus: {
     total: totalTodo,
     completed: completedTodo
   }
@@ -24,7 +24,7 @@ const TodoProcess = ({
 )
 
 TodoProcess.propTypes = {
-  todoState: {
+  todoStatus: {
     total: PropTypes.number.isRequired,
     completed: PropTypes.number.isRequired
   }

--- a/browser/components/TodoProcess.js
+++ b/browser/components/TodoProcess.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Percentage of todo achievement.
+ */
+
+import React, { PropTypes } from 'react'
+import CSSModules from 'browser/lib/CSSModules'
+import styles from './TodoProcess.styl'
+
+const TodoProcess = ({
+  todoState: {
+    total: totalTodo,
+    completed: completedTodo
+  }
+}) => (
+  <div styleName='todo-process' style={{display: totalTodo > 0 ? '' : 'none'}}>
+    <div styleName='todo-process-text'>
+      <i className='fa fa-fw fa-tasks' />
+      {completedTodo} of {totalTodo}
+    </div>
+    <div styleName='todo-process-bar'>
+      <div styleName='todo-process-bar--inner' style={{width: parseInt(completedTodo / totalTodo * 100) + '%'}} />
+    </div>
+  </div>
+)
+
+TodoProcess.propTypes = {
+  todoState: {
+    total: PropTypes.number.isRequired,
+    completed: PropTypes.number.isRequired
+  }
+}
+
+export default CSSModules(TodoProcess, styles)

--- a/browser/components/TodoProcess.styl
+++ b/browser/components/TodoProcess.styl
@@ -1,0 +1,35 @@
+.todo-process
+  font-size 12px
+  display flex
+
+.todo-process-text
+  display inline-block
+  padding-right 10px
+  white-space nowrap
+  text-overflow ellipsis
+  i
+    color grey
+    padding-right 5px
+
+.todo-process-bar
+  display inline-block
+  margin auto
+  width 150px
+  height 5px
+  background-color #DADFE1
+  border-radius 2px
+  flex-grow 1
+
+.todo-process-bar--inner
+  height 100%
+  background-color #6C7A89
+
+
+body[data-theme="dark"]
+  .todo-process
+    color $ui-dark-text-color
+  .todo-process-bar
+    background-color #363A3D
+
+  .todo-process-bar--inner
+    background-color: alpha(#939395, 50%)

--- a/browser/components/TodoProcess.styl
+++ b/browser/components/TodoProcess.styl
@@ -23,6 +23,7 @@
 .todo-process-bar--inner
   height 100%
   background-color #6C7A89
+  transition 0.3s
 
 
 body[data-theme="dark"]

--- a/browser/lib/getTodoState.js
+++ b/browser/lib/getTodoState.js
@@ -1,0 +1,25 @@
+export function getTodoState (content) {
+  let splitted = content.split('\n')
+  let numberOfTodo = 0
+  let numberOfCompletedTodo = 0
+
+  splitted.forEach((line) => {
+    let trimmedLine = line.trim()
+    if (trimmedLine.match(/^[\+\-\*] \[\s|x\] ./)) {
+      numberOfTodo++
+    }
+    if (trimmedLine.match(/^[\+\-\*] \[x\] ./)) {
+      numberOfCompletedTodo++
+    }
+  })
+
+  return {
+    total: numberOfTodo,
+    completed: numberOfCompletedTodo
+  }
+}
+
+export function getTodoPercentageOfCompleted (content) {
+  const state = getTodoState(content)
+  return Math.floor(state.completed / state.total * 100)
+}

--- a/browser/lib/getTodoStatus.js
+++ b/browser/lib/getTodoStatus.js
@@ -1,4 +1,4 @@
-export function getTodoState (content) {
+export function getTodoStatus (content) {
   let splitted = content.split('\n')
   let numberOfTodo = 0
   let numberOfCompletedTodo = 0
@@ -20,6 +20,6 @@ export function getTodoState (content) {
 }
 
 export function getTodoPercentageOfCompleted (content) {
-  const state = getTodoState(content)
+  const state = getTodoStatus(content)
   return Math.floor(state.completed / state.total * 100)
 }

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -18,7 +18,7 @@ import TrashButton from './TrashButton'
 import InfoButton from './InfoButton'
 import InfoPanel from './InfoPanel'
 import { formatDate } from 'browser/lib/date-formatter'
-import { getTodoPercentageOfCompleted } from 'browser/lib/getTodoState'
+import { getTodoPercentageOfCompleted } from 'browser/lib/getTodoStatus'
 
 const electron = require('electron')
 const { remote } = electron

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -18,6 +18,7 @@ import TrashButton from './TrashButton'
 import InfoButton from './InfoButton'
 import InfoPanel from './InfoPanel'
 import { formatDate } from 'browser/lib/date-formatter'
+import { getTodoPercentageOfCompleted } from 'browser/lib/getTodoState'
 
 const electron = require('electron')
 const { remote } = electron
@@ -67,24 +68,6 @@ class MarkdownNoteDetail extends React.Component {
 
   componentDidUnmount () {
     ee.off('topbar:togglelockbutton', this.toggleLockButton)
-  }
-
-  getPercentageOfCompleteTodo (noteContent) {
-    let splitted = noteContent.split('\n')
-    let numberOfTodo = 0
-    let numberOfCompletedTodo = 0
-
-    splitted.forEach((line) => {
-      let trimmedLine = line.trim()
-      if (trimmedLine.match(/^[\+\-\*] \[\s|x\] ./)) {
-        numberOfTodo++
-      }
-      if (trimmedLine.match(/^[\+\-\*] \[x\] ./)) {
-        numberOfCompletedTodo++
-      }
-    })
-
-    return Math.floor(numberOfCompletedTodo / numberOfTodo * 100)
   }
 
   handleChange (e) {
@@ -321,7 +304,7 @@ class MarkdownNoteDetail extends React.Component {
           onChange={(e) => this.handleChange(e)}
         />
         <TodoListPercentage
-          percentageOfTodo={this.getPercentageOfCompleteTodo(note.content)}
+          percentageOfTodo={getTodoPercentageOfCompleted(note.content)}
         />
       </div>
       <div styleName='info-right'>


### PR DESCRIPTION
#750 

And I implement it like github todo list.

Before:
![qq20170810-123435](https://user-images.githubusercontent.com/9291212/29154656-8a31e408-7dc8-11e7-87e9-843eb0dad88f.png)

After:
![qq20170810-123357](https://user-images.githubusercontent.com/9291212/29154660-91b1d846-7dc8-11e7-960a-5408521a4845.png)
![qq20170810-123338](https://user-images.githubusercontent.com/9291212/29154662-9208f496-7dc8-11e7-9062-46179acdf1e5.png)

Color as same as TodoListPercentage.
Todo style is like github todo style. And todo list doesn't show in folded mode.

Added:
* browser/lib/getTodoState.js get percentage of complete todo helper function
* browser/compoents/TodoProcess.{js/styl} 