### PR TITLE
Add PlantUML support

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -69,6 +69,8 @@ md.use(require('markdown-it-named-headers'), {
   }
 })
 md.use(require('markdown-it-kbd'))
+md.use(require('markdown-it-plantuml'))
+
 // Override task item
 md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
   let content, terminate, i, l, token

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "markdown-it-kbd": "^1.1.0",
     "markdown-it-multimd-table": "^2.0.1",
     "markdown-it-named-headers": "^0.0.4",
+    "markdown-it-plantuml": "^0.3.0",
     "md5": "^2.0.0",
     "mdurl": "^1.0.1",
     "mixpanel": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,19 +1059,12 @@ babel-register@^6.11.6, babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.11.6:
+babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.3.19:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
-
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.3.19:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
 
 babel-template@^6.24.1, babel-template@^6.7.0:
   version "6.24.1"
@@ -4050,6 +4043,10 @@ markdown-it-named-headers@^0.0.4:
   dependencies:
     string "^3.0.1"
 
+markdown-it-plantuml@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-plantuml/-/markdown-it-plantuml-0.3.0.tgz#6eb039c45f618e89bb992968f7922765f2735665"
+
 markdown-it@^5.0.3:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-5.1.0.tgz#25286b8465bac496f3f1b77eed544643e9bd718d"
@@ -5520,10 +5517,6 @@ redux@^3.5.2:
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
-
-regenerator-runtime@^0.10.0:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
# context
I integrate `markdown-it-plantuml`.

# before
![image](https://user-images.githubusercontent.com/11307908/32402030-b12e62dc-c15e-11e7-97ba-dcae8f24f00c.png)

# after
```
@startuml

Bob -> Alice : hello
@enduml


asdfsd
```

![image](https://user-images.githubusercontent.com/11307908/32402024-a45ed1b8-c15e-11e7-8b1c-8019b13a938e.png)

# ref
https://github.com/BoostIO/Boostnote/issues/771

# note
This markdown-it plugin is a brand new one.
https://github.com/gmunguia/markdown-it-plantuml