### PR TITLE
add MAIN_FOCUSED event

### DIFF
--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -18,7 +18,7 @@ function initAwsMobileAnalytics () {
   AWS.config.credentials.get((err) => {
     if (!err) {
       console.log('Cognito Identity ID: ' + AWS.config.credentials.identityId)
-      recordDynamicCustomEvent('MAIN_FOCUSED')
+      recordDynamicCustomEvent('APP_STARTED')
       recordStaticCustomEvent()
     }
   })

--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -18,9 +18,10 @@ function initAwsMobileAnalytics () {
   AWS.config.credentials.get((err) => {
     if (!err) {
       console.log('Cognito Identity ID: ' + AWS.config.credentials.identityId)
+      recordDynamicCustomEvent('MAIN_FOCUSED')
+      recordStaticCustomEvent()
     }
   })
-  recordStaticCustomEvent()
 }
 
 function recordDynamicCustomEvent (type) {


### PR DESCRIPTION
When we open Boostnote, send AmazonMobileAnalytics event. its named 'MAIN_FOCUSED'.