### PR TITLE
Remove inline-style from markdown link list

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -105,7 +105,6 @@ a
   border-radius 5px
   margin -5px
   transition .1s
-  display inline-block
   img
     vertical-align sub
   &:hover


### PR DESCRIPTION
Fix #1401

### Before
![before](https://user-images.githubusercontent.com/2596943/35030934-2ebf93a4-fba4-11e7-860e-f5591210d3c8.png)

### After
![after](https://user-images.githubusercontent.com/2596943/35030935-30bbb89a-fba4-11e7-956f-46a977158ba6.png)
