### PR TITLE
iss #809 normalize text works only in img tag

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -291,8 +291,9 @@ export default class MarkdownPreview extends React.Component {
     })
 
     _.forEach(this.refs.root.contentWindow.document.querySelectorAll('img'), (el) => {
+      el.src = markdown.normalizeLinkText(el.src)
       if (!/\/:storage/.test(el.src)) return
-      el.src = `file:///${path.join(storagePath, 'images', path.basename(el.src))}`
+      el.src = `file:///${markdown.normalizeLinkText(path.join(storagePath, 'images', path.basename(el.src)))}`
     })
 
     codeBlockTheme = consts.THEMES.some((_theme) => _theme === codeBlockTheme)

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -165,12 +165,17 @@ function strip (input) {
   return output
 }
 
+function normalizeLinkText (linkText) {
+  return md.normalizeLinkText(linkText)
+}
+
 const markdown = {
   render: function markdown (content) {
     if (!_.isString(content)) content = ''
     const renderedContent = md.render(content)
-    return md.normalizeLinkText(renderedContent)
+    return renderedContent
   },
-  strip
+  strip,
+  normalizeLinkText
 }
 export default markdown


### PR DESCRIPTION
# context
I change `normalizeTextLink`works in only img tags.

# before
The entities encoded even if they're not links.

```
%A0
%AB
```

![image](https://user-images.githubusercontent.com/11307908/29481804-b42e9c20-84c0-11e7-8c5c-921e35cf0648.png)

ref: https://github.com/BoostIO/Boostnote/issues/809

# after
```
%00
%AA

![img](C:\Users\asmsuechan\images\aaaa.png)
```

![image](https://user-images.githubusercontent.com/11307908/29481852-5903f484-84c1-11e7-90c6-e51f519d0d4d.png)

# For tests
* An image link is inserted properly on windows
* `%AA` is rendered as `%AA` not `�`

# refs
https://github.com/BoostIO/Boostnote/pull/728
https://github.com/BoostIO/Boostnote/issues/809