### PR TITLE
[Improvement] - Option for preferences in menus (916 & 1074)

### DIFF
--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -9,9 +9,19 @@ import TagListItem from 'browser/components/TagListItem'
 import SideNavFilter from 'browser/components/SideNavFilter'
 import StorageList from 'browser/components/StorageList'
 import NavToggleButton from 'browser/components/NavToggleButton'
+import EventEmitter from 'browser/main/lib/eventEmitter'
 
 class SideNav extends React.Component {
   // TODO: should not use electron stuff v0.7
+
+  componentDidMount () {
+    EventEmitter.on('side:preferences', this.handleMenuButtonClick)
+  }
+
+  componentWillUnmount () {
+    EventEmitter.off('side:preferences', this.handleMenuButtonClick)
+  }
+
   handleMenuButtonClick (e) {
     openModal(PreferencesModal)
   }

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -19,6 +19,15 @@ const boost = macOS
         type: 'separator'
       },
       {
+        label: 'Preferences',
+        click () {
+          mainWindow.webContents.send('side:preferences')
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
         label: 'Hide Boostnote',
         accelerator: 'Command+H',
         selector: 'hide:'
@@ -45,6 +54,15 @@ const boost = macOS
   : {
     label: 'Boostnote',
     submenu: [
+      {
+        label: 'Preferences',
+        click () {
+          mainWindow.webContents.send('side:preferences')
+        }
+      },
+      {
+        type: 'separator'
+      },
       {
         role: 'quit',
         accelerator: 'Control+Q'
@@ -131,6 +149,13 @@ const file = {
 
 if (LINUX) {
   file.submenu.push({
+    type: 'separator'
+  }, {
+    label: 'Preferences',
+    click () {
+      mainWindow.webContents.send('side:preferences')
+    }
+  }, {
     type: 'separator'
   }, {
     role: 'quit',


### PR DESCRIPTION
**Reference**
Fixes issues #916 and #1074 

**Description**
This pull request adds an option to open 'Preferences' to the menu. For Windows/OS X this is in the 'Boostnote' menu, for Linux in the 'File' menu.

**Screenshot/GIF**
![peek 2017-11-09 09-49](https://user-images.githubusercontent.com/4518410/32596736-945e29ce-c534-11e7-84b9-6e9da3772d7b.gif)
