### PR TITLE
Fixbug react code mirror

### DIFF
--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -25,6 +25,7 @@ class UiTab extends React.Component {
   }
 
   componentDidMount () {
+    CodeMirror.autoLoadMode(this.codeMirrorInstance.getCodeMirror(), 'javascript')
     this.handleSettingDone = () => {
       this.setState({UiAlert: {
         type: 'success',
@@ -39,10 +40,6 @@ class UiTab extends React.Component {
     }
     ipc.addListener('APP_SETTING_DONE', this.handleSettingDone)
     ipc.addListener('APP_SETTING_ERROR', this.handleSettingError)
-  }
-
-  componentWillMount () {
-    CodeMirror.autoLoadMode(ReactCodeMirror, 'javascript')
   }
 
   componentWillUnmount () {
@@ -191,7 +188,7 @@ class UiTab extends React.Component {
                 }
               </select>
               <div styleName='code-mirror'>
-                <ReactCodeMirror value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
+                <ReactCodeMirror ref={e => this.codeMirrorInstance = e} value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
               </div>
             </div>
           </div>

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -188,7 +188,7 @@ class UiTab extends React.Component {
                 }
               </select>
               <div styleName='code-mirror'>
-                <ReactCodeMirror ref={inst => (this.codeMirrorInstance = inst)} value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
+                <ReactCodeMirror ref={e => (this.codeMirrorInstance = e)} value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
               </div>
             </div>
           </div>

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -188,7 +188,7 @@ class UiTab extends React.Component {
                 }
               </select>
               <div styleName='code-mirror'>
-                <ReactCodeMirror ref={e => (this.codeMirrorInstance = e)} value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
+                <ReactCodeMirror ref={inst => (this.codeMirrorInstance = inst)} value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
               </div>
             </div>
           </div>

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -188,7 +188,7 @@ class UiTab extends React.Component {
                 }
               </select>
               <div styleName='code-mirror'>
-                <ReactCodeMirror ref={e => this.codeMirrorInstance = e} value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
+                <ReactCodeMirror ref={e => (this.codeMirrorInstance = e)} value={codemirrorSampleCode} options={{ lineNumbers: true, readOnly: true, mode: 'javascript', theme: codemirrorTheme }} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Hi :)

* **Bug fix**

[React-codemirror library](https://github.com/JedWatson/react-codemirror) produced a bug with the ```loadModule()``` method.

The mini editor inside the UI tab was not highlighted when the component was mount for the first time due to an error with react-codemirror.
<img width="1154" alt="capture d ecran 2017-12-01 a 16 42 11" src="https://user-images.githubusercontent.com/14330374/33493974-abc8f076-d6b9-11e7-81f3-f0b035358c97.png">
