### PR TITLE
show 'USE' label instead of 'CREATE' at init modal if path exists

### DIFF
--- a/browser/main/modals/InitModal.js
+++ b/browser/main/modals/InitModal.js
@@ -48,7 +48,7 @@ class InitModal extends React.Component {
     this.updatePath(e.target.value)
   }
 
-  updatePath(path) {
+  updatePath (path) {
     const pathAlreadyExists = pathExists(path)
     this.setState({ path, pathAlreadyExists })
   }
@@ -257,12 +257,11 @@ InitModal.propTypes = {
 
 export default CSSModules(InitModal, styles)
 
-
-function pathExists(path) {
+function pathExists (path) {
   try {
     fs.statSync(path)
     return true
-  } catch(e) {
+  } catch (e) {
     if (e.errno === -2) {
       // no such file or dir
       return false

--- a/browser/main/modals/InitModal.js
+++ b/browser/main/modals/InitModal.js
@@ -5,11 +5,11 @@ import dataApi from 'browser/main/lib/dataApi'
 import store from 'browser/main/store'
 import { hashHistory } from 'react-router'
 import _ from 'lodash'
+import fsHelpers from 'browser/lib/fs-helpers'
 
 const CSON = require('@rokt33r/season')
 const path = require('path')
 const electron = require('electron')
-const fs = require('fs')
 const { remote } = electron
 
 function browseFolder () {
@@ -35,7 +35,7 @@ class InitModal extends React.Component {
     const initPath = path.join(remote.app.getPath('home'), 'Boostnote')
     this.state = {
       path: initPath,
-      pathAlreadyExists: pathExists(initPath),
+      pathAlreadyExists: fsHelpers.pathExists(initPath),
       migrationRequested: true,
       isLoading: true,
       data: null,
@@ -49,7 +49,7 @@ class InitModal extends React.Component {
   }
 
   updatePath (path) {
-    const pathAlreadyExists = pathExists(path)
+    const pathAlreadyExists = fsHelpers.pathExists(path)
     this.setState({ path, pathAlreadyExists })
   }
 
@@ -256,17 +256,3 @@ InitModal.propTypes = {
 }
 
 export default CSSModules(InitModal, styles)
-
-function pathExists (path) {
-  try {
-    fs.statSync(path)
-    return true
-  } catch (e) {
-    if (e.errno === -2) {
-      // no such file or dir
-      return false
-    } else {
-      throw e
-    }
-  }
-}

--- a/browser/main/modals/PreferencesModal/StoragesTab.js
+++ b/browser/main/modals/PreferencesModal/StoragesTab.js
@@ -44,7 +44,8 @@ class StoragesTab extends React.Component {
       newStorage: {
         name: 'Unnamed',
         type: 'FILESYSTEM',
-        path: ''
+        path: '',
+        pathAlreadyExists: false,
       }
     }, () => {
       this.refs.addStorageName.select()

--- a/browser/main/modals/PreferencesModal/StoragesTab.js
+++ b/browser/main/modals/PreferencesModal/StoragesTab.js
@@ -44,8 +44,7 @@ class StoragesTab extends React.Component {
       newStorage: {
         name: 'Unnamed',
         type: 'FILESYSTEM',
-        path: '',
-        pathAlreadyExists: false,
+        path: ''
       }
     }, () => {
       this.refs.addStorageName.select()

--- a/lib/fs-helpers.js
+++ b/lib/fs-helpers.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+
+export default {
+  pathExists
+}
+
+function pathExists (path) {
+  try {
+    fs.statSync(path)
+    return true
+  } catch (e) {
+    if (e.errno === -2) {
+      // no such file or dir
+      return false
+    } else {
+      throw e
+    }
+  }
+}


### PR DESCRIPTION
<img width="1377" alt="boostnote-init-modal-label" src="https://user-images.githubusercontent.com/190381/34481830-9d55fe12-efb4-11e7-9f82-7fd319945757.png">

It was strange for me to open the app on another machine, select existing directory I want to use and seeing "Create" label. I was afraid it would override my storage created on another machine (lying within "cloud drive").

Have two questions, though:

1. I'd also update same thing at the storages tab but am not sure if you prefer two smaller PRs or one with both changes
2. Do we have any common place for utils like `pathExists` functions? I've left it at `InitModal` component but would prefer to extract it somewhere (as this function would be used for similar check at storages tab)