### PR TITLE
Add try/catch logic to recording of analytics events

### DIFF
--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -26,14 +26,22 @@ function initAwsMobileAnalytics () {
 
 function recordDynamicCustomEvent (type) {
   if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled) return
-  mobileAnalyticsClient.recordEvent(type)
+  try {
+    mobileAnalyticsClient.recordEvent(type)
+  } catch (analyticsError) {
+    console.error(analyticsError)
+  }
 }
 
 function recordStaticCustomEvent () {
   if (process.env.NODE_ENV !== 'production' || !ConfigManager.default.get().amaEnabled) return
-  mobileAnalyticsClient.recordEvent('UI_COLOR_THEME', {
-    uiColorTheme: ConfigManager.default.get().ui.theme
-  })
+  try {
+    mobileAnalyticsClient.recordEvent('UI_COLOR_THEME', {
+      uiColorTheme: ConfigManager.default.get().ui.theme
+    })
+  } catch (analyticsError) {
+    console.error(analyticsError)
+  }
 }
 
 module.exports = {

--- a/browser/main/lib/AwsMobileAnalyticsConfig.js
+++ b/browser/main/lib/AwsMobileAnalyticsConfig.js
@@ -29,7 +29,9 @@ function recordDynamicCustomEvent (type) {
   try {
     mobileAnalyticsClient.recordEvent(type)
   } catch (analyticsError) {
-    console.error(analyticsError)
+    if (analyticsError instanceof ReferenceError) {
+      console.log(analyticsError.name + ': ' + analyticsError.message)
+    }
   }
 }
 
@@ -40,7 +42,9 @@ function recordStaticCustomEvent () {
       uiColorTheme: ConfigManager.default.get().ui.theme
     })
   } catch (analyticsError) {
-    console.error(analyticsError)
+    if (analyticsError instanceof ReferenceError) {
+      console.log(analyticsError.name + ': ' + analyticsError.message)
+    }
   }
 }
 


### PR DESCRIPTION
**Reason for pull request**
Currently the app no longer works as expected when the app fails to connect to the analytics server as seen in issue #939. This pull request intends to fix that behavior.

**Fix**
Add a try/catch around the recording of events to ensure the app continues to work even when it cannot connect to the server. Log the error message in a clean way.

**Issues fixed**
This fixes #939  