### PR TITLE
fix(code-editor): use correct prop for font family

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -250,7 +250,7 @@ export default class CodeEditor extends React.Component {
 
   render () {
     const { className, fontSize } = this.props
-    let fontFamily = this.props.className
+    let fontFamily = this.props.fontFamily
     fontFamily = _.isString(fontFamily) && fontFamily.length > 0
       ? [fontFamily].concat(defaultEditorFontFamily)
       : defaultEditorFontFamily


### PR DESCRIPTION
Closes #1358 

Bug was introduced here: https://github.com/BoostIO/Boostnote/commit/3fbc749395b7c90643d05ee09b8e7f74e00eb190#diff-4771352a7e4e4f9d82f0be3e914757adL245