### PR TITLE
Add markdown-it-named-headers and adjust to use Japanese or Chinese

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -60,6 +60,14 @@ md.use(math, {
 md.use(require('markdown-it-imsize'))
 md.use(require('markdown-it-footnote'))
 md.use(require('markdown-it-multimd-table'))
+md.use(require('markdown-it-named-headers'), {
+  slugify: (header) => {
+    return encodeURI(header.trim()
+      .replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~]/g, '')
+      .replace(/\s+/g, '-'))
+      .replace(/\-+$/, '')
+  }
+})
 // Override task item
 md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
   let content, terminate, i, l, token

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "markdown-it-footnote": "^3.0.0",
     "markdown-it-imsize": "^2.0.1",
     "markdown-it-multimd-table": "^2.0.1",
+    "markdown-it-named-headers": "^0.0.4",
     "md5": "^2.0.0",
     "mixpanel": "^0.4.1",
     "moment": "^2.10.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,7 +132,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.7:
+argparse@^1.0.7, argparse@~1.0.3:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
   dependencies:
@@ -3866,7 +3866,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-linkify-it@~1.2.2:
+linkify-it@~1.2.0, linkify-it@~1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-1.2.4.tgz#0773526c317c8fd13bd534ee1d180ff88abf881a"
   dependencies:
@@ -4020,6 +4020,28 @@ markdown-it-footnote@^3.0.0:
 markdown-it-imsize:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz#cca0427905d05338a247cb9ca9d968c5cddd5170"
+
+markdown-it-multimd-table@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-multimd-table/-/markdown-it-multimd-table-2.0.1.tgz#2e246dc2ec4ca093cbf05d43c9c1cc64e31f255d"
+  dependencies:
+    markdown-it "^5.0.3"
+
+markdown-it-named-headers@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz#82efc28324240a6b1e77b9aae501771d5f351c1f"
+  dependencies:
+    string "^3.0.1"
+
+markdown-it@^5.0.3:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-5.1.0.tgz#25286b8465bac496f3f1b77eed544643e9bd718d"
+  dependencies:
+    argparse "~1.0.3"
+    entities "~1.1.1"
+    linkify-it "~1.2.0"
+    mdurl "~1.0.1"
+    uc.micro "^1.0.0"
 
 markdown-it@^6.0.1:
   version "6.1.1"
@@ -5987,6 +6009,10 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
+string@^3.0.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
+
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -6345,7 +6371,7 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uc.micro@^1.0.1:
+uc.micro@^1.0.0, uc.micro@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 


### PR DESCRIPTION
# context
I added markdown-it-named-headers for jumping by a header.

USAGE:

```
# TOP
[Hello](#Hello)
[Hello World](#Hello-World)

## Hello
print('hello')
[TOP](#TOP)

## Hello World
print('hello world')
[TOP](#TOP)
```

# before
User cannot jump headers.

# after
![989127607c990844a0aa51e7a6f2cd13](https://user-images.githubusercontent.com/11307908/29446721-a87ab5a0-8428-11e7-9a59-a9311a6fc73d.gif)

Also, Japanese and Chinese are supported.

![461d9aa15c77f84fdf6c0de71bac0e13](https://user-images.githubusercontent.com/11307908/29446726-b6832c22-8428-11e7-864c-8538ba7da245.gif)
