### PR TITLE
electron-prebuilt is obsolete. use latest electron instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev-start": "concurrently --kill-others \"npm run webpack\" \"npm run hot\""
   },
   "config": {
-    "electron-version": "1.2.8"
+    "electron-version": "1.6.15"
   },
   "repository": {
     "type": "git",
@@ -104,7 +104,7 @@
     "devtron": "^1.1.0",
     "dom-storage": "^2.0.2",
     "electron-packager": "^6.0.0",
-    "electron-prebuilt": "^1.2.8",
+    "electron": "^1.6.15",
     "eslint": "^3.13.1",
     "eslint-config-standard": "^6.2.1",
     "eslint-config-standard-jsx": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,10 @@
     fs-plus "2.x"
     optimist "~0.4.0"
 
+"@types/node@^7.0.18":
+  version "7.0.46"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.46.tgz#c3dedd25558c676b3d6303e51799abb9c3f8f314"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -2150,16 +2154,17 @@ electron-packager@^6.0.0:
     rimraf "^2.3.2"
     run-series "^1.1.1"
 
-electron-prebuilt@^1.2.8:
-  version "1.4.13"
-  resolved "https://registry.yarnpkg.com/electron-prebuilt/-/electron-prebuilt-1.4.13.tgz#0a0e4d7bf895a242061ccfab29394dcda1da33d2"
-  dependencies:
-    electron-download "^3.0.1"
-    extract-zip "^1.0.3"
-
 electron-to-chromium@^1.2.7:
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.11.tgz#744761df1d67b492b322ce9aa0aba5393260eb61"
+
+electron@^1.6.15:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.9.tgz#add54e9f8f83ed02f6519ec10135f698b19336cf"
+  dependencies:
+    "@types/node" "^7.0.18"
+    electron-download "^3.0.1"
+    extract-zip "^1.0.3"
 
 emojis-list@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Today I investigate the #1090 problem, but unfortunately, I couldn't reproduce the problem.

According to this thread https://github.com/electron/electron/issues/9616, it has already been fixed in electron 1.6.x. So, I update electron to latest stable version.
And electron-prebuilt is obsolete. So I use latest electron instead. 

I have built in Ubuntu 17.10 in my Virtualbox and it seems working fine.
Would some one try this PR?