### PR TITLE
SideNavItem: add background when hover

### DIFF
--- a/browser/components/SideNavFilter.styl
+++ b/browser/components/SideNavFilter.styl
@@ -60,6 +60,9 @@
     &:hover .menu-button-label
       transition opacity 0.15s
       opacity 1
+      color $ui-tooltip-text-color
+      background-color $ui-tooltip-backgroundColor
+
 
   .menu-button-label
     position fixed


### PR DESCRIPTION
When SideNav is folded, there is no background-color when I hover on an item

Before : 
![screen shot 2017-11-26 at 10 46 43](https://user-images.githubusercontent.com/13620579/33239149-3374cada-d29c-11e7-878f-3b6efeca2c69.png)

So I added a background-color in order to see better what the SideNavItem is about

After : 
![screen shot 2017-11-26 at 11 13 34](https://user-images.githubusercontent.com/13620579/33239164-72104c42-d29c-11e7-80ec-8962ba61aa35.png)

