### PR TITLE
Avoid undefined error for recording analytics events

### DIFF
--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -26,14 +26,22 @@ function initAwsMobileAnalytics () {
 
 function recordDynamicCustomEvent (type) {
   if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled) return
-  mobileAnalyticsClient.recordEvent(type)
+  try {
+    mobileAnalyticsClient.recordEvent(type)
+  } catch (analyticsError) {
+    console.error(analyticsError)
+  }
 }
 
 function recordStaticCustomEvent () {
   if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled) return
-  mobileAnalyticsClient.recordEvent('UI_COLOR_THEME', {
-    uiColorTheme: ConfigManager.default.get().ui.theme
-  })
+  try {
+    mobileAnalyticsClient.recordEvent('UI_COLOR_THEME', {
+      uiColorTheme: ConfigManager.default.get().ui.theme
+    })
+  } catch (analyticsError) {
+    console.error(analyticsError)
+  }
 }
 
 module.exports = {

--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -25,23 +25,15 @@ function initAwsMobileAnalytics () {
 }
 
 function recordDynamicCustomEvent (type) {
-  if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled) return
-  try {
-    mobileAnalyticsClient.recordEvent(type)
-  } catch (analyticsError) {
-    console.error(analyticsError)
-  }
+  if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled || typeof mobileAnalyticsClient === 'undefined') return
+  mobileAnalyticsClient.recordEvent(type)
 }
 
 function recordStaticCustomEvent () {
-  if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled) return
-  try {
-    mobileAnalyticsClient.recordEvent('UI_COLOR_THEME', {
-      uiColorTheme: ConfigManager.default.get().ui.theme
-    })
-  } catch (analyticsError) {
-    console.error(analyticsError)
-  }
+  if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled || typeof mobileAnalyticsClient === 'undefined') return
+  mobileAnalyticsClient.recordEvent('UI_COLOR_THEME', {
+    uiColorTheme: ConfigManager.default.get().ui.theme
+  })
 }
 
 module.exports = {


### PR DESCRIPTION
**Reason for this pull request**
Currently when Boostnote fails to connect to the analytics server it blocks the app from functioning as expected. This can be seen in issue #939.

**Fixes implemented**
A try/catch around the recording of events allows the app to continue working as expected even when it can't connect to the analytics server.

**Issues fixed**
Issue #939 