### PR TITLE
Fix note creation in All Notes

### DIFF
--- a/browser/main/NewNoteButton/index.js
+++ b/browser/main/NewNoteButton/index.js
@@ -58,8 +58,7 @@ class NewNoteButton extends React.Component {
     }
 
     if (storage == null) this.showMessageBox('No storage to create a note')
-    let folder = storage.folders[0]
-    folder = _.find(storage.folders, {key: params.folderKey})
+    const folder = _.find(storage.folders, {key: params.folderKey}) || storage.folders[0]
     if (folder == null) this.showMessageBox('No folder to create a note')
 
     return {


### PR DESCRIPTION
# context
A bug contains in https://github.com/BoostIO/Boostnote/pull/800.

# before
Cannot open the modal for note creation.
![aafdcb68fb384ca612232fe8a8aa356a](https://user-images.githubusercontent.com/11307908/29298375-24cde2e6-81a2-11e7-8737-32501d30cc89.gif)

# after
![18aa0e391f12c0b1bc3e373662dedbc5](https://user-images.githubusercontent.com/11307908/29298382-29fd9b3a-81a2-11e7-902c-83f5c384126a.gif)

# for tests
* Open the note-creation modal in `All Notes`

# ref
https://github.com/BoostIO/Boostnote/pull/800