### PR TITLE
Fix linking to other notes

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -235,18 +235,8 @@ class NoteList extends React.Component {
       return
     }
 
-    const { router } = this.context
-    const { location } = this.props
-
-    let targetIndex = this.getTargetIndex()
-
-    if (targetIndex < 0) targetIndex = 0
-
-    const selectedNoteKeys = []
-    const nextNoteKey = this.getNoteKeyFromTargetIndex(targetIndex)
-    selectedNoteKeys.push(nextNoteKey)
-
-    this.focusNote(selectedNoteKeys, nextNoteKey)
+    const selectedNoteKeys = [noteHash]
+    this.focusNote(selectedNoteKeys, noteHash)
 
     ee.emit('list:moved')
   }


### PR DESCRIPTION
This PR restores the ability to jump to other notes from links within markdown notes. This functionality was broken because we were routing to the hash of the currently visible note, rather than routing to the hash of the new note. 

Thanks for the opportunity to help with a quick bug fix! What a great way to spend a flight 😄 

Closes #1315 