### PR TITLE
Remove leading # when creating tag

### DIFF
--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -64,7 +64,8 @@ class TagSelect extends React.Component {
   submitTag () {
     AwsMobileAnalyticsConfig.recordDynamicCustomEvent('ADD_TAG')
     let { value } = this.props
-    const newTag = this.refs.newTag.value.trim().replace(/ +/g, '_')
+    let newTag = this.refs.newTag.value.trim().replace(/ +/g, '_')
+    newTag = newTag.charAt(0) === '#' ? newTag.substring(1) : newTag
 
     if (newTag.length <= 0) {
       this.setState({


### PR DESCRIPTION
- Remove leading # from tags that are created with leading # (user types in `#tagName`)
- Convenience method for users who tend to type them, but did not want a tag with two #
- If a user wants a tag with a leading #, then can enter `##OfPeople`, and only the first will be removed
- Resolves #1476 