### PR TITLE
store correct window size on Linux

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -61,8 +61,12 @@ if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') 
     mainWindow.removeAllListeners()
   })
 } else {
+  mainWindow.on('close', function () {
+    storeWindowSize()
+  })
+
   app.on('window-all-closed', function () {
-    quitApp()
+    app.quit()
   })
 }
 


### PR DESCRIPTION
Boostnote ~never stores~~ always resets the window size on Ubuntu.

I noticed that `mainWindow.getBounds()` in `storeWindowSize()`, which is called on `window-all-closed` event ([lib/main-window.js](https://github.com/BoostIO/Boostnote/blob/29fa512a90d1cee974d62fed46d4f43293e23df8/lib/main-window.js#L64,L76)),  always returns `{ x: 0, y: 0, width: 0, height: 0 }`.

Handling [`before-quit`](https://github.com/electron/electron/blob/master/docs/api/app.md#event-before-quit) event or [`will-quit`](https://github.com/electron/electron/blob/master/docs/api/app.md#event-will-quit) event doen't fix either.

I'm not sure if this makes sense but `storeWindowSize()` on `close` event works.

## Environment
* Ubuntu 16.04.3 LTS
* Boostnote 0.8.16

## Related commits

* [fix quit bug on Ubuntu · BoostIO/Boostnote@394e86f](https://github.com/BoostIO/Boostnote/commit/394e86f765f15d728eecdfbb1e63a84d60d7f9f9) 
* [added shortcut ctrl+q for quit and quit the app when using the Window… · BoostIO/Boostnote@34e9238](https://github.com/BoostIO/Boostnote/commit/34e9238cc4ee7590b6019366092504c117bf7b8d)

---
Just for reference, this or #1168 should fix #1166 :smiley: