### PR TITLE
Finder UI Fix (My Storage positioning)

### DIFF
--- a/browser/finder/FinderMain.styl
+++ b/browser/finder/FinderMain.styl
@@ -64,7 +64,7 @@ $list-width = 250px
 
 .result-nav-storageList
   absolute bottom left right
-  top 80px + 32px + 10px + 10px
+  top 110px + 32px + 10px + 10px
   overflow-y auto
 
 .result-list


### PR DESCRIPTION
Fixes the positioning of the My Storage section for the Finder, so that it is no longer shown over the top of the Trash.

Fixes: #761 

Before Fix:

![screen shot 2017-08-09 at 12 24 04](https://user-images.githubusercontent.com/6931281/29119789-6e40245e-7cff-11e7-83c0-ff199293408b.png)

After Fix:

![screen shot 2017-08-09 at 12 24 39](https://user-images.githubusercontent.com/6931281/29119797-72d9955e-7cff-11e7-8cd6-68a3ad3d140a.png)
