### PR TITLE
solarized light/dark bug fix

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -259,7 +259,7 @@ export default class MarkdownPreview extends React.Component {
       ? theme
       : 'elegant'
     this.getWindow().document.getElementById('codeTheme').href = theme.startsWith('solarized')
-      ? `${appPath}/node_modules/codemirror/theme/${theme.split(' ')[0]}.css`
+      ? `${appPath}/node_modules/codemirror/theme/solarized.css`
       : `${appPath}/node_modules/codemirror/theme/${theme}.css`
   }
 

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -258,7 +258,9 @@ export default class MarkdownPreview extends React.Component {
     theme = consts.THEMES.some((_theme) => _theme === theme) && theme !== 'default'
       ? theme
       : 'elegant'
-    this.getWindow().document.getElementById('codeTheme').href = `${appPath}/node_modules/codemirror/theme/${theme.split(' ')[0]}.css`
+    this.getWindow().document.getElementById('codeTheme').href = theme.startsWith('solarized')
+      ? `${appPath}/node_modules/codemirror/theme/${theme.split(' ')[0]}.css`
+      : `${appPath}/node_modules/codemirror/theme/${theme}.css`
   }
 
   rewriteIframe () {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -92,7 +92,7 @@ function get () {
 
     if (config.editor.theme !== 'default') {
       if (config.editor.theme.startsWith('solarized')) {
-        editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + config.editor.theme.split(' ')[0] + '.css')
+        editorTheme.setAttribute('href', '../node_modules/codemirror/theme/solarized.css')
       } else {
         editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + config.editor.theme + '.css')
       }
@@ -127,7 +127,7 @@ function set (updates) {
 
   if (newTheme !== 'default') {
     if (newTheme.startsWith('solarized')) {
-      editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + newTheme.split(' ')[0] + '.css')
+      editorTheme.setAttribute('href', '../node_modules/codemirror/theme/solarized.css')
     } else {
       editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + newTheme + '.css')
     }

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -91,7 +91,11 @@ function get () {
       : 'default'
 
     if (config.editor.theme !== 'default') {
-      editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + config.editor.theme.split(' ')[0] + '.css')
+      if (config.editor.theme.startsWith('solarized')) {
+        editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + config.editor.theme.split(' ')[0] + '.css')
+      } else {
+        editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + config.editor.theme + '.css')
+      }
     }
   }
 
@@ -122,7 +126,11 @@ function set (updates) {
     : 'default'
 
   if (newTheme !== 'default') {
-    editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + newTheme.split(' ')[0] + '.css')
+    if (newTheme.startsWith('solarized')) {
+      editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + newTheme.split(' ')[0] + '.css')
+    } else {
+      editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + newTheme + '.css')
+    }
   }
 
   ipcRenderer.send('config-renew', {

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -91,7 +91,7 @@ function get () {
       : 'default'
 
     if (config.editor.theme !== 'default') {
-      editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + config.editor.theme + '.css')
+      editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + config.editor.theme.split(' ')[0] + '.css')
     }
   }
 
@@ -122,7 +122,7 @@ function set (updates) {
     : 'default'
 
   if (newTheme !== 'default') {
-    editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + newTheme + '.css')
+    editorTheme.setAttribute('href', '../node_modules/codemirror/theme/' + newTheme.split(' ')[0] + '.css')
   }
 
   ipcRenderer.send('config-renew', {


### PR DESCRIPTION
fixup commit for 0bf7e8b705793f432545c204749526d457547552
Solarized light/dark shares the same css file 'solarized.css'. Split by a space and use first one, since "solarized light" and "solarized dark" are the only theme which has a space in the theme name. 