### PR TITLE
Add simple addon for CodeMirror

### DIFF
--- a/lib/main.html
+++ b/lib/main.html
@@ -67,6 +67,7 @@
   <script src="../node_modules/codemirror/mode/meta.js"></script>
   <script src="../node_modules/codemirror/addon/mode/overlay.js"></script>
   <script src="../node_modules/codemirror/addon/mode/loadmode.js"></script>
+  <script src="../node_modules/codemirror/addon/mode/simple.js"></script>
   <script src="../node_modules/codemirror/keymap/sublime.js"></script>
   <script src="../node_modules/codemirror/keymap/vim.js"></script>
   <script src="../node_modules/codemirror/keymap/emacs.js"></script>


### PR DESCRIPTION
Hi. Thanks for Boostnote. It's very useful.
but, Boostnote can't syntax highlight Rust. CodeMirror need simple addon for the Rust. 

## Before

![simple_addpm_before](https://user-images.githubusercontent.com/2596943/32818826-ea071150-ca08-11e7-8dee-3a043cf9dccf.jpg)

## After

![simple_addon_after](https://user-images.githubusercontent.com/2596943/32818825-e9e1e858-ca08-11e7-9703-97e003b2666c.jpg)
