### PR TITLE
Fix custom preview fonts

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -92,7 +92,7 @@ const OSX = global.process.platform === 'darwin'
 
 const defaultFontFamily = ['helvetica', 'arial', 'sans-serif']
 if (!OSX) {
-  defaultFontFamily.unshift('\'Microsoft YaHei\'')
+  defaultFontFamily.unshift('Microsoft YaHei')
   defaultFontFamily.unshift('meiryo')
 }
 const defaultCodeBlockFontFamily = ['Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', 'monospace']


### PR DESCRIPTION
After upgrading to 0.8.16, I failed customize Preview Font Family. I found the CSS rule below failed due to escaped quotation marks, causing font-family inherited to another rule.

```css
body {
    font-family: 'Ubuntu','meiryo',''Microsoft YaHei'','helvetica','arial','sans-serif';
}
```

Removing the escaped quotation marks between `Microsoft YaHei` would solve the problem.
My environment is:
* OS: Ubuntu 17.04 x86_64
* node: v6.11.5

**Before**
![2017-10-29 12-02-53](https://user-images.githubusercontent.com/11537681/32140591-d4b22bb0-bca1-11e7-8603-732c56ca0a77.png)
**After**
![2017-10-29 12-00-27](https://user-images.githubusercontent.com/11537681/32140593-db2759f2-bca1-11e7-8522-9fbee5d74360.png)
with preview font set to `Ubuntu`
