### PR TITLE
Added border radius & background color to NavToggleButton 

### DIFF
--- a/browser/components/NavToggleButton.styl
+++ b/browser/components/NavToggleButton.styl
@@ -9,6 +9,10 @@
   width 34px
   line-height 32px
   padding 0
+  &:hover
+    border: 1px solid #1EC38B;
+    background-color: alpha(#1EC38B, 30%)
+    border-radius: 50%;
 
 body[data-theme="white"]
   navWhiteButtonColor()


### PR DESCRIPTION
At the moment when you hover the left menu icon its hard to see that you fully hovering it, yes there is a white color and a cursor icon I was thinking it would be useful to have a more visual effect

Folded out:
<img width="545" alt="screen shot 2017-12-04 at 15 04 56" src="https://user-images.githubusercontent.com/3925474/33554424-5607e27a-d905-11e7-904b-ebb7be23e8c0.png">

Folded in:
<img width="356" alt="screen shot 2017-12-04 at 15 04 42" src="https://user-images.githubusercontent.com/3925474/33554425-5624b6a2-d905-11e7-9a67-c7fe96591bb0.png">

White theme: 
<img width="202" alt="screen shot 2017-12-04 at 15 02 42" src="https://user-images.githubusercontent.com/3925474/33554426-5642d7a4-d905-11e7-982a-ca2d30103238.png">

