### PR TITLE
Allows keyboard text selection in Finder search box

### DIFF
--- a/browser/finder/index.js
+++ b/browser/finder/index.js
@@ -104,7 +104,7 @@ class FinderMain extends React.Component {
       hideFinder()
       e.preventDefault()
     }
-    if (e.keyCode === 91 || e.metaKey) {
+    if (e.keyCode === 91) {
       return
     }
   }


### PR DESCRIPTION
Hi, this fixes #1238. If the e.metaKey swallow was placed there for a reason then please let me know and I can look into a different approach. 

Thanks!