### PR TITLE
Strip HTML tags from the note title

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -20,6 +20,7 @@ import InfoPanel from './InfoPanel'
 import InfoPanelTrashed from './InfoPanelTrashed'
 import { formatDate } from 'browser/lib/date-formatter'
 import { getTodoPercentageOfCompleted } from 'browser/lib/getTodoStatus'
+import striptags from 'striptags'
 
 const electron = require('electron')
 const { remote } = electron
@@ -76,7 +77,7 @@ class MarkdownNoteDetail extends React.Component {
 
     note.content = this.refs.content.value
     if (this.refs.tags) note.tags = this.refs.tags.value
-    note.title = markdown.strip(findNoteTitle(note.content))
+    note.title = markdown.strip(striptags(findNoteTitle(note.content)))
     note.updatedAt = new Date()
 
     this.setState({

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -13,6 +13,7 @@ import fs from 'fs'
 import { hashHistory } from 'react-router'
 import markdown from 'browser/lib/markdown'
 import { findNoteTitle } from 'browser/lib/findNoteTitle'
+import stripgtags from 'striptags'
 
 const { remote } = require('electron')
 const { Menu, MenuItem, dialog } = remote
@@ -363,7 +364,7 @@ class NoteList extends React.Component {
           const newNote = {
             content: content,
             folder: folderKey,
-            title: markdown.strip(findNoteTitle(content)),
+            title: markdown.strip(striptags(findNoteTitle(content))),
             type: 'MARKDOWN_NOTE'
           }
           dataApi.createNote(storageKey, newNote)

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "sander": "^0.5.1",
+    "striptags": "^3.1.0",
     "superagent": "^1.2.0",
     "superagent-promise": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6075,6 +6075,10 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+striptags@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.0.tgz#763e534338d9cf542f004a4b1eb099e32d295e44"
+
 style-loader@^0.12.4:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.12.4.tgz#ae7d0665dc4dc653daa2fe97bb90914bc1d22d9b"


### PR DESCRIPTION
I'd like to style my headings with a color. The problem is the HTML tags aren't stripped from the title. This PR fixes it.

Before:
![Before](https://user-images.githubusercontent.com/3393339/30702471-557ad63e-9eed-11e7-90fb-ae2b118092e1.png)

After:
![After](https://user-images.githubusercontent.com/3393339/30702490-641906de-9eed-11e7-83a4-1ed0119c231a.png)
