### PR TITLE
replace selection with pasted image

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -213,7 +213,6 @@ export default class CodeEditor extends React.Component {
   }
 
   insertImageMd (imageMd) {
-    const textarea = this.editor.getInputField()
     this.editor.replaceSelection(imageMd)
   }
 

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -214,8 +214,7 @@ export default class CodeEditor extends React.Component {
 
   insertImageMd (imageMd) {
     const textarea = this.editor.getInputField()
-    const cm = this.editor
-    cm.replaceSelection(`${textarea.value.substr(0, textarea.selectionStart)}${imageMd}${textarea.value.substr(textarea.selectionEnd)}`)
+    this.editor.replaceSelection(imageMd)
   }
 
   handlePaste (editor, e) {


### PR DESCRIPTION
fixes issue #1086 - only paste the created image tag over the current selection, not the start and end of the whole textarea.