### PR TITLE
convert uml to utf8 before converting to base64

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -78,9 +78,9 @@ md.use(require('markdown-it-named-headers'), {
 md.use(require('markdown-it-kbd'))
 md.use(require('markdown-it-plantuml'), '', {
   generateSource: function (umlCode) {
-    var deflate = require('markdown-it-plantuml/lib/deflate')
-    var s = unescape(encodeURIComponent(umlCode))
-    var zippedCode = deflate.encode64(
+    const deflate = require('markdown-it-plantuml/lib/deflate')
+    const s = unescape(encodeURIComponent(umlCode))
+    const zippedCode = deflate.encode64(
       deflate.zip_deflate(`@startuml\n${s}\n@enduml`, 9)
     )
     return `http://www.plantuml.com/plantuml/svg/${zippedCode}`

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -8,7 +8,7 @@ import ConfigManager from 'browser/main/lib/ConfigManager'
 const katex = window.katex
 const config = ConfigManager.get()
 
-function createGutter (str) {
+function createGutter(str) {
   const lc = (str.match(/\n/g) || []).length
   const lines = []
   for (let i = 1; i <= lc; i++) {
@@ -31,10 +31,10 @@ var md = markdownit({
       return `<pre class="sequence">${str}</pre>`
     }
     return '<pre class="code">' +
-    createGutter(str) +
-    '<code class="' + lang + '">' +
-    str +
-    '</code></pre>'
+      createGutter(str) +
+      '<code class="' + lang + '">' +
+      str +
+      '</code></pre>'
   }
 })
 md.use(emoji, {
@@ -57,7 +57,7 @@ md.use(math, {
   blockRenderer: function (str) {
     let output = ''
     try {
-      output = katex.renderToString(str.trim(), {displayMode: true})
+      output = katex.renderToString(str.trim(), { displayMode: true })
     } catch (err) {
       output = `<div class="katex-error">${err.message}</div>`
     }
@@ -76,7 +76,16 @@ md.use(require('markdown-it-named-headers'), {
   }
 })
 md.use(require('markdown-it-kbd'))
-md.use(require('markdown-it-plantuml'))
+md.use(require("markdown-it-plantuml"), "", {
+  generateSource: function (umlCode) {
+    var deflate = require("markdown-it-plantuml/lib/deflate")
+    var s = unescape(encodeURIComponent(umlCode))
+    var zippedCode = deflate.encode64(
+      deflate.zip_deflate("@startuml\n" + s + "\n@enduml", 9)
+    );
+    return "http://www.plantuml.com/plantuml/svg/" + zippedCode
+  }
+})
 
 // Override task item
 md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
@@ -110,7 +119,7 @@ md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
   state.line = nextLine
 
   token = state.push('paragraph_open', 'p', 1)
-  token.map = [ startLine, state.line ]
+  token.map = [startLine, state.line]
 
   if (state.parentType === 'list') {
     const match = content.match(/^\[( |x)\] ?(.+)/i)
@@ -121,7 +130,7 @@ md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
 
   token = state.push('inline', '', 0)
   token.content = content
-  token.map = [ startLine, state.line ]
+  token.map = [startLine, state.line]
   token.children = []
 
   token = state.push('paragraph_close', 'p', -1)
@@ -131,7 +140,7 @@ md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
 
 // Add line number attribute for scrolling
 const originalRender = md.renderer.render
-md.renderer.render = function render (tokens, options, env) {
+md.renderer.render = function render(tokens, options, env) {
   tokens.forEach((token) => {
     switch (token.type) {
       case 'heading_open':
@@ -147,12 +156,12 @@ md.renderer.render = function render (tokens, options, env) {
 // FIXME We should not depend on global variable.
 window.md = md
 
-function normalizeLinkText (linkText) {
+function normalizeLinkText(linkText) {
   return md.normalizeLinkText(linkText)
 }
 
 const markdown = {
-  render: function markdown (content) {
+  render: function markdown(content) {
     if (!_.isString(content)) content = ''
     const renderedContent = md.render(content)
     return renderedContent

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -8,7 +8,7 @@ import ConfigManager from 'browser/main/lib/ConfigManager'
 const katex = window.katex
 const config = ConfigManager.get()
 
-function createGutter(str) {
+function createGutter (str) {
   const lc = (str.match(/\n/g) || []).length
   const lines = []
   for (let i = 1; i <= lc; i++) {
@@ -76,14 +76,14 @@ md.use(require('markdown-it-named-headers'), {
   }
 })
 md.use(require('markdown-it-kbd'))
-md.use(require("markdown-it-plantuml"), "", {
+md.use(require('markdown-it-plantuml'), '', {
   generateSource: function (umlCode) {
-    var deflate = require("markdown-it-plantuml/lib/deflate")
+    var deflate = require('markdown-it-plantuml/lib/deflate')
     var s = unescape(encodeURIComponent(umlCode))
     var zippedCode = deflate.encode64(
-      deflate.zip_deflate("@startuml\n" + s + "\n@enduml", 9)
-    );
-    return "http://www.plantuml.com/plantuml/svg/" + zippedCode
+      deflate.zip_deflate(`@startuml\n${s}\n@enduml`, 9)
+    )
+    return `http://www.plantuml.com/plantuml/svg/${zippedCode}`
   }
 })
 
@@ -140,7 +140,7 @@ md.block.ruler.at('paragraph', function (state, startLine/*, endLine */) {
 
 // Add line number attribute for scrolling
 const originalRender = md.renderer.render
-md.renderer.render = function render(tokens, options, env) {
+md.renderer.render = function render (tokens, options, env) {
   tokens.forEach((token) => {
     switch (token.type) {
       case 'heading_open':
@@ -156,12 +156,12 @@ md.renderer.render = function render(tokens, options, env) {
 // FIXME We should not depend on global variable.
 window.md = md
 
-function normalizeLinkText(linkText) {
+function normalizeLinkText (linkText) {
   return md.normalizeLinkText(linkText)
 }
 
 const markdown = {
-  render: function markdown(content) {
+  render: function markdown (content) {
     if (!_.isString(content)) content = ''
     const renderedContent = md.render(content)
     return renderedContent

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -76,9 +76,10 @@ md.use(require('markdown-it-named-headers'), {
   }
 })
 md.use(require('markdown-it-kbd'))
+
+const deflate = require('markdown-it-plantuml/lib/deflate')
 md.use(require('markdown-it-plantuml'), '', {
   generateSource: function (umlCode) {
-    const deflate = require('markdown-it-plantuml/lib/deflate')
     const s = unescape(encodeURIComponent(umlCode))
     const zippedCode = deflate.encode64(
       deflate.zip_deflate(`@startuml\n${s}\n@enduml`, 9)


### PR DESCRIPTION
fixes #1270
Convert the input string to utf-8 with `unescape(encodeURIComponent(umlCode))`, directly copied from [plantUML Web Server](http://www.plantuml.com/plantuml/uml/ZP51JWCn34NtFeLtJA_GggAZAK9TWBf1h4t6qub8an8xBUs9k0SNmpDK55Kis4NEz_VxzaAKifPjWF41cNTC2jDxLdmIpf6sZ7LiSKqYXvJR6SIaZ84xXUUUC-Cwit1Kma0epafRKeBMOqWR7v52k2bg0WOsdw4RV8VLZ_jyZb8_rCwb4lNHAXFKdYDMHvO9J9kUtUlVB0ZrXdmKnTgftpCkVMQdAHz_Kwu2MlEUCnhJjH0-Ft17sPmr-zE9D65B-5OeM184-p8RAJX6lGJW88nLJF_b-zxK8CAbRUU5XC-8sMzwXIP5AMp3kr14qa0AD6xDEphv57aeNKF4rdSmlNjdPr8SGMRd2-AXzy4GLtAXQL8UKjzExDPf1mlhjyD_0G00): 
```javascript
function compress(s, change) {
  //UTF8
  s = unescape(encodeURIComponent(s));
  dest = "http://www.plantuml.com/plantuml" + "/uml/"+encode64(zip_deflate(s, 9));
  if (change) dest += "?switch";
  window.location.href = dest;
}
```