### PR TITLE
Add boostnoterc revival

### DIFF
--- a/.boostnoterc.sample
+++ b/.boostnoterc.sample
@@ -1,0 +1,32 @@
+{
+    "editor": {
+        "fontFamily": "Monaco, Consolas",
+        "fontSize": "14",
+        "indentSize": "2",
+        "indentType": "space",
+        "keyMap": "vim",
+        "switchPreview": "BLUR",
+        "theme": "monokai"
+    },
+    "hotkey": {
+        "toggleFinder": "Cmd + Alt + S",
+        "toggleMain": "Cmd + Alt + L"
+    },
+    "isSideNavFolded": false,
+    "listStyle": "DEFAULT",
+    "listWidth": 174,
+    "navWidth": 200,
+    "preview": {
+        "codeBlockTheme": "dracula",
+        "fontFamily": "Lato",
+        "fontSize": "14",
+        "lineNumber": true,
+    },
+    "sortBy": "UPDATED_AT",
+    "ui": {
+        "defaultNote": "ALWAYS_ASK",
+        "disableDirectWrite": false,
+        "theme": "default"
+    },
+    "zoom": 1
+}

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -15,8 +15,6 @@ import mixpanel from 'browser/main/lib/mixpanel'
 import mobileAnalytics from 'browser/main/lib/AwsMobileAnalyticsConfig'
 import eventEmitter from 'browser/main/lib/eventEmitter'
 
-const BOOSTNOTERC = '.boostnoterc'
-
 function focused () {
   mixpanel.track('MAIN_FOCUSED')
 }

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -14,8 +14,6 @@ import InitModal from 'browser/main/modals/InitModal'
 import mixpanel from 'browser/main/lib/mixpanel'
 import mobileAnalytics from 'browser/main/lib/AwsMobileAnalyticsConfig'
 import eventEmitter from 'browser/main/lib/eventEmitter'
-import RcParser from 'browser/main/lib/RcParser'
-import path from 'path'
 
 const BOOSTNOTERC = '.boostnoterc'
 
