### PR TITLE
Fix enabling no focus right click pin to top and show adequate context menu

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -351,19 +351,23 @@ class NoteList extends React.Component {
 
   handleNoteContextMenu (e, uniqueKey) {
     const { location } = this.props
-    const targetIndex = this.getTargetIndex()
-    let note = this.notes[targetIndex]
-    const label = note.isPinned ? 'Remove pin' : 'Pin to Top'
+    const note = this.notes.find((note) => {
+      const noteKey = `${note.storage}-${note.key}`
+      return noteKey === uniqueKey
+    })
 
-    let menu = new Menu()
+    const pinLabel = note.isPinned ? 'Remove pin' : 'Pin to Top'
+    const deleteLabel = 'Delete Note'
+
+    const menu = new Menu()
     if (!location.pathname.match(/\/home|\/starred|\/trash/)) {
       menu.append(new MenuItem({
-        label: label,
+        label: pinLabel,
         click: (e) => this.pinToTop(e, uniqueKey)
       }))
     }
     menu.append(new MenuItem({
-      label: 'Delete Note',
+      label: deleteLabel,
       click: (e) => this.deleteNote(e, uniqueKey)
     }))
     menu.popup()
@@ -377,6 +381,7 @@ class NoteList extends React.Component {
     const currentStorage = data.storageMap.get(storageKey)
     const currentFolder = _.find(currentStorage.folders, {key: folderKey})
 
+    this.handleNoteClick(e, uniqueKey)
     const targetIndex = this.getTargetIndex()
     let note = this.notes[targetIndex]
     note.isPinned = !note.isPinned


### PR DESCRIPTION
# WHY?

For user friendly movement in terms of pin to top interfaces

## BEFORE

![pin-before](https://user-images.githubusercontent.com/16035247/32179351-8ba3fe4e-bdd2-11e7-803a-9dbdccd194b4.gif)

## AFTER

![pin-after](https://user-images.githubusercontent.com/16035247/32179365-924da560-bdd2-11e7-92d2-2a3983fa3e14.gif)
