### PR TITLE
Highlight global search matches on code editor

### DIFF
--- a/browser/main/TopBar/index.js
+++ b/browser/main/TopBar/index.js
@@ -22,14 +22,18 @@ class TopBar extends React.Component {
     this.focusSearchHandler = () => {
       this.handleOnSearchFocus()
     }
+
+    this.codeInitHandler = this.handleCodeInit.bind(this)
   }
 
   componentDidMount () {
     ee.on('top:focus-search', this.focusSearchHandler)
+    ee.on('code:init', this.codeInitHandler)
   }
 
   componentWillUnmount () {
     ee.off('top:focus-search', this.focusSearchHandler)
+    ee.off('code:init', this.codeInitHandler)
   }
 
   handleKeyDown (e) {
@@ -73,14 +77,16 @@ class TopBar extends React.Component {
 
   handleSearchChange (e) {
     const { router } = this.context
+    const keyword = this.refs.searchInput.value
     if (this.state.isAlphabet || this.state.isConfirmTranslation) {
       router.push('/searched')
     } else {
       e.preventDefault()
     }
     this.setState({
-      search: this.refs.searchInput.value
+      search: keyword
     })
+    ee.emit('top:search', keyword)
   }
 
   handleSearchFocus (e) {
@@ -113,6 +119,10 @@ class TopBar extends React.Component {
     } else {
       this.refs.search.childNodes[0].focus()
     }
+  }
+
+  handleCodeInit () {
+    ee.emit('top:search', this.refs.searchInput.value)
   }
 
   render () {


### PR DESCRIPTION
I like to see the global search matches in the markdown editor for productivity reasons. I implemented this for personal use, and I hope it will be useful to others.

This partially addresses #755.

This PR makes it more evident that the global search box could really use both an "x" symbol that appears to clean/delete the current input (for touch users) or having the escape key clean the input (for keyboard users), but that is beyond the scope of this PR. See #1525.