### PR TITLE
only decode the url when the content of the link is a string

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -185,11 +185,13 @@ export default class MarkdownPreview extends React.Component {
   }
 
   fixDecodedURI (node) {
-    const { innerText, href } = node
+    if (node && node.children.length === 1 && typeof node.children[0] === 'string') {
+      const { innerText, href } = node
 
-    node.innerText = mdurl.decode(href) === innerText
-      ? href
-      : innerText
+      node.innerText = mdurl.decode(href) === innerText
+        ? href
+        : innerText
+    }
   }
 
   componentDidMount () {


### PR DESCRIPTION
Fixes #1040

The cause of the problem is in ```MarkdownPreview.js```. The function ```fixDecodedURI``` only checks for innerText for every anchor element, but doesn't check if the anchor element contains other elements. In that case the uri is not decoded and the node remains as is.