### PR TITLE
Add task item to indent adjustment target for list

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -67,7 +67,7 @@ export default class CodeEditor extends React.Component {
           if (cm.somethingSelected()) cm.indentSelection('add')
           else {
             const tabs = cm.getOption('indentWithTabs')
-            if (line.trimLeft() === '- ' || line.trimLeft() === '* ' || line.trimLeft() === '+ ') {
+            if (line.trimLeft().match(/^(-|\*|\+) (\[( |x)\] )?$/)) {
               cm.execCommand('goLineStart')
               if (tabs) {
                 cm.execCommand('insertTab')


### PR DESCRIPTION
Checkbox type item list is not supported for list indentation by tab key.
I would like to be able to make possible this. Is this specification is accepted?

## Before

![indent_before](https://user-images.githubusercontent.com/2596943/32819213-4ad273ec-ca0b-11e7-9f17-3dc7f47c4888.gif)

## After

![indent_after](https://user-images.githubusercontent.com/2596943/32819212-4aabe7e0-ca0b-11e7-84af-0fe4bfb8354d.gif)
