### PR TITLE
add the tag to routing

### DIFF
--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -38,6 +38,18 @@ class SideNav extends React.Component {
     router.push('/trashed')
   }
 
+  handleSwitchFolderButtonClick (e) {
+    console.log('SwitchfolderButton Clicked')
+    let { router } = this.context
+    router.push('/home')
+  }
+
+  handleSwitchTagButtonClick (e) {
+    console.log('SwitchTagButton clicked')
+    let { router } = this.context
+    router.push('/tag')
+  }
+
   render () {
     let { data, location, config, dispatch } = this.props
 
@@ -64,6 +76,10 @@ class SideNav extends React.Component {
         tabIndex='1'
         style={style}
       >
+        <div styleName='SwitchModeButtons'>
+          <button onClick={(e) => this.handleSwitchFolderButtonClick(e)}>Folder</button>
+          <button onClick={(e) => this.handleSwitchTagButtonClick(e)}>Tag</button>
+        </div>
         <div styleName='top'>
           <button styleName='top-menu'
             onClick={(e) => this.handleMenuButtonClick(e)}

--- a/browser/main/TopBar/.#index.js
+++ b/browser/main/TopBar/.#index.js
@@ -1,0 +1,1 @@
+suzuki@suzuki-no-MacBook-Air-2.local.31032

--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -62,6 +62,7 @@ ReactDOM.render((
         <Route path='starred' />
         <Route path='searched' />
         <Route path='trashed' />
+        <Route path='tag' />
         <Route path='storages'>
           <IndexRedirect to='/home' />
           <Route path=':storageKey'>


### PR DESCRIPTION
# タグエリアの実装
サイドバー上部にFolder/Tag切り替えボタンをつけて、Folderボタンを押すと従来の動作をし、Tagボタンを押すとサイドバーにタグのリストを表示し、タグ付けされているノートをノートリスト部に表示する。
タグリストのアイテムをクリックすると、そのタグのつけられたノートをノートリストに表示する。