### PR TITLE
Make RcParser ignore errors at JSON.parse()

### DIFF
--- a/browser/main/lib/RcParser.js
+++ b/browser/main/lib/RcParser.js
@@ -7,7 +7,13 @@ function parse () {
   const boostnotercPath = path.join(homePath, BOOSTNOTERC)
 
   if (!sander.existsSync(boostnotercPath)) return {}
-  return JSON.parse(sander.readFileSync(boostnotercPath).toString())
+  try {
+    return JSON.parse(sander.readFileSync(boostnotercPath).toString())
+  } catch (e) {
+    console.warn(e)
+    console.warn('Your .boostnoterc is broken so it\'s not used.')
+    return {}
+  }
 }
 
 export default {


### PR DESCRIPTION
# context

# before
The settings turned DEFAULT if `~/.boostntoerc` is invalid json.

# after
The original settings in localStorage will be used even if `~/.boostnoterc` is invalid json.