### PR TITLE
Correction Notification top-left

### DIFF
--- a/browser/components/RealtimeNotification.styl
+++ b/browser/components/RealtimeNotification.styl
@@ -1,11 +1,8 @@
 .notification-area
   z-index 1000
   font-size 12px
-  position absolute
-  bottom 20px
-  width 100%
-  float left
-  height 30px
+  position: relative
+  top: 12px
   background-color none
 
 .notification-link


### PR DESCRIPTION
Hi :)

Suggestion about the problem with the notification area, she is now top-left.
<img width="1152" alt="capture d ecran 2017-11-30 a 21 35 42" src="https://user-images.githubusercontent.com/14330374/33456165-76f9dcfa-d616-11e7-8059-062faa5cf791.png">

Tell me what do you think :)

