### PR TITLE
Support for solarized dark and light themes

### DIFF
--- a/browser/lib/consts.js
+++ b/browser/lib/consts.js
@@ -10,6 +10,7 @@ const themes = fs.readdirSync(themePath)
   .map((themePath) => {
     return themePath.substring(0, themePath.lastIndexOf('.'))
   })
+themes.splice(themes.indexOf('solarized'), 1, 'solarized dark', 'solarized light')
 
 const consts = {
   FOLDER_COLORS: [

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -61,7 +61,7 @@ class UiTab extends React.Component {
     const newCodemirrorTheme = this.refs.editorTheme.value
 
     if (newCodemirrorTheme !== codemirrorTheme) {
-      checkHighLight.setAttribute('href', `../node_modules/codemirror/theme/${newCodemirrorTheme}.css`)
+      checkHighLight.setAttribute('href', `../node_modules/codemirror/theme/${newCodemirrorTheme.split(" ")[0]}.css`)
     }
 
     this.setState({ config: newConfig, codemirrorTheme: newCodemirrorTheme })

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -61,7 +61,7 @@ class UiTab extends React.Component {
     const newCodemirrorTheme = this.refs.editorTheme.value
 
     if (newCodemirrorTheme !== codemirrorTheme) {
-      checkHighLight.setAttribute('href', `../node_modules/codemirror/theme/${newCodemirrorTheme.split(" ")[0]}.css`)
+      checkHighLight.setAttribute('href', `../node_modules/codemirror/theme/${newCodemirrorTheme.split(' ')[0]}.css`)
     }
 
     this.setState({ config: newConfig, codemirrorTheme: newCodemirrorTheme })


### PR DESCRIPTION
Fixes #896 

CodeMirror seems to have the two solarized themes within the
`node_modules/coemirror/theme/solarized.css`. So passing the string
"solarized light" and "solarized dark" to the editor theme appropriately
sets these themes.

The Boostnote app appears to be dynamically determining themes based
on the css files found within `node_modules/codemirror/theme/`.
So that's why there was just a single option of 'solarized' before.

The light and dark 'solarized' themes appear to be the *only* themes
that share a css style, whereas all other light and dark variarnt
themes get their own css file (ex: base16-dark.css and base16-light.css).

Weird!