### PR TITLE
Add a specific style for checked inputs

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -77,6 +77,10 @@ body
 li
   label.taskListItem
     margin-left -2em
+    &.checked
+      font-style italic
+      text-decoration line-through
+      opacity 0.5
 div.math-rendered
   text-align center
 .math-failed

--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -78,7 +78,6 @@ li
   label.taskListItem
     margin-left -2em
     &.checked
-      font-style italic
       text-decoration line-through
       opacity 0.5
 div.math-rendered

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -109,7 +109,7 @@ md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
   if (state.parentType === 'list') {
     const match = content.match(/^\[( |x)\] ?(.+)/i)
     if (match) {
-      content = `<label class='taskListItem' for='checkbox-${startLine + 1}'><input type='checkbox'${match[1] !== ' ' ? ' checked' : ''} id='checkbox-${startLine + 1}'/> ${content.substring(4, content.length)}</label>`
+      content = `<label class='taskListItem${match[1] !== ' ' ? ' checked' : ''}' for='checkbox-${startLine + 1}'><input type='checkbox'${match[1] !== ' ' ? ' checked' : ''} id='checkbox-${startLine + 1}'/> ${content.substring(4, content.length)}</label>`
     }
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1761469/33278551-2bb9f4e0-d39c-11e7-9d59-b972dad3a342.png)

A really small PR to have a better style on checked items (before on the left). Simple but easier to find uncompleted items in a todo list 😉 