### PR TITLE
Tags cut off

### DIFF
--- a/browser/main/Detail/TagSelect.styl
+++ b/browser/main/Detail/TagSelect.styl
@@ -3,7 +3,6 @@
   user-select none
   height 23px
   vertical-align middle
-  width 300px
   overflow-x scroll
   white-space nowrap
 


### PR DESCRIPTION
Fixes #703 - By removing the width of the TagsSelect component, the tags won't be cut off and are still correctly positioned. 