### PR TITLE
iss #832 Make :q work in vim mode

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -104,6 +104,12 @@ export default class CodeEditor extends React.Component {
 
     let editorTheme = document.getElementById('editorTheme')
     editorTheme.addEventListener('load', this.loadStyleHandler)
+
+    CodeMirror.Vim.defineEx('quit', 'q', this.quitEditor)
+  }
+
+  quitEditor () {
+    document.querySelector('textarea').blur()
   }
 
   componentWillUnmount () {

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -106,6 +106,8 @@ export default class CodeEditor extends React.Component {
     editorTheme.addEventListener('load', this.loadStyleHandler)
 
     CodeMirror.Vim.defineEx('quit', 'q', this.quitEditor)
+    CodeMirror.Vim.defineEx('q!', 'q!', this.quitEditor)
+    CodeMirror.Vim.defineEx('wq', 'wq', this.quitEditor)
   }
 
   quitEditor () {

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -108,6 +108,7 @@ export default class CodeEditor extends React.Component {
     CodeMirror.Vim.defineEx('quit', 'q', this.quitEditor)
     CodeMirror.Vim.defineEx('q!', 'q!', this.quitEditor)
     CodeMirror.Vim.defineEx('wq', 'wq', this.quitEditor)
+    CodeMirror.Vim.defineEx('qw', 'qw', this.quitEditor)
   }
 
   quitEditor () {


### PR DESCRIPTION
# context
We want to exit from the editor in Vim mode.

# before
![02a6570e0dd85231d3120aa861a95a83](https://user-images.githubusercontent.com/11307908/30750815-6adf47d4-9ff2-11e7-8f2e-cc80685ffeaa.gif)

# after
![f76f1b74be813ee10f631b1cd41486d0](https://user-images.githubusercontent.com/11307908/30750823-703cde58-9ff2-11e7-8da6-236fbe3a7c0d.gif)

# For test
* :q exits from editor mode
* :q! exits from editor mode
* :qw exits from editor mode
