### PR TITLE
Add storageKey to MarkdownEditor

### DIFF
--- a/browser/finder/NoteDetail.js
+++ b/browser/finder/NoteDetail.js
@@ -146,6 +146,7 @@ class NoteDetail extends React.Component {
               config={config}
               value={snippet.content}
               ref={'code-' + index}
+              storageKey={note.storage}
             />
             : <CodeEditor styleName='tabView-content'
               mode={snippet.mode}

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -519,6 +519,7 @@ class SnippetNoteDetail extends React.Component {
             onChange={(e) => this.handleCodeChange(index)(e)}
             ref={'code-' + index}
             ignorePreviewPointerEvents={this.props.ignorePreviewPointerEvents}
+            storageKey={storageKey}
           />
           : <CodeEditor styleName='tabView-content'
             mode={snippet.mode}


### PR DESCRIPTION
# context
If there's any snippet of which type is `Markdown`, the notes fail to load.

# before
`Uncaught Error: Target storage doesn't exist.` happened.
![image](https://user-images.githubusercontent.com/11307908/29125749-8910b3f4-7d57-11e7-8a09-fe13a31c2618.png)

# after
![a411174e02d1174dc0a7e50ea9d81947](https://user-images.githubusercontent.com/11307908/29125754-8b293454-7d57-11e7-805c-e6b516ceda35.gif)

# note
I'm still not sure this will fix https://github.com/BoostIO/Boostnote/issues/742.