### PR TITLE
Trashed notes should not be counted

### DIFF
--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -86,7 +86,7 @@ class SideNav extends React.Component {
             isTrashedActive={isTrashedActive}
             handleStarredButtonClick={(e) => this.handleStarredButtonClick(e)}
             handleTrashedButtonClick={(e) => this.handleTrashedButtonClick(e)}
-            counterTotalNote={data.noteMap._map.size}
+            counterTotalNote={data.noteMap._map.size - data.trashedSet._set.size}
             counterStarredNote={data.starredSet._set.size}
             counterDelNote={data.trashedSet._set.size}
           />


### PR DESCRIPTION
The selected note category count should equal the amount of notes visible in the note list. Currently, trashed notes are counted as notes, but are not visible, so the counts don't add up.

![image](https://user-images.githubusercontent.com/1702193/36052605-b01ed476-0dee-11e8-9f3f-323e7f22993b.png)

This PR fixes that.