### PR TITLE
Replace pdf to print

### DIFF
--- a/browser/main/Detail/InfoPanel.js
+++ b/browser/main/Detail/InfoPanel.js
@@ -3,7 +3,7 @@ import CSSModules from 'browser/lib/CSSModules'
 import styles from './InfoPanel.styl'
 
 const InfoPanel = ({
-  storageName, folderName, noteLink, updatedAt, createdAt, exportAsMd, exportAsTxt, wordCount, letterCount, type
+  storageName, folderName, noteLink, updatedAt, createdAt, exportAsMd, exportAsTxt, wordCount, letterCount, type, print
 }) => (
   <div className='infoPanel' styleName='control-infoButton-panel' style={{display: 'none'}}>
     <div styleName='group-section'>
@@ -79,9 +79,9 @@ const InfoPanel = ({
         <p>.txt</p>
       </button>
 
-      <button styleName='export--unable'>
-        <i className='fa fa-file-pdf-o fa-fw' />
-        <p>.pdf</p>
+      <button styleName='export--enable' onClick={(e) => print(e)}>
+        <i className='fa fa-print fa-fw' />
+        <p>Print</p>
       </button>
     </div>
   </div>
@@ -97,7 +97,8 @@ InfoPanel.propTypes = {
   exportAsTxt: PropTypes.func.isRequired,
   wordCount: PropTypes.number,
   letterCount: PropTypes.number,
-  type: PropTypes.string.isRequired
+  type: PropTypes.string.isRequired,
+  print: PropTypes.func.isRequired
 }
 
 export default CSSModules(InfoPanel, styles)

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -256,6 +256,10 @@ class MarkdownNoteDetail extends React.Component {
     if (infoPanel.style) infoPanel.style.display = infoPanel.style.display === 'none' ? 'inline' : 'none'
   }
 
+  print (e) {
+    ee.emit('print')
+  }
+
   render () {
     let { data, config, location } = this.props
     let { note } = this.state
@@ -357,6 +361,7 @@ class MarkdownNoteDetail extends React.Component {
           wordCount={note.content.split(' ').length}
           letterCount={note.content.replace(/\r?\n/g, '').length}
           type={note.type}
+          print={this.print}
         />
       </div>
     </div>


### PR DESCRIPTION
# context
I replace `.pdf export` on InfoPanel to `Print` because I don't think it will be implemented soon and we can export as .pdf via `Print`.

![image](https://user-images.githubusercontent.com/11307908/31525138-16bc3a10-aff9-11e7-9f73-26745b450366.png)

