### PR TITLE
Fix image insesration problem

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -201,7 +201,7 @@ export default class CodeEditor extends React.Component {
   insertImageMd (imageMd) {
     const textarea = this.editor.getInputField()
     const cm = this.editor
-    textarea.value = `${textarea.value.substr(0, textarea.selectionStart)}${imageMd}${textarea.value.substr(textarea.selectionEnd)}`
+    cm.replaceSelection(`${textarea.value.substr(0, textarea.selectionStart)}${imageMd}${textarea.value.substr(textarea.selectionEnd)}`)
   }
 
   render () {


### PR DESCRIPTION
# context
Use a function of CodeMirror instead of dom function

# environment
Ubuntu 16.04 LTS

# before
The image link is not inserted on ubuntu

# after
It succeeded.
![out4](https://user-images.githubusercontent.com/11307908/29490990-9064722e-8588-11e7-9360-d4f92ffdeead.gif)


# For tests
* work on windows/mac
* insert appropriate position
