### PR TITLE
Fix side nav style

### DIFF
--- a/browser/components/SideNavFilter.styl
+++ b/browser/components/SideNavFilter.styl
@@ -50,6 +50,7 @@
 .menu--folded
   @extend .menu
   .menu-button, .menu-button--active
+    text-align center
     &:hover .menu-button-label
       transition opacity 0.15s
       opacity 1

--- a/browser/components/SideNavFilter.styl
+++ b/browser/components/SideNavFilter.styl
@@ -50,7 +50,6 @@
 .menu--folded
   @extend .menu
   .menu-button, .menu-button--active
-    text-align center
     &:hover .menu-button-label
       transition opacity 0.15s
       opacity 1

--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -15,7 +15,8 @@
   navButtonColor()
   position absolute
   top 22px
-  right 5px
+  left 200px
+  height 23px
   &:hover
     color $ui-text-color
   &:active, &:active:hover
@@ -49,6 +50,7 @@
 .top-menu-label
   margin-left 5px
   overflow ellipsis
+  opacity 0
 
 .tabBody
   flex 1

--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -65,6 +65,10 @@
   overflow-y auto
   flex: 1
 
+.root--folded
+  .swith-buttons
+    display none
+
 body[data-theme="dark"]
   .root, .root--folded
     border-color $ui-dark-borderColor

--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -66,7 +66,7 @@
   flex: 1
 
 .root--folded
-  .swith-buttons
+  .switch-buttons
     display none
   .top
     height 60px

--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -76,7 +76,7 @@
     height 60px
   .top-menu
     position static
-    width 43px
+    width $sideNav--folded-width
     height 60px
     text-align center
     &:hover .top-menu-label
@@ -86,7 +86,7 @@
     position fixed
     display inline-block
     height 30px
-    left 43px
+    left $sideNav--folded-width
     padding 0 10px
     margin-top -8px
     opacity 0

--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -68,6 +68,8 @@
   flex: 1
 
 .root--folded
+  height 100vh
+  width $sideNav--folded-width
   .switch-buttons
     display none
   .top

--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -68,6 +68,13 @@
 .root--folded
   .swith-buttons
     display none
+  .top
+    height 60px
+  .top-menu
+    position static
+    width 43px
+    height 60px
+    text-align center
 
 body[data-theme="dark"]
   .root, .root--folded

--- a/browser/main/SideNav/SideNav.styl
+++ b/browser/main/SideNav/SideNav.styl
@@ -75,6 +75,27 @@
     width 43px
     height 60px
     text-align center
+    &:hover .top-menu-label
+      transition opacity 0.15s
+      opacity 1
+  .top-menu-label
+    position fixed
+    display inline-block
+    height 30px
+    left 43px
+    padding 0 10px
+    margin-top -8px
+    opacity 0
+    margin-left 0
+    overflow hidden
+    background-color $ui-tooltip-backgroundColor
+    z-index 10
+    color white
+    line-height 30px
+    border-top-right-radius 2px
+    border-bottom-right-radius 2px
+    pointer-events none
+    font-size 12px
 
 body[data-theme="dark"]
   .root, .root--folded

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -150,6 +150,7 @@ class SideNav extends React.Component {
               onClick={(e) => this.handleMenuButtonClick(e)}
             >
               <i className='fa fa-wrench fa-fw' />
+              <span styleName='top-menu-label'>Preferences</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
on v0.8.16, we added tagArea.
It cause some style bugs. I fixed these bugs.
## before
When, we pushed NavToggle Button, 
<img width="520" alt="2017-10-21 14 34 49" src="https://user-images.githubusercontent.com/14838850/31848406-0a7825dc-b66d-11e7-9708-d2fd71d6d262.png">
* 1: background-color of storageList is white.
* 2: icon of PreferenceButton, AllNotesButton, StarredButton, and TrashedButton is disable.
* 3: There is a mystery space at the top of SideNav.

## after
<img width="469" alt="2017-10-21 14 39 33" src="https://user-images.githubusercontent.com/14838850/31848432-af9b5e3a-b66d-11e7-8e83-e76eb1ef3ad3.png">
