### PR TITLE
ClearMessage notification HotKeyTab

### DIFF
--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -3,6 +3,7 @@ import CSSModules from 'browser/lib/CSSModules'
 import styles from './ConfigTab.styl'
 import ConfigManager from 'browser/main/lib/ConfigManager'
 import store from 'browser/main/store'
+import _ from 'lodash'
 
 const electron = require('electron')
 const ipc = electron.ipcRenderer
@@ -50,6 +51,7 @@ class HotkeyTab extends React.Component {
       type: 'SET_UI',
       config: newConfig
     })
+    this.clearMessage()
   }
 
   handleHintToggleButtonClick (e) {
@@ -67,6 +69,14 @@ class HotkeyTab extends React.Component {
     this.setState({
       config
     })
+  }
+
+  clearMessage () {
+    _.debounce(() => {
+      this.setState({
+        keymapAlert: null
+      })
+    }, 2000)()
   }
 
   render () {


### PR DESCRIPTION

1. Notification can disappear, to be more like a notification.

![boostnotepr](https://user-images.githubusercontent.com/14330374/31998705-a25d15ba-b988-11e7-8313-e4240d203ec0.gif)
