### PR TITLE
Fix typo regarding fullscreen

### DIFF
--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -172,8 +172,8 @@ class Main extends React.Component {
   }
 
   hideLeftLists (noteDetail, noteList, mainBody) {
-    this.setState({noteDetail: noteDetail.style.left})
-    this.setState({mainBody: mainBody.style.left})
+    this.setState({noteDetailWidth: noteDetail.style.left})
+    this.setState({mainBodyWidth: mainBody.style.left})
     noteDetail.style.left = '0px'
     mainBody.style.left = '0px'
     noteList.style.display = 'none'


### PR DESCRIPTION
# context
The fullscreen button cannot show left columns once they're hidden.

# before
![8b0f9cb5aa8e257f85abf7805197fe3a](https://user-images.githubusercontent.com/11307908/29314176-dd5aadb2-81f7-11e7-9845-069da4429b7a.gif)

# after
It works fine. I clicked the infobutton but it was a mistake.
![37fa13e011f75e6de969e3164cb13ce3](https://user-images.githubusercontent.com/11307908/29314184-e27950e6-81f7-11e7-9572-acd989cfb6b3.gif)

# ref
https://github.com/BoostIO/Boostnote/pull/802