### PR TITLE
Sync Split Editor scroll position

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -269,6 +269,7 @@ export default class CodeEditor extends React.Component {
     if (this.props.onScroll) {
       this.props.onScroll(e)
     }
+  }
 
   handlePasteUrl (e, editor, pastedTxt) {
     e.preventDefault()

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -47,6 +47,7 @@ export default class CodeEditor extends React.Component {
     this.loadStyleHandler = (e) => {
       this.editor.refresh()
     }
+    this.scrollHandler = _.debounce(this.handleScroll.bind(this), 100, {leading: false, trailing: true})
   }
 
   componentDidMount () {
@@ -107,6 +108,7 @@ export default class CodeEditor extends React.Component {
     this.editor.on('blur', this.blurHandler)
     this.editor.on('change', this.changeHandler)
     this.editor.on('paste', this.pasteHandler)
+    this.editor.on('scroll', this.scrollHandler)
 
     const editorTheme = document.getElementById('editorTheme')
     editorTheme.addEventListener('load', this.loadStyleHandler)
@@ -126,6 +128,7 @@ export default class CodeEditor extends React.Component {
     this.editor.off('blur', this.blurHandler)
     this.editor.off('change', this.changeHandler)
     this.editor.off('paste', this.pasteHandler)
+    this.editor.off('scroll', this.scrollHandler)
     const editorTheme = document.getElementById('editorTheme')
     editorTheme.removeEventListener('load', this.loadStyleHandler)
   }
@@ -251,6 +254,12 @@ export default class CodeEditor extends React.Component {
       fs.writeFile(imagePath, binaryData, 'binary')
       const imageMd = `![${imageName}](${path.join('/:storage', `${imageName}.png`)})`
       this.insertImageMd(imageMd)
+    }
+  }
+
+  handleScroll (e) {
+    if (this.props.onScroll) {
+      this.props.onScroll(e)
     }
   }
 

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -121,6 +121,7 @@ export default class MarkdownPreview extends React.Component {
     this.mouseDownHandler = (e) => this.handleMouseDown(e)
     this.mouseUpHandler = (e) => this.handleMouseUp(e)
     this.DoubleClickHandler = (e) => this.handleDoubleClick(e)
+    this.scrollHandler = _.debounce(this.handleScroll.bind(this), 100, {leading: false, trailing: true})
     this.anchorClickHandler = (e) => this.handlePreviewAnchorClick(e)
     this.checkboxClickHandler = (e) => this.handleCheckboxClick(e)
     this.saveAsTextHandler = () => this.handleSaveAsText()
@@ -149,6 +150,12 @@ export default class MarkdownPreview extends React.Component {
 
   handleCheckboxClick (e) {
     this.props.onCheckboxClick(e)
+  }
+
+  handleScroll (e) {
+    if (this.props.onScroll) {
+      this.props.onScroll(e)
+    }
   }
 
   handleContextMenu (e) {
@@ -279,6 +286,7 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.addEventListener('dblclick', this.DoubleClickHandler)
     this.refs.root.contentWindow.document.addEventListener('drop', this.preventImageDroppedHandler)
     this.refs.root.contentWindow.document.addEventListener('dragover', this.preventImageDroppedHandler)
+    this.refs.root.contentWindow.document.addEventListener('scroll', this.scrollHandler)
     eventEmitter.on('export:save-text', this.saveAsTextHandler)
     eventEmitter.on('export:save-md', this.saveAsMdHandler)
     eventEmitter.on('export:save-html', this.saveAsHtmlHandler)
@@ -292,6 +300,7 @@ export default class MarkdownPreview extends React.Component {
     this.refs.root.contentWindow.document.removeEventListener('dblclick', this.DoubleClickHandler)
     this.refs.root.contentWindow.document.removeEventListener('drop', this.preventImageDroppedHandler)
     this.refs.root.contentWindow.document.removeEventListener('dragover', this.preventImageDroppedHandler)
+    this.refs.root.contentWindow.document.removeEventListener('scroll', this.scrollHandler)
     eventEmitter.off('export:save-text', this.saveAsTextHandler)
     eventEmitter.off('export:save-md', this.saveAsMdHandler)
     eventEmitter.off('export:save-html', this.saveAsHtmlHandler)

--- a/browser/components/MarkdownSplitEditor.js
+++ b/browser/components/MarkdownSplitEditor.js
@@ -39,25 +39,28 @@ class MarkdownSplitEditor extends React.Component {
         targetHeight = _.get(codeDoc, 'height')
       }
 
-      const factor = srcTop / srcHeight
-      const previewTarget = targetHeight * factor
-      const distance = previewTarget - targetTop
+      const distance = (targetHeight * srcTop / srcHeight) - targetTop
+      const framerate = 1000 / 60
+      const frames = 20
+      const refractory = frames * framerate
 
       this.userScroll = false
-      const s = 20
-      let i = s
-      let f, t
+
+      let frame = 0
+      let scrollPos, time
       const timer = setInterval(() => {
-        t = (s - i) / s
-        f = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t
-        if (e.doc) _.set(previewDoc, 'body.scrollTop', targetTop + f * distance)
-        else _.get(this, 'refs.code.editor').scrollTo(0, targetTop + f * distance)
-        if (!i) {
+        time = frame / frames
+        scrollPos = time < 0.5
+                  ? 2 * time * time // ease in
+                  : -1 + (4 - 2 * time) * time // ease out
+        if (e.doc) _.set(previewDoc, 'body.scrollTop', targetTop + scrollPos * distance)
+        else _.get(this, 'refs.code.editor').scrollTo(0, targetTop + scrollPos * distance)
+        if (frame >= frames) {
           clearInterval(timer)
-          setTimeout(() => { this.userScroll = true }, 400)
+          setTimeout(() => { this.userScroll = true }, refractory)
         }
-        i -= 1
-      }, 1000 / 60)
+        frame++
+      }, framerate)
     }
   }
 


### PR DESCRIPTION
I have created a low impact delayed debounced scroll sync for the split editor.

This could probably be done better with some modules that allow queueing and animation in order to better catch missed events from rapid scrolling, but I know absolutely nothing about react, so I coded this moon-lander-style. That said, it's already infinitely better than nothing.

This would close #1355.

![scroll](https://user-images.githubusercontent.com/1702193/36056332-e7b77f18-0e03-11e8-8b22-d855a8380179.gif)