### PR TITLE
Add notelist right click(context menu) and delete note

### DIFF
--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -41,16 +41,18 @@ const TagElementList = (tags) => {
  * @param {boolean} isActive
  * @param {Object} note
  * @param {Function} handleNoteClick
+ * @param {Function} handleNoteContextMenu
  * @param {Function} handleDragStart
  * @param {string} dateDisplay
  */
-const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleDragStart }) => (
+const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleNoteContextMenu, handleDragStart }) => (
   <div styleName={isActive
       ? 'item--active'
       : 'item'
     }
     key={`${note.storage}-${note.key}`}
     onClick={e => handleNoteClick(e, `${note.storage}-${note.key}`)}
+    onContextMenu={e => handleNoteContextMenu(e, `${note.storage}-${note.key}`)}
     onDragStart={e => handleDragStart(e, note)}
     draggable='true'
   >

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -338,6 +338,17 @@ class NoteList extends React.Component {
     e.dataTransfer.setData('note', noteData)
   }
 
+  handleNoteContextMenu (e, uniqueKey) {
+    this.handleNoteClick(e, uniqueKey)
+
+    let menu = new Menu()
+    menu.append(new MenuItem({
+      label: 'Delete Note',
+      click: () => ee.emit('detail:delete')
+    }))
+    menu.popup()
+  }
+
   importFromFile () {
     const { dispatch, location } = this.props
 
@@ -432,6 +443,7 @@ class NoteList extends React.Component {
               note={note}
               dateDisplay={dateDisplay}
               key={key}
+              handleNoteContextMenu={this.handleNoteContextMenu.bind(this)}
               handleNoteClick={this.handleNoteClick.bind(this)}
               handleDragStart={this.handleDragStart.bind(this)}
             />


### PR DESCRIPTION
# Usage

![delete_note_light](https://user-images.githubusercontent.com/16035247/31315531-8bbcb3d2-ac55-11e7-86e7-7845a17c80c5.gif)

# Why?

I wanted to add this feature because it is very convenient and easy-to-know note deleting way.

As SideNav's folder also can be renamed and deleted with rightclick(context menu), I thought deleting note is also can be made by right click as well and I(as daily user) really felt that way.