### PR TITLE
Change timing of ama editnote

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -94,7 +94,7 @@ class MarkdownNoteDetail extends React.Component {
 
     this.sendEventQueue = setTimeout(() => {
       this.sendEditnoteEvent()
-    }, 3000)
+    }, 30000)
 
     this.saveQueue = setTimeout(() => {
       this.saveNow()

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -54,6 +54,7 @@ class MarkdownNoteDetail extends React.Component {
   componentWillReceiveProps (nextProps) {
     if (nextProps.note.key !== this.props.note.key && !this.isMovingNote) {
       if (this.saveQueue != null) this.saveNow()
+      if (this.sendEventQueue != null) this.sendEditnoteEvent()
       this.setState({
         note: Object.assign({}, nextProps.note)
       }, () => {
@@ -65,6 +66,7 @@ class MarkdownNoteDetail extends React.Component {
 
   componentWillUnmount () {
     if (this.saveQueue != null) this.saveNow()
+    if (this.sendEventQueue != null) this.sendEditnoteEvent()
   }
 
   componentDidUnmount () {
@@ -88,6 +90,12 @@ class MarkdownNoteDetail extends React.Component {
 
   save () {
     clearTimeout(this.saveQueue)
+    clearTimeout(this.sendEventQueue)
+
+    this.sendEventQueue = setTimeout(() => {
+      this.sendEditnoteEvent()
+    }, 3000)
+
     this.saveQueue = setTimeout(() => {
       this.saveNow()
     }, 1000)
@@ -106,6 +114,12 @@ class MarkdownNoteDetail extends React.Component {
           note: note
         })
       })
+  }
+
+  sendEditnoteEvent () {
+    clearTimeout(this.saveQueue)
+    this.sendEventQueue = null
+    AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
   }
 
   handleFolderChange (e) {

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -105,7 +105,6 @@ class MarkdownNoteDetail extends React.Component {
           type: 'UPDATE_NOTE',
           note: note
         })
-        AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
       })
   }
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -116,7 +116,6 @@ class SnippetNoteDetail extends React.Component {
           type: 'UPDATE_NOTE',
           note: note
         })
-        AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
       })
   }
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -105,7 +105,7 @@ class SnippetNoteDetail extends React.Component {
 
     this.sendEventQueue = setTimeout(() => {
       this.sendEditnoteEvent()
-    }, 3000)
+    }, 30000)
 
     this.saveQueue = setTimeout(() => {
       this.saveNow()

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -60,6 +60,7 @@ class SnippetNoteDetail extends React.Component {
   componentWillReceiveProps (nextProps) {
     if (nextProps.note.key !== this.props.note.key && !this.isMovingNote) {
       if (this.saveQueue != null) this.saveNow()
+      if (this.sendEventQueue != null) this.sendEditnoteEvent()
       let nextNote = Object.assign({
         description: ''
       }, nextProps.note, {
@@ -80,6 +81,7 @@ class SnippetNoteDetail extends React.Component {
 
   componentWillUnmount () {
     if (this.saveQueue != null) this.saveNow()
+    if (this.sendEventQueue != null) this.sendEditnoteEvent()
   }
 
   handleChange (e) {
@@ -99,6 +101,12 @@ class SnippetNoteDetail extends React.Component {
 
   save () {
     clearTimeout(this.saveQueue)
+    clearTimeout(this.sendEventQueue)
+
+    this.sendEventQueue = setTimeout(() => {
+      this.sendEditnoteEvent()
+    }, 3000)
+
     this.saveQueue = setTimeout(() => {
       this.saveNow()
     }, 1000)
@@ -117,6 +125,12 @@ class SnippetNoteDetail extends React.Component {
           note: note
         })
       })
+  }
+
+  sendEditnoteEvent () {
+    clearTimeout(this.saveQueue)
+    this.sendEventQueue = null
+    AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
   }
 
   handleFolderChange (e) {


### PR DESCRIPTION
Hi!
Boostnote is sending some events by AWS mobile analytics.
Among them is EDIT_NOTE. The timing at which the event is sent is too many.The event transmit in 1 seconds since input stopped.I think that is too many.
I think that we should change the interval that to send its event.
I changed it from 1 seconds to 30 seconds.
