### PR TITLE
only make the selected tag active

### DIFF
--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -104,11 +104,17 @@ class SideNav extends React.Component {
         <TagListItem
           name={tag}
           handleClickTagListItem={this.handleClickTagListItem.bind(this)}
-          isActive={!!location.pathname.match(tag)}
+          isActive={this.getTagActive(location.pathname, tag)}
           key={tag}
         />
       ))
     )
+  }
+
+  getTagActive (path, tag) {
+    const pathSegments = path.split('/')
+    const pathTag = pathSegments[pathSegments.length - 1]
+    return pathTag === tag
   }
 
   handleClickTagListItem (name) {


### PR DESCRIPTION
Fixes #981

The tag got highlighted when the current pathname contained the tagname (so for pathname /tag/boostnote both boost and boostnote got highlighted). I changed this by checking the exact name of the tag in the pathname.