### PR TITLE
Add fr /docs translations

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,5 +1,5 @@
 # Build
-This page is also available in [Japanese](https://github.com/BoostIO/Boostnote/blob/master/docs/jp/build.md), [Korean](https://github.com/BoostIO/Boostnote/blob/master/docs/ko/build.md), [Russain](https://github.com/BoostIO/Boostnote/blob/master/docs/ru/build.md), and [Simplified Chinese](https://github.com/BoostIO/Boostnote/blob/master/docs/zh_CN/build.md).
+This page is also available in [Japanese](https://github.com/BoostIO/Boostnote/blob/master/docs/jp/build.md), [Korean](https://github.com/BoostIO/Boostnote/blob/master/docs/ko/build.md), [Russain](https://github.com/BoostIO/Boostnote/blob/master/docs/ru/build.md), [Simplified Chinese](https://github.com/BoostIO/Boostnote/blob/master/docs/zh_CN/build.md), and [French](https://github.com/BoostIO/Boostnote/blob/master/docs/fr/build.md).
 
 ## Environments
 * npm: 4.x

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,5 +1,5 @@
 # How to debug Boostnote (Electron app)
-This page is also available in [Japanese](https://github.com/BoostIO/Boostnote/blob/master/docs/jp/debug.md), [Korean](https://github.com/BoostIO/Boostnote/blob/master/docs/ko/debug.md), [Russain](https://github.com/BoostIO/Boostnote/blob/master/docs/ru/debug.md), and [Simplified Chinese](https://github.com/BoostIO/Boostnote/blob/master/docs/zh_CN/debug.md)
+This page is also available in [Japanese](https://github.com/BoostIO/Boostnote/blob/master/docs/jp/debug.md), [Korean](https://github.com/BoostIO/Boostnote/blob/master/docs/ko/debug.md), [Russain](https://github.com/BoostIO/Boostnote/blob/master/docs/ru/debug.md), [Simplified Chinese](https://github.com/BoostIO/Boostnote/blob/master/docs/zh_CN/debug.md), and [French](https://github.com/BoostIO/Boostnote/blob/master/docs/fr/debug.md).
 
 Boostnote is an Electron app so it's based on Chromium; developers can use `Developer Tools` just like Google Chrome.
 

--- a/docs/fr/build.md
+++ b/docs/fr/build.md
@@ -1,0 +1,83 @@
+# Build
+Cette page est également disponible en [Japonais](https://github.com/BoostIO/Boostnote/blob/master/docs/jp/build.md), [Coréen](https://github.com/BoostIO/Boostnote/blob/master/docs/ko/build.md), [Russe](https://github.com/BoostIO/Boostnote/blob/master/docs/ru/build.md), et en [Chinois Simplifié](https://github.com/BoostIO/Boostnote/blob/master/docs/zh_CN/build.md).
+
+## Environnements
+* npm: 4.x
+* node: 7.x
+
+Il est conseillé d'utiliser `npm v4.x` car `$ grunt pre-build` ne marche pas sur la `v5.x`.
+
+## Développement
+
+Webpack HMR est utilisé pour développer Boostnote.
+En utilisant les commandes suivantes à la racine du projet, cela va démarrer Boostnote avec les configurations par défaut.
+
+Installez les paquets requis à l'aide de `yarn`.
+
+```
+$ yarn
+```
+Build et start
+
+```
+$ yarn run dev-start
+```
+
+Cette commande lance `yarn run webpack` et `yarn run hot` en parallèle. Cela revient au même que si on utilisait ces deux commandes dans 2 terminaux.
+
+La commande `webpack` va surveiller les changements de code et les appliquer automatiquement.
+
+Si l'erreur suivante apparait : `Failed to load resource: net::ERR_CONNECTION_REFUSED`, relancez Boostnote.
+
+![net::ERR_CONNECTION_REFUSED](https://cloud.githubusercontent.com/assets/11307908/24343004/081e66ae-1279-11e7-8d9e-7f478043d835.png)
+
+> ### Notice
+> Il y a certains cas où vous voudrez relancer l'application manuellement.
+> 1. Quand vous éditez la méthode constructeur dans un composant
+> 2. Quand vous ajoutez une nouvelle classe css. (Comme pour 1: la classe est réécrite pour chaque composant. Le process intervient dans la méthode constructeur)
+
+## Déploiement
+
+On utilise Grunt pour le déploiement automatique.
+Vous pouvez build le programme en utilisant `grunt`. Cependant, nous ne recommandons pas cette méthode car la task par défaut inclut codesign et authenticode.
+
+Nous avons donc préparé un script séparé qui va rendre un fichier exécutable.
+
+Le build ne fonctionne pas sur `npm v5.3.0`. Il faut donc utiliser `npm v5.2.0` quand vous faites le build.
+
+```
+grunt pre-build
+```
+Vous trouverez l'exécutable dans le dossier `dist`.
+Note : l'auto updater ne marchera pas car l'application n'est pas signée.
+
+Si vous trouvez ça nécessaire, vous pouvez utiliser codesign ou authenticode avec cet exécutable.
+
+## Faire un paquet (deb, rpm)
+
+Les paquets sont créés en exécutant `grunt build` sur une plateforme Linux (e.g. Ubuntu, Fedora).
+
+> Note: Vous pouvez créer à la fois un `.deb` et un `.rpm` dans un seul et même environnement.
+
+Après avoir installé la version supportée de `node` et de `npm`, installer les paquets de builds.
+
+
+Ubuntu/Debian:
+
+```
+$ sudo apt-get install -y rpm fakeroot
+```
+
+Fedora:
+
+```
+$ sudo dnf install -y dpkg dpkg-dev rpm-build fakeroot
+```
+
+Puis exécutez `grunt build`.
+
+```
+$ grunt build
+```
+
+Vous trouverez le `.deb` et le `.rpm` dans le dossier `dist`.

--- a/docs/fr/debug.md
+++ b/docs/fr/debug.md
@@ -1,0 +1,22 @@
+# Comment débugger Boostnote (Application Electron)
+Cette page est également disponible en [Japonais](https://github.com/BoostIO/Boostnote/blob/master/docs/jp/debug.md), [Coréen](https://github.com/BoostIO/Boostnote/blob/master/docs/ko/debug.md), [Russe](https://github.com/BoostIO/Boostnote/blob/master/docs/ru/debug.md), et en [Chinois Simplifié](https://github.com/BoostIO/Boostnote/blob/master/docs/zh_CN/debug.md)
+
+Boostnote est une application Electron donc basée sur Chromium. Il est possible d'utiliser les `Developer Tools` comme dans Google Chrome.
+
+Vous pouvez utiliser les `Developer Tools` de la façon suivante :
+![how_to_toggle_devTools](https://cloud.githubusercontent.com/assets/11307908/24343585/162187e2-127c-11e7-9c01-23578db03ecf.png)
+
+Les `Developer Tools` ressemblent à ça :
+![Developer_Tools](https://cloud.githubusercontent.com/assets/11307908/24343545/eff9f3a6-127b-11e7-94cf-cb67bfda634a.png)
+
+Quand une erreur arrive, les messages d'erreurs sont affichés dans la `console`.
+
+## Debugging
+Par exemple, vous pouvez utiliser le `debugger` pour placer un point d'arrêt dans le code de la façon suivante:
+
+![debugger](https://cloud.githubusercontent.com/assets/11307908/24343879/9459efea-127d-11e7-9943-f60bf7f66d4a.png)
+
+C'est une façon comme une autre de faire, vous pouvez trouver une façon de débugger que vous trouverez plus adaptée.
+
+## Références
+* [Documentation officiel de Google Chrome sur le debugging](https://developer.chrome.com/devtools)


### PR DESCRIPTION
Added the translation for French.
I added the link in the EN files, but not in jp, ko, ru and zh, since I don't know how to reference it in those languages.