### PR TITLE
Fix link to Cloud-Syncing

### DIFF
--- a/browser/main/modals/PreferencesModal/StoragesTab.js
+++ b/browser/main/modals/PreferencesModal/StoragesTab.js
@@ -168,9 +168,9 @@ class StoragesTab extends React.Component {
               </select>
               <div styleName='addStorage-body-section-type-description'>
                 3rd party cloud integration:
-                <a href='https://github.com/BoostIO/Boostnote/wiki/Cloud-Syncing'
+                <a href='https://github.com/BoostIO/Boostnote/wiki/Cloud-Syncing-and-Backup'
                   onClick={(e) => this.handleLinkClick(e)}
-                >Cloud-Syncing</a>
+                >Cloud-Syncing-and-Backup</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
[Cloud-Syncing](https://github.com/BoostIO/Boostnote/wiki/Cloud-Syncing) link in `Preference > Add Storage` seems to have been renamed.
I'd say it should point to [Cloud-Syncing-and-Backup](https://github.com/BoostIO/Boostnote/wiki/Cloud-Syncing-and-Backup) now.

related to #889

<img width="1675" alt="screen shot 2017-12-12 at 0 04 25" src="https://user-images.githubusercontent.com/4394282/33837658-64b01880-ded0-11e7-85a2-60f32824dda0.png">
