### PR TITLE
Change the tooltip text of the lock button for easy to understand what its role

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -334,7 +334,7 @@ class MarkdownNoteDetail extends React.Component {
             >
               <i className={faClassName} styleName='lock-button' />
               <span styleName='control-lockButton-tooltip'>
-                {this.state.isLocked ? 'Unlock' : 'Lock'}
+                {this.state.isLocked ? 'Unlock Editor' : 'Keep Editor Locked'}
               </span>
             </button>
           return (


### PR DESCRIPTION
# context
As @piefel mentioned in https://github.com/BoostIO/Boostnote/issues/1009#issuecomment-339235083, it's not easy to understand the role of the lock button. So I changed the tooltip text.

# before
![image](https://user-images.githubusercontent.com/11307908/31995222-7b743524-b9be-11e7-8699-60038e19a4bb.png)

![image](https://user-images.githubusercontent.com/11307908/31995229-80687680-b9be-11e7-917d-3cd407e31887.png)


# after
![image](https://user-images.githubusercontent.com/11307908/31995189-60031e22-b9be-11e7-8545-cbdacec2f67b.png)

![image](https://user-images.githubusercontent.com/11307908/31995181-577be54a-b9be-11e7-9e12-801d88aa943a.png)
