### PR TITLE
store window size on resize

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -4,6 +4,7 @@ const BrowserWindow = electron.BrowserWindow
 const path = require('path')
 const Config = require('electron-config')
 const config = new Config()
+const _ = require('lodash')
 
 var showMenu = process.platform !== 'win32'
 const windowSize = config.get('windowsize') || { width: 1080, height: 720 }
@@ -39,11 +40,13 @@ mainWindow.webContents.sendInputEvent({
   keyCode: '\u0008'
 })
 
+mainWindow.on('resize', _.debounce(storeWindowSize, 500))
+
 if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') {
   mainWindow.on('close', function (e) {
     e.preventDefault()
     if (process.platform === 'win32') {
-      quitApp()
+      app.quit()
     } else {
       if (mainWindow.isFullScreen()) {
         mainWindow.once('leave-full-screen', function () {
@@ -62,13 +65,8 @@ if (process.platform !== 'linux' || process.env.DESKTOP_SESSION === 'cinnamon') 
   })
 } else {
   app.on('window-all-closed', function () {
-    quitApp()
+    app.quit()
   })
-}
-
-function quitApp () {
-  storeWindowSize()
-  app.quit()
 }
 
 function storeWindowSize () {


### PR DESCRIPTION
Fixes #1166

```MainWindow.getBounds()``` is always 0 for height and width under Linux, so I store the window size on 'resize' event (with debounce, otherwise the function is called way too often). 