### PR TITLE
Fix #982: Tag list cannot be scroll

### DIFF
--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -4,9 +4,12 @@
   background-color #f9f9f9
   user-select none
   color $ui-text-color
+  height: 100vh
+  display: flex
+  flex-direction column
 
 .top
-  height 45px
+  padding-bottom 15px
 
 .top-menu
   navButtonColor()
@@ -47,18 +50,20 @@
   margin-left 5px
   overflow ellipsis
 
+.tabBody
+  flex 1
+  display flex
+  flex-direction column
+
 .tag-title
-  height 65px
-  position relative
-  left 15px
+  padding-left 15px
+  padding-bottom 13px
   p
     color $ui-text-color
 
 .tagList
-  absolute left right
-  bottom 37px
   overflow-y auto
-  position relative
+  flex: 1
 
 body[data-theme="dark"]
   .root, .root--folded

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -80,7 +80,7 @@ class SideNav extends React.Component {
       )
     } else {
       component = (
-        <div>
+        <div styleName='tabBody'>
           <div styleName='tag-title'>
             <p>Tags</p>
           </div>


### PR DESCRIPTION
This PR resolve #982. 
I give height to the `.root` of  `SideNav`.

## Before
![tag-sgroll_before](https://user-images.githubusercontent.com/1206676/31655041-a3ee0a1e-b362-11e7-9b3e-49ef01e133d0.gif)

## After
![tag-sgroll](https://user-images.githubusercontent.com/1206676/31644524-cdfb95d2-b331-11e7-921c-af944882ee1b.gif)
