### PR TITLE
Adjust notification HotKeyTab

### DIFF
--- a/browser/main/modals/PreferencesModal/ConfigTab.styl
+++ b/browser/main/modals/PreferencesModal/ConfigTab.styl
@@ -67,10 +67,17 @@
   text-align right
   :global
     .alert
-      font-size 12px
-      line-height 30px
-      padding 0 5px
-      float right
+      display inline-block
+      position absolute
+      top 60px
+      right 15px
+      font-size 14px
+    .success
+      color green
+    .error
+      color red
+
+
 
 .group-control-leftButton
   colorDefaultButton()

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -69,7 +69,7 @@ class HotkeyTab extends React.Component {
     })
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     setTimeout(() => {
       this.setState({
         keymapAlert: null

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -69,12 +69,12 @@ class HotkeyTab extends React.Component {
     })
   }
 
-  clearMessage() {
+  componentDidUpdate() {
     setTimeout(() => {
       this.setState({
         keymapAlert: null
       })
-    }, 3000)
+    }, 2500)
   }
 
   render () {
@@ -84,7 +84,6 @@ class HotkeyTab extends React.Component {
         {keymapAlert.message}
       </p>
       : null
-      this.clearMessage()
     let { config } = this.state
 
     return (

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -69,6 +69,14 @@ class HotkeyTab extends React.Component {
     })
   }
 
+  clearMessage() {
+    setTimeout(() => {
+      this.setState({
+        keymapAlert: null
+      })
+    }, 3000)
+  }
+
   render () {
     let keymapAlert = this.state.keymapAlert
     let keymapAlertElement = keymapAlert != null
@@ -76,6 +84,7 @@ class HotkeyTab extends React.Component {
         {keymapAlert.message}
       </p>
       : null
+      this.clearMessage()
     let { config } = this.state
 
     return (

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -50,12 +50,6 @@ class HotkeyTab extends React.Component {
       type: 'SET_UI',
       config: newConfig
     })
-
-    setTimeout(() => {
-      this.setState({
-        keymapAlert: null
-      })
-    }, 2000)
   }
 
   handleHintToggleButtonClick (e) {
@@ -73,6 +67,11 @@ class HotkeyTab extends React.Component {
     this.setState({
       config
     })
+  }
+
+  componentWillUnmount () {
+    console.log("YAYA")
+    clearTimeout(this.timer)
   }
 
   render () {

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -50,6 +50,12 @@ class HotkeyTab extends React.Component {
       type: 'SET_UI',
       config: newConfig
     })
+
+    setTimeout(() => {
+      this.setState({
+        keymapAlert: null
+      })
+    }, 2000)
   }
 
   handleHintToggleButtonClick (e) {
@@ -67,14 +73,6 @@ class HotkeyTab extends React.Component {
     this.setState({
       config
     })
-  }
-
-  componentDidUpdate () {
-    setTimeout(() => {
-      this.setState({
-        keymapAlert: null
-      })
-    }, 2500)
   }
 
   render () {

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -69,11 +69,6 @@ class HotkeyTab extends React.Component {
     })
   }
 
-  componentWillUnmount () {
-    console.log("YAYA")
-    clearTimeout(this.timer)
-  }
-
   render () {
     let keymapAlert = this.state.keymapAlert
     let keymapAlertElement = keymapAlert != null


### PR DESCRIPTION
1.  Adjust position of notification in HotKeyTab

2. Notification can disappear, to be more like a notification.
Would like to but break some test. For the moment, deleted feature in commit below.

![boostnotepr](https://user-images.githubusercontent.com/14330374/31969804-e9e8d0de-b90d-11e7-8ec0-180a934c2e6c.gif)


