### PR TITLE
Add scroll past end

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -155,7 +155,7 @@ export default class CodeEditor extends React.Component {
     }
 
     if (prevProps.scrollPastEnd !== this.props.scrollPastEnd) {
-      this.editor.setOption('scrollPastEnd', this.props.scrollPastEnd);
+      this.editor.setOption('scrollPastEnd', this.props.scrollPastEnd)
     }
 
     if (needRefresh) {

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -59,6 +59,7 @@ export default class CodeEditor extends React.Component {
       tabSize: this.props.indentSize,
       indentWithTabs: this.props.indentType !== 'space',
       keyMap: this.props.keyMap,
+      scrollPastEnd: this.props.scrollPastEnd,
       inputStyle: 'textarea',
       dragDrop: false,
       extraKeys: {
@@ -151,6 +152,10 @@ export default class CodeEditor extends React.Component {
     }
     if (prevProps.indentType !== this.props.indentType) {
       this.editor.setOption('indentWithTabs', this.props.indentType !== 'space')
+    }
+
+    if (prevProps.scrollPastEnd !== this.props.scrollPastEnd) {
+      this.editor.setOption('scrollPastEnd', this.props.scrollPastEnd);
     }
 
     if (needRefresh) {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -242,6 +242,7 @@ class MarkdownEditor extends React.Component {
           fontSize={editorFontSize}
           indentType={config.editor.indentType}
           indentSize={editorIndentSize}
+          scrollPastEnd={config.editor.scrollPastEnd}
           storageKey={storageKey}
           onChange={(e) => this.handleChange(e)}
           onBlur={(e) => this.handleBlur(e)}
@@ -259,6 +260,7 @@ class MarkdownEditor extends React.Component {
           codeBlockFontFamily={config.editor.fontFamily}
           lineNumber={config.preview.lineNumber}
           indentSize={editorIndentSize}
+          scrollPastEnd={config.editor.scrollPastEnd}
           ref='preview'
           onContextMenu={(e) => this.handleContextMenu(e)}
           tabIndex='0'

--- a/browser/finder/NoteDetail.js
+++ b/browser/finder/NoteDetail.js
@@ -157,6 +157,7 @@ class NoteDetail extends React.Component {
               indentType={config.editor.indentType}
               indentSize={editorIndentSize}
               keyMap={config.editor.keyMap}
+              scrollPastEnd={config.editor.scrollPastEnd}
               readOnly
               ref={'code-' + index}
             />

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -236,6 +236,27 @@ class SnippetNoteDetail extends React.Component {
     })
   }
 
+  handleTabDragStart (e, index) {
+    e.dataTransfer.setData('text/plain', index)
+  }
+
+  handleTabDrop (e, index) {
+    const oldIndex = parseInt(e.dataTransfer.getData('text'))
+
+    const snippets = this.state.note.snippets.slice()
+    const draggedSnippet = snippets[oldIndex]
+    snippets[oldIndex] = snippets[index]
+    snippets[index] = draggedSnippet
+    const snippetIndex = index
+
+    const note = Object.assign({}, this.state.note, {snippets})
+    this.setState({ note, snippetIndex }, () => {
+      this.save()
+      this.refs['code-' + index].reload()
+      this.refs['code-' + oldIndex].reload()
+    })
+  }
+
   handleTabDeleteButtonClick (e, index) {
     if (this.state.note.snippets.length > 1) {
       if (this.state.note.snippets[index].content.trim().length > 0) {
@@ -511,6 +532,8 @@ class SnippetNoteDetail extends React.Component {
         onDelete={(e) => this.handleTabDeleteButtonClick(e, index)}
         onRename={(name) => this.renameSnippetByIndex(index, name)}
         isDeletable={note.snippets.length > 1}
+        onDragStart={(e) => this.handleTabDragStart(e, index)}
+        onDrop={(e) => this.handleTabDrop(e, index)}
       />
     })
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -236,27 +236,6 @@ class SnippetNoteDetail extends React.Component {
     })
   }
 
-  handleTabDragStart (e, index) {
-    e.dataTransfer.setData('text/plain', index)
-  }
-
-  handleTabDrop (e, index) {
-    const oldIndex = parseInt(e.dataTransfer.getData('text'))
-
-    const snippets = this.state.note.snippets.slice()
-    const draggedSnippet = snippets[oldIndex]
-    snippets[oldIndex] = snippets[index]
-    snippets[index] = draggedSnippet
-    const snippetIndex = index
-
-    const note = Object.assign({}, this.state.note, {snippets})
-    this.setState({ note, snippetIndex }, () => {
-      this.save()
-      this.refs['code-' + index].reload()
-      this.refs['code-' + oldIndex].reload()
-    })
-  }
-
   handleTabDeleteButtonClick (e, index) {
     if (this.state.note.snippets.length > 1) {
       if (this.state.note.snippets[index].content.trim().length > 0) {
@@ -532,8 +511,6 @@ class SnippetNoteDetail extends React.Component {
         onDelete={(e) => this.handleTabDeleteButtonClick(e, index)}
         onRename={(name) => this.renameSnippetByIndex(index, name)}
         isDeletable={note.snippets.length > 1}
-        onDragStart={(e) => this.handleTabDragStart(e, index)}
-        onDrop={(e) => this.handleTabDrop(e, index)}
       />
     })
 
@@ -565,6 +542,7 @@ class SnippetNoteDetail extends React.Component {
             indentType={config.editor.indentType}
             indentSize={editorIndentSize}
             keyMap={config.editor.keyMap}
+            scrollPastEnd={config.editor.scrollPastEnd}
             onChange={(e) => this.handleCodeChange(index)(e)}
             ref={'code-' + index}
           />

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -34,7 +34,8 @@ export const DEFAULT_CONFIG = {
     fontFamily: win ? 'Segoe UI' : 'Monaco, Consolas',
     indentType: 'space',
     indentSize: '2',
-    switchPreview: 'BLUR' // Available value: RIGHTCLICK, BLUR
+    switchPreview: 'BLUR', // Available value: RIGHTCLICK, BLUR
+    scrollPastEnd: false
   },
   preview: {
     fontSize: '14',

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -73,7 +73,8 @@ class UiTab extends React.Component {
         indentType: this.refs.editorIndentType.value,
         indentSize: this.refs.editorIndentSize.value,
         switchPreview: this.refs.editorSwitchPreview.value,
-        keyMap: this.refs.editorKeyMap.value
+        keyMap: this.refs.editorKeyMap.value,
+        scrollPastEnd: this.refs.scrollPastEnd.checked
       },
       preview: {
         fontSize: this.refs.previewFontSize.value,
@@ -276,6 +277,17 @@ class UiTab extends React.Component {
               </select>
               <p styleName='note-for-keymap'>⚠️ Please restart boostnote after you change the keymap</p>
             </div>
+          </div>
+
+          <div styleName='group-checkBoxSection'>
+            <label>
+              <input onChange={(e) => this.handleUIChange(e)}
+                checked={this.state.config.editor.scrollPastEnd}
+                ref='scrollPastEnd'
+                type='checkbox'
+              />&nbsp;
+              Allow editor to scroll past the last line
+            </label>
           </div>
 
           <div styleName='group-header2'>Preview</div>

--- a/lib/main.html
+++ b/lib/main.html
@@ -82,6 +82,7 @@
   <script src="../node_modules/codemirror/addon/search/search.js"></script>
   <script src="../node_modules/codemirror/addon/search/searchcursor.js"></script>
   <script src="../node_modules/codemirror/addon/scroll/annotatescrollbar.js"></script>
+  <script src="../node_modules/codemirror/addon/scroll/scrollpastend.js"></script>
   <script src="../node_modules/codemirror/addon/search/matchesonscrollbar.js"></script>
   <script src="../node_modules/codemirror/addon/search/jump-to-line.js"></script>
   <script src="../node_modules/codemirror/addon/dialog/dialog.js"></script>


### PR DESCRIPTION
Implements feature request in #838. This is something I missed from the editor, as well.
CodeMirror has a `scrollPastEnd` addon and I just added a checkbox in the UI tab of Preferences to enable it in the code editor.