@@ -80,10 +78,6 @@ class Main extends React.Component {
 
     eventEmitter.on('editor:fullscreen', this.toggleFullScreen)
     window.addEventListener('focus', focused)
-
-    const homePath = global.process.env.HOME || global.process.env.USERPROFILE
-    const boostnotercPath = path.join(homePath, BOOSTNOTERC)
-    RcParser.exec(boostnotercPath)
   }
 
   componentWillUnmount () {

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -14,6 +14,10 @@ import InitModal from 'browser/main/modals/InitModal'
 import mixpanel from 'browser/main/lib/mixpanel'
 import mobileAnalytics from 'browser/main/lib/AwsMobileAnalyticsConfig'
 import eventEmitter from 'browser/main/lib/eventEmitter'
+import RcParser from 'browser/main/lib/RcParser'
+import path from 'path'
+
+const BOOSTNOTERC = '.boostnoterc'
 
 function focused () {
   mixpanel.track('MAIN_FOCUSED')
@@ -76,6 +80,10 @@ class Main extends React.Component {
 
     eventEmitter.on('editor:fullscreen', this.toggleFullScreen)
     window.addEventListener('focus', focused)
+
+    const homePath = global.process.env.HOME || global.process.env.USERPROFILE
+    const boostnotercPath = path.join(homePath, BOOSTNOTERC)
+    RcParser.exec(boostnotercPath)
   }
 
   componentWillUnmount () {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -71,17 +71,17 @@ function get () {
     config = Object.assign({}, DEFAULT_CONFIG, JSON.parse(config))
 
     if (boostnotercConfig !== undefined) {
+      config = Object.assign({}, DEFAULT_CONFIG, boostnotercConfig)
       config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, boostnotercConfig.hotkey)
       config.ui = Object.assign({}, DEFAULT_CONFIG.ui, boostnotercConfig.ui)
       config.editor = Object.assign({}, DEFAULT_CONFIG.editor, boostnotercConfig.editor)
       config.preview = Object.assign({}, DEFAULT_CONFIG.preview, boostnotercConfig.preview)
     }
 
-    config = Object.assign(config, DEFAULT_CONFIG, config)
-    config.hotkey = Object.assign(config, DEFAULT_CONFIG.hotkey, config.hotkey)
-    config.ui = Object.assign(config, DEFAULT_CONFIG.ui, config.ui)
-    config.editor = Object.assign(config, DEFAULT_CONFIG.editor, config.editor)
-    config.preview = Object.assign(config, DEFAULT_CONFIG.preview, config.preview)
+    config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, config.hotkey)
+    config.ui = Object.assign({}, DEFAULT_CONFIG.ui, config.ui)
+    config.editor = Object.assign({}, DEFAULT_CONFIG.editor, config.editor)
+    config.preview = Object.assign({}, DEFAULT_CONFIG.preview, config.preview)
 
     if (!validate(config)) throw new Error('INVALID CONFIG')
   } catch (err) {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -8,7 +8,6 @@ const { ipcRenderer } = electron
 const consts = require('browser/lib/consts')
 const path = require('path')
 const fs = require('fs')
-const BOOSTNOTERC = '.boostnoterc'
 
 let isInitialized = false
 

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -64,24 +64,12 @@ function get () {
   let config = window.localStorage.getItem('config')
 
   try {
-    const homePath = global.process.env.HOME || global.process.env.USERPROFILE
-    const boostnotercPath = path.join(homePath, BOOSTNOTERC)
-    const boostnotercConfig = RcParser.parse(boostnotercPath)
+    const boostnotercConfig = RcParser.parse()
 
     config = Object.assign({}, DEFAULT_CONFIG, JSON.parse(config))
 
-    if (boostnotercConfig !== undefined) {
-      config = Object.assign({}, DEFAULT_CONFIG, boostnotercConfig)
-      config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, boostnotercConfig.hotkey)
-      config.ui = Object.assign({}, DEFAULT_CONFIG.ui, boostnotercConfig.ui)
-      config.editor = Object.assign({}, DEFAULT_CONFIG.editor, boostnotercConfig.editor)
-      config.preview = Object.assign({}, DEFAULT_CONFIG.preview, boostnotercConfig.preview)
-    }
-
-    config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, config.hotkey)
-    config.ui = Object.assign({}, DEFAULT_CONFIG.ui, config.ui)
-    config.editor = Object.assign({}, DEFAULT_CONFIG.editor, config.editor)
-    config.preview = Object.assign({}, DEFAULT_CONFIG.preview, config.preview)
+    config = Object.assign({}, DEFAULT_CONFIG, boostnotercConfig)
+    config = assignConfigValues(config, boostnotercConfig, config)
 
     if (!validate(config)) throw new Error('INVALID CONFIG')
   } catch (err) {
@@ -142,6 +130,14 @@ function set (updates) {
   ipcRenderer.send('config-renew', {
     config: get()
   })
+}
+
+function assignConfigValues (config, rcConfig, originalConfig) {
+  config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, rcConfig, originalConfig.hotkey)
+  config.ui = Object.assign({}, DEFAULT_CONFIG.ui, rcConfig, originalConfig.ui)
+  config.editor = Object.assign({}, DEFAULT_CONFIG.editor, rcConfig, originalConfig.editor)
+  config.preview = Object.assign({}, DEFAULT_CONFIG.preview, rcConfig, originalConfig.preview)
+  return config
 }
 
 export default {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -133,10 +133,11 @@ function set (updates) {
 }
 
 function assignConfigValues (config, rcConfig, originalConfig) {
-  config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, rcConfig, originalConfig.hotkey)
-  config.ui = Object.assign({}, DEFAULT_CONFIG.ui, rcConfig, originalConfig.ui)
-  config.editor = Object.assign({}, DEFAULT_CONFIG.editor, rcConfig, originalConfig.editor)
-  config.preview = Object.assign({}, DEFAULT_CONFIG.preview, rcConfig, originalConfig.preview)
+  config = Object.assign({}, DEFAULT_CONFIG, rcConfig, originalConfig)
+  config.hotkey = Object.assign({}, DEFAULT_CONFIG.hotkey, rcConfig.hotkey, originalConfig.hotkey)
+  config.ui = Object.assign({}, DEFAULT_CONFIG.ui, rcConfig.ui, originalConfig.ui)
+  config.editor = Object.assign({}, DEFAULT_CONFIG.editor, rcConfig.editor, originalConfig.editor)
+  config.preview = Object.assign({}, DEFAULT_CONFIG.preview, rcConfig.preview, originalConfig.preview)
   return config
 }
 

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 const path = require('path')
 const sander = require('sander')
 
@@ -7,6 +9,15 @@ function parse (boostnotercPath) {
   return config
 }
 
+function exec (boostnotercPath) {
+  const config = this.parse(boostnotercPath)
+  if (config.execs === undefined) return
+  _.forEach(config.execs, (exec) => {
+    eval(exec)
+  })
+}
+
 export default {
-  parse
+  parse,
+  exec
 }

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -14,7 +14,12 @@ function exec (boostnotercPath) {
   const config = this.parse(boostnotercPath)
   if (config.execs === undefined) return
   _.forEach(config.execs, (exec) => {
-    eval(exec)
+    try {
+      eval(exec)
+    } catch (e) {
+      // Ignore any errors in ~/.boostnoterc
+      console.log(e)
+    }
   })
 }
 

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -10,20 +10,6 @@ function parse () {
   return JSON.parse(sander.readFileSync(boostnotercPath).toString())
 }
 
-function exec (boostnotercPath) {
-  const config = this.parse(boostnotercPath)
-  if (config.execs === undefined) return
-  _.forEach(config.execs, (exec) => {
-    try {
-      eval(exec)
-    } catch (e) {
-      // Ignore any errors in ~/.boostnoterc
-      console.log(e)
-    }
-  })
-}
-
 export default {
-  parse,
-  exec
+  parse
 }

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,0 +1,12 @@
+const path = require('path')
+const sander = require('sander')
+
+function parse (boostnotercPath) {
+  if (!sander.existsSync(boostnotercPath)) return
+  let config = JSON.parse(sander.readFileSync(boostnotercPath).toString())
+  return config
+}
+
+export default {
+  parse
+}

--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -1,12 +1,13 @@
-import _ from 'lodash'
+import path from 'path'
+import sander from 'sander'
 
-const path = require('path')
-const sander = require('sander')
+function parse () {
+  const BOOSTNOTERC = '.boostnoterc'
+  const homePath = global.process.env.HOME || global.process.env.USERPROFILE
+  const boostnotercPath = path.join(homePath, BOOSTNOTERC)
 
-function parse (boostnotercPath) {
-  if (!sander.existsSync(boostnotercPath)) return
-  let config = JSON.parse(sander.readFileSync(boostnotercPath).toString())
-  return config
+  if (!sander.existsSync(boostnotercPath)) return {}
+  return JSON.parse(sander.readFileSync(boostnotercPath).toString())
 }
 
 function exec (boostnotercPath) {


### PR DESCRIPTION
# context
I want to manage the configurations of Boostnote in a file.

```
{
  "editor": {
    "keyMap": "vim",
    "theme": "monokai"
  },
  "hotkey": {
    "toggleMain": "Control + L"
  },
  "listWidth": 174,
  "navWidth": 130
}
```

# before

# after
I can put my settings in `~/.boostnoterc`.

# note
It **overwrite** your settings.