### PR TITLE
make ZZ work in vim mode

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -110,6 +110,7 @@ export default class CodeEditor extends React.Component {
     CodeMirror.Vim.defineEx('q!', 'q!', this.quitEditor)
     CodeMirror.Vim.defineEx('wq', 'wq', this.quitEditor)
     CodeMirror.Vim.defineEx('qw', 'qw', this.quitEditor)
+    CodeMirror.Vim.map('ZZ',':q','normal')
   }
 
   quitEditor () {


### PR DESCRIPTION
As an avid vim user, I often use "ZZ" while in normal mode to quickly save and exit. This PR makes that bit of vim functionality work in Boostnote as well.