### PR TITLE
Fix: "Uncaught TypeError: Cannot read property 'className' of null"

### DIFF
--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -27,7 +27,10 @@ document.addEventListener('click', function (e) {
   const className = e.target.className
   if (!className && typeof (className) !== 'string') return
   const isInfoButton = className.includes('infoButton')
-  const isInfoPanel = e.target.offsetParent.className.includes('infoPanel')
+  let isInfoPanel = false
+  if (e.target.offsetParent !== null) {
+    isInfoPanel = e.target.offsetParent.className.includes('infoPanel')
+  }
   if (isInfoButton || isInfoPanel) return
   const infoPanel = document.querySelector('.infoPanel')
   if (infoPanel) infoPanel.style.display = 'none'

--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -27,10 +27,10 @@ document.addEventListener('click', function (e) {
   const className = e.target.className
   if (!className && typeof (className) !== 'string') return
   const isInfoButton = className.includes('infoButton')
-  let isInfoPanel = false
-  if (e.target.offsetParent !== null) {
-    isInfoPanel = e.target.offsetParent.className.includes('infoPanel')
-  }
+  const offsetParent = e.target.offsetParent
+  const isInfoPanel = offsetParent !== null
+    ? offsetParent.className.includes('infoPanel')
+    : false
   if (isInfoButton || isInfoPanel) return
   const infoPanel = document.querySelector('.infoPanel')
   if (infoPanel) infoPanel.style.display = 'none'


### PR DESCRIPTION
This fixes a bug where elements without a target offsetParent were throwing uncaught errors when trying to determine if a click event originated from an info panel element or not.