### PR TITLE
Support for extended table markdown syntax

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -59,6 +59,7 @@ md.use(math, {
 })
 md.use(require('markdown-it-imsize'))
 md.use(require('markdown-it-footnote'))
+md.use(require('markdown-it-multimd-table'))
 // Override task item
 md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
   let content, terminate, i, l, token

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "markdown-it-emoji": "^1.1.1",
     "markdown-it-footnote": "^3.0.0",
     "markdown-it-imsize": "^2.0.1",
+    "markdown-it-multimd-table": "^2.0.1",
     "md5": "^2.0.0",
     "mixpanel": "^0.4.1",
     "moment": "^2.10.3",


### PR DESCRIPTION
Related to the issue #778 I posed.
I've written a markdown-it plugin for that, and here below is the demo:
![demo](https://user-images.githubusercontent.com/11537681/29444743-a150a294-8414-11e7-9f60-5658e77a2e2c.png)
