### PR TITLE
enable importing file to empty folder

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -434,10 +434,8 @@ class NoteList extends React.Component {
   addNotesFromFiles (filepaths) {
     const { dispatch, location } = this.props
 
-    const targetIndex = this.getTargetIndex()
-
-    const storageKey = this.notes[targetIndex].storage
-    const folderKey = this.notes[targetIndex].folder
+    const storageKey = this.props.params.storageKey
+    const folderKey = this.props.params.folderKey
 
     if (filepaths === undefined) return
     filepaths.forEach((filepath) => {

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -433,9 +433,7 @@ class NoteList extends React.Component {
   // Add notes to the current folder
   addNotesFromFiles (filepaths) {
     const { dispatch, location } = this.props
-
-    const storageKey = this.props.params.storageKey
-    const folderKey = this.props.params.folderKey
+    const { storage, folder } = this.resolveTargetFolder()
 
     if (filepaths === undefined) return
     filepaths.forEach((filepath) => {
@@ -444,11 +442,11 @@ class NoteList extends React.Component {
         const content = data.toString()
         const newNote = {
           content: content,
-          folder: folderKey,
+          folder: folder.key,
           title: markdown.strip(findNoteTitle(content)),
           type: 'MARKDOWN_NOTE'
         }
-        dataApi.createNote(storageKey, newNote)
+        dataApi.createNote(storage.key, newNote)
         .then((note) => {
           dispatch({
             type: 'UPDATE_NOTE',
@@ -469,6 +467,36 @@ class NoteList extends React.Component {
       return `${note.storage}-${note.key}` === location.query.key
     })
     return targetIndex
+  }
+
+  resolveTargetFolder () {
+    const { data, params } = this.props
+    let storage = data.storageMap.get(params.storageKey)
+
+    // Find first storage
+    if (storage == null) {
+      for (let kv of data.storageMap) {
+        storage = kv[1]
+        break
+      }
+    }
+
+    if (storage == null) this.showMessageBox('No storage for importing note(s)')
+    const folder = _.find(storage.folders, {key: params.folderKey}) || storage.folders[0]
+    if (folder == null) this.showMessageBox('No folder for importing note(s)')
+
+    return {
+      storage,
+      folder
+    }
+  }
+
+  showMessageBox (message) {
+    dialog.showMessageBox(remote.getCurrentWindow(), {
+      type: 'warning',
+      message: message,
+      buttons: ['OK']
+    })
   }
 
   render () {


### PR DESCRIPTION
fix #1057

Current implementation is fetching the import destination storageKey and folderkey from a file in the folder. If no files are in the folder, it cannot fetch these keys. Use prop.params.storageKey / folderKey instead.