### PR TITLE
confirm tag at onBlur event

### DIFF
--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -38,6 +38,10 @@ class TagSelect extends React.Component {
     }
   }
 
+  handleNewTagBlur (e) {
+    this.submitTag()
+  }
+
   removeLastTag () {
     let { value } = this.props
 
@@ -135,6 +139,7 @@ class TagSelect extends React.Component {
           placeholder='Add tag...'
           onChange={(e) => this.handleNewTagInputChange(e)}
           onKeyDown={(e) => this.handleNewTagInputKeyDown(e)}
+          onBlur={(e) => this.handleNewTagBlur(e)}
         />
       </div>
     )


### PR DESCRIPTION
## Before

![tag_before](https://user-images.githubusercontent.com/9694/33455757-55b4300c-d61d-11e7-9bc9-39e78e48aba5.gif)

## After
![tag_after](https://user-images.githubusercontent.com/9694/33455738-4aeda14e-d61d-11e7-9562-0843549d9f11.gif)

When user inputs the tag and leave the tag input box without fixing(enter or tab key), tag string is still there, but it is not stored as a tag.

This PR solves this problem. When the cursol is out of the tag input, it registers the current input contents as a tag.