### PR TITLE
enable to get appVerion and platformName

### DIFF
--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -11,23 +11,26 @@ if (process.env.NODE_ENV === 'production' && ConfigManager.default.get().amaEnab
     IdentityPoolId: 'us-east-1:xxxxxxxxxxxxxxxxxxxxxxxxx'
   })
 
-  const rawPlatform = os.platform()
-
-  let actualPlatform
-  if (rawPlatform === 'darwin') {
-    actualPlatform = 'MacOS'
-  } else if (rawPlatform === 'win32') {
-    actualPlatform = 'Windows'
-  } else if (rawPlatform === 'linux') {
-    actualPlatform = 'Linux'
-  }
+  const validPlatformName = convertPlatformName(os.platform())
 
   const mobileAnalyticsClient = new AMA.Manager({
     appId: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     appTitle: 'xxxxxxxxxx',
     appVersionName: remote.app.getVersion().toString(),
-    platform: actualPlatform
+    platform: validPlatformName
   })
+}
+
+function convertPlatformName (platformName) {
+  if (platformName === 'darwin') {
+    return 'MacOS'
+  } else if (platformName === 'win32') {
+    return 'Windows'
+  } else if (platformName === 'linux') {
+    return 'Linux'
+  } else {
+    return ''
+  }
 }
 
 function initAwsMobileAnalytics () {

--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -2,6 +2,9 @@ const AWS = require('aws-sdk')
 const AMA = require('aws-sdk-mobile-analytics')
 const ConfigManager = require('browser/main/lib/ConfigManager')
 
+const remote = require('electron').remote
+const os = require('os')
+
 AWS.config.region = 'us-east-1'
 if (process.env.NODE_ENV === 'production' && ConfigManager.default.get().amaEnabled) {
   AWS.config.credentials = new AWS.CognitoIdentityCredentials({
@@ -9,7 +12,9 @@ if (process.env.NODE_ENV === 'production' && ConfigManager.default.get().amaEnab
   })
   const mobileAnalyticsClient = new AMA.Manager({
     appId: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-    appTitle: 'xxxxxxxxxx'
+    appTitle: 'xxxxxxxxxx',
+    appVersionName: remote.app.getVersion().toString(),
+    platform: os.platform()
   })
 }
 

--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -10,11 +10,23 @@ if (process.env.NODE_ENV === 'production' && ConfigManager.default.get().amaEnab
   AWS.config.credentials = new AWS.CognitoIdentityCredentials({
     IdentityPoolId: 'us-east-1:xxxxxxxxxxxxxxxxxxxxxxxxx'
   })
+
+  const rawPlatform = os.platform()
+
+  let actualPlatform
+  if (rawPlatform === 'darwin') {
+    actualPlatform = 'MacOS'
+  } else if (rawPlatform === 'win32') {
+    actualPlatform = 'Windows'
+  } else if (rawPlatform === 'linux') {
+    actualPlatform = 'Linux'
+  }
+
   const mobileAnalyticsClient = new AMA.Manager({
     appId: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     appTitle: 'xxxxxxxxxx',
     appVersionName: remote.app.getVersion().toString(),
-    platform: os.platform()
+    platform: actualPlatform
   })
 }
 


### PR DESCRIPTION
We want to know platform and Boostnote's version.
So, I added options to get information of platform and Boostnote's version to config file of ama.