### PR TITLE
Add Lato font-face definition to main.html

### DIFF
--- a/lib/main.html
+++ b/lib/main.html
@@ -20,6 +20,15 @@
     font-weight: normal;
     text-rendering: optimizeLegibility;
   }
+  @font-face {
+    font-family: 'Lato';
+    src: url('../resources/fonts/Lato-Regular.woff2') format('woff2'), /* Modern Browsers */
+         url('../resources/fonts/Lato-Regular.woff') format('woff'), /* Modern Browsers */
+         url('../resources/fonts/Lato-Regular.ttf') format('truetype');
+    font-style: normal;
+    font-weight: normal;
+    text-rendering: optimizeLegibility;
+  }
   #loadingCover{
     background-color: #f4f4f4;
     position: absolute;


### PR DESCRIPTION
Lato is the default "Preview font family" font. However, in the case that Lato is not installed on the user's system, it falls back to using a different font instead of using the font included with the application.

This means in some cases, such as for the Snippet Note description the wrong font is displayed. Defining Lato as a font-face in main.html fixes this issue.

Before Fix:
![screen shot 2017-08-09 at 14 34 56](https://user-images.githubusercontent.com/6931281/29124604-46ab2cce-7d11-11e7-9e65-8df3c3b00f23.png)

After Fix:
![screen shot 2017-08-09 at 14 36 13](https://user-images.githubusercontent.com/6931281/29124615-4c7d0834-7d11-11e7-9527-091b279ce378.png)

