### PR TITLE
Add keyboard markdown

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -269,6 +269,16 @@ table
       border-color borderColor
       &:last-child
         border-right solid 1px borderColor
+kbd
+  background-color #fafbfc
+  border solid 1px borderColor
+  border-bottom-color btnColor
+  border-radius 3px
+  box-shadow inset 0 -1px 0 #959da5
+  display inline-block
+  font-size .8em
+  line-height 1
+  padding 3px 5px
 
 themeDarkBackground = darken(#21252B, 10%)
 themeDarkText = #f9f9f9
@@ -317,3 +327,6 @@ body[data-theme="dark"]
         border-color themeDarkTableBorder
         &:last-child
           border-right solid 1px themeDarkTableBorder
+  kbd
+    background-color themeDarkBorder
+    color themeDarkText

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -68,6 +68,7 @@ md.use(require('markdown-it-named-headers'), {
       .replace(/\-+$/, '')
   }
 })
+md.use(require('markdown-it-kbd'))
 // Override task item
 md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
   let content, terminate, i, l, token

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "markdown-it-emoji": "^1.1.1",
     "markdown-it-footnote": "^3.0.0",
     "markdown-it-imsize": "^2.0.1",
+    "markdown-it-kbd": "^1.1.0",
     "markdown-it-multimd-table": "^2.0.1",
     "markdown-it-named-headers": "^0.0.4",
     "md5": "^2.0.0",

--- a/webpack-skeleton.js
+++ b/webpack-skeleton.js
@@ -39,6 +39,7 @@ var config = {
     'fs-jetpack',
     '@rokt33r/markdown-it-math',
     'markdown-it-checkbox',
+    'markdown-it-kbd',
     'devtron',
     'mixpanel',
     '@rokt33r/season',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4034,6 +4034,10 @@ markdown-it-imsize:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz#cca0427905d05338a247cb9ca9d968c5cddd5170"
 
+markdown-it-kbd@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-kbd/-/markdown-it-kbd-1.1.0.tgz#d3faf5c30d494796b9cc540ab1f1a8a53dbc5d3b"
+
 markdown-it-multimd-table@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/markdown-it-multimd-table/-/markdown-it-multimd-table-2.0.1.tgz#2e246dc2ec4ca093cbf05d43c9c1cc64e31f255d"


### PR DESCRIPTION
This feature solves #1015, adding `kbd` functionality by using `<kbd></kbd>` tags or `[[]]` syntax. 

![screen shot 2017-10-25 at 11 08 30 am](https://user-images.githubusercontent.com/4202993/32012504-4c380888-b975-11e7-9c60-37dbf653f030.png)
![screen shot 2017-10-25 at 11 08 35 am](https://user-images.githubusercontent.com/4202993/32012507-4eb94fb8-b975-11e7-90bc-6bf99057ccf7.png)
![screen shot 2017-10-25 at 11 08 45 am](https://user-images.githubusercontent.com/4202993/32012513-52a12894-b975-11e7-8ec6-0cb05c4a3e13.png)