### PR TITLE
added shortcut ctrl+q for quit and quit the app when using the Windows Close button

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -37,7 +37,8 @@ const boost = macOS
       },
       {
         label: 'Quit Boostnote',
-        role: 'quit'
+        role: 'quit',
+        accelerator: 'CommandOrControl+Q'
       }
     ]
   }
@@ -45,7 +46,8 @@ const boost = macOS
     label: 'Boostnote',
     submenu: [
       {
-        role: 'quit'
+        role: 'quit',
+        accelerator: 'Control+Q'
       }
     ]
   }
@@ -131,7 +133,8 @@ if (LINUX) {
   file.submenu.push({
     type: 'separator'
   }, {
-    role: 'quit'
+    role: 'quit',
+    accelerator: 'Control+Q'
   })
 }
 

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -43,7 +43,7 @@ if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') 
   mainWindow.on('close', function (e) {
     e.preventDefault()
     if (process.platform === 'win32') {
-      mainWindow.minimize()
+      quitApp()
     } else {
       if (mainWindow.isFullScreen()) {
         mainWindow.once('leave-full-screen', function () {
@@ -51,24 +51,33 @@ if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') 
         })
         mainWindow.setFullScreen(false)
       } else {
-        mainWindow.hide()
+        quitApp()
       }
     }
   })
 
   app.on('before-quit', function (e) {
-    try {
-      config.set('windowsize', mainWindow.getBounds())
-    } catch (e) {
-      // ignore any errors because an error occurs only on update
-      // refs: https://github.com/BoostIO/Boostnote/issues/243
-    }
+    storeWindowSize()
     mainWindow.removeAllListeners()
   })
 } else {
   app.on('window-all-closed', function () {
-    app.quit()
+    quitApp()
   })
+}
+
+function quitApp () {
+  storeWindowSize()
+  app.quit()
+}
+
+function storeWindowSize () {
+  try {
+    config.set('windowsize', mainWindow.getBounds())
+  } catch (e) {
+    // ignore any errors because an error occurs only on update
+    // refs: https://github.com/BoostIO/Boostnote/issues/243
+  }
 }
 
 app.on('activate', function () {


### PR DESCRIPTION
Fixes #997 

**Changes:**
- added a shortcut (like mentioned in the comments of the issue) CTRL/CMD+Q to quit the app.
- close the app (instead of minimize) when clicking the close button (could be changed in a setting in the future).