### PR TITLE
Fix "borde-box" typo

### DIFF
--- a/browser/main/Detail/TagSelect.styl
+++ b/browser/main/Detail/TagSelect.styl
@@ -51,7 +51,7 @@
   margin 2px 0 15px 2px
   vertical-align middle
   height 18px
-  box-sizing borde-box
+  box-sizing border-box
   border none
   background-color transparent
   outline none


### PR DESCRIPTION
Mistake in code. Changed from `borde-box` to `border-box`.

![image](https://user-images.githubusercontent.com/24367010/31198369-f0c74fec-a94b-11e7-9240-5f11e6bfb17c.png)
