### PR TITLE
I fixed the behavior of the editor when the enter key is pushed.

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -92,7 +92,7 @@ export default class CodeEditor extends React.Component {
         'Cmd-T': function (cm) {
           // Do nothing
         },
-        Enter: 'newlineAndIndentContinueMarkdownList',
+        Enter: 'boostNewLineAndIndentContinueMarkdownList',
         'Ctrl-C': (cm) => {
           if (cm.getOption('keyMap').substr(0, 3) === 'vim') {
             document.execCommand('copy')

--- a/lib/main.html
+++ b/lib/main.html
@@ -78,7 +78,7 @@
   <script src="../node_modules/codemirror/keymap/emacs.js"></script>
   <script src="../node_modules/codemirror/addon/runmode/runmode.js"></script>
 
-  <script src="../node_modules/codemirror/addon/edit/continuelist.js"></script>
+  <script src="../node_modules/boost/boostNewLineIndentContinueMarkdownList.js"></script>
 
   <script src="../node_modules/codemirror/addon/edit/closebrackets.js"></script>
 

--- a/node_modules/boost/boostNewLineIndentContinueMarkdownList.js
+++ b/node_modules/boost/boostNewLineIndentContinueMarkdownList.js
@@ -13,7 +13,6 @@
         unorderedListRE = /[*+-]\s/;
 
     CodeMirror.commands.boostNewLineAndIndentContinueMarkdownList = function(cm) {
-        console.log('success');
         if (cm.getOption("disableInput")) return CodeMirror.Pass;
         var ranges = cm.listSelections(), replacements = [];
         for (var i = 0; i < ranges.length; i++) {

--- a/node_modules/boost/boostNewLineIndentContinueMarkdownList.js
+++ b/node_modules/boost/boostNewLineIndentContinueMarkdownList.js
@@ -1,0 +1,47 @@
+(function(mod) {
+    if (typeof exports == "object" && typeof module == "object") // CommonJS
+        mod(require("../codemirror/lib/codemirror"));
+    else if (typeof define == "function" && define.amd) // AMD
+        define(["../codemirror/lib/codemirror"], mod);
+    else // Plain browser env
+        mod(CodeMirror);
+})(function(CodeMirror) {
+    "use strict";
+
+    var listRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/,
+        emptyListRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/,
+        unorderedListRE = /[*+-]\s/;
+
+    CodeMirror.commands.boostNewLineAndIndentContinueMarkdownList = function(cm) {
+        console.log('success');
+        if (cm.getOption("disableInput")) return CodeMirror.Pass;
+        var ranges = cm.listSelections(), replacements = [];
+        for (var i = 0; i < ranges.length; i++) {
+            var pos = ranges[i].head;
+            var eolState = cm.getStateAfter(pos.line);
+            var inList = eolState.list !== false;
+            var inQuote = eolState.quote !== 0;
+            var line = cm.getLine(pos.line), match = listRE.exec(line);
+            if (!ranges[i].empty() || (!inList && !inQuote) || !match || pos.ch < match[2].length - 1) {
+                cm.execCommand("newlineAndIndent");
+                return;
+            }
+            if (emptyListRE.test(line)) {
+                if (!/>\s*$/.test(line)) cm.replaceRange("", {
+                    line: pos.line, ch: 0
+                }, {
+                    line: pos.line, ch: pos.ch + 1
+                });
+                replacements[i] = "\n";
+            } else {
+                var indent = match[1], after = match[5];
+                var bullet = unorderedListRE.test(match[2]) || match[2].indexOf(">") >= 0
+                    ? match[2].replace("x", " ")
+                    : (parseInt(match[3], 10) + 1) + match[4];
+                replacements[i] = "\n" + indent + bullet + after;
+            }
+        }
+
+        cm.replaceSelections(replacements);
+    };
+});


### PR DESCRIPTION
On the enter key pushed, if already the line contains a token in markdown list, no completion is needed, I think.

For example, if I push the enter key when md is like below, and my cursor selects the head of the line,
```
- [ ] a
```

the behavior before
```

- [ ] - [ ] a
```

the behavior after.
```

- [ ] a
```

By this change, node_modules/codemirror/addon/edit/continueList.js could be trashed, but I can't because of the gitignore.