### PR TITLE
Include each note only once when sorting by pin

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -285,11 +285,18 @@ class NoteList extends React.Component {
   }
 
   sortByPin (unorderedNotes) {
-    const pinnedNotes = unorderedNotes.filter((note) => {
-      return note.isPinned
+    const pinnedNotes = []
+    const unpinnedNotes = []
+
+    unorderedNotes.forEach((note) => {
+      if (note.isPinned) {
+        pinnedNotes.push(note)
+      } else {
+        unpinnedNotes.push(note)
+      }
     })
 
-    return pinnedNotes.concat(unorderedNotes)
+    return pinnedNotes.concat(unpinnedNotes)
   }
 
   handleNoteClick (e, uniqueKey) {


### PR DESCRIPTION
Fixes #983 

Previously the `sortByPin` function was getting the pinned notes then preprending them to *all* the notes, pinned notes included, meaning there were duplicate items in the `notes` array. This caused the "Next Note" functionality to not always work correctly (if the next note was in fact a duplicate of the selected note).

This fix filters the notes into "pinned" and "unpinned" then concatenates them together, avoiding duplicates.