### PR TITLE
Change to apply font with single quotations

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -34,7 +34,7 @@ function buildStyle (fontFamily, fontSize, codeBlockFontFamily, lineNumber) {
 }
 ${markdownStyle}
 body {
-  font-family: ${fontFamily.join(', ')};
+  font-family: '${fontFamily.join("','")}';
   font-size: ${fontSize}px;
 }
 code {


### PR DESCRIPTION
# context
A font with space in the name such as `Migu 1M` could not apply to font-family.

# before
The font is not quoted.
![image](https://user-images.githubusercontent.com/11307908/31420755-6b3ad6ea-ae7e-11e7-879f-b0270a321e4e.png)

# after
Quoted.
![image](https://user-images.githubusercontent.com/11307908/31420769-820329f4-ae7e-11e7-9416-b39f06235549.png)
