### PR TITLE
Fix permanently deleting note

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -210,10 +210,9 @@ class MarkdownNoteDetail extends React.Component {
         }, () => {
           this.save()
         })
-
-        ee.emit('list:next')
       }
     }
+    ee.emit('list:next')
   }
 
   handleUndoButtonClick (e) {

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -203,10 +203,9 @@ class SnippetNoteDetail extends React.Component {
         }, () => {
           this.save()
         })
-
-        ee.emit('list:next')
       }
     }
+    ee.emit('list:next')
   }
 
   handleUndoButtonClick (e) {


### PR DESCRIPTION
- Permanently deleting note would not remove note from list until after refresh
- Fix so that permanently deleted note is removed from list
- Resolve #1465 

This bug was created in 9f9463f0e8932ae02dec4d4b6bd243e409d71e25 (git bisect), and I'm not sure of what review comments the commit message is referring to (looked through a few PRs around that time). So this fix might not be the fix we really want, depending on those comments.