### PR TITLE
Fix layout at note item

### DIFF
--- a/browser/components/NoteItem.styl
+++ b/browser/components/NoteItem.styl
@@ -100,10 +100,9 @@ $control-height = 30px
 .item-bottom-tagList
   flex 1
   overflow ellipsis
-  line-height 20px
-  padding-top 7px
+  line-height 25px
   padding-left 2px
-  margin-right 27px
+  margin-right 40px
 
 .item-bottom-tagList-item
   font-size 11px
@@ -136,8 +135,8 @@ $control-height = 30px
 
 .item-pin
   position absolute
-  right -21px
-  bottom 28px
+  right 0px
+  bottom 2px
   width 34px
   height 34px
   color #E54D42


### PR DESCRIPTION
## Before
<img width="290" alt="screen shot 0029-11-21 at 5 56 33 pm" src="https://user-images.githubusercontent.com/8602615/33063276-591b2cf8-cee5-11e7-9930-5a5fa82b3704.png">

## After
<img width="305" alt="screen shot 0029-11-21 at 5 53 53 pm" src="https://user-images.githubusercontent.com/8602615/33063281-5bf67eb4-cee5-11e7-8b74-9f4f6fa31369.png">
