### PR TITLE
UX: Keep selection synced with note visibility

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -109,14 +109,27 @@ class NoteList extends React.Component {
 
   componentDidUpdate (prevProps) {
     const { location } = this.props
+    const { selectedNoteKeys } = this.state
+    const visibleNoteKeys = this.notes.map(note => `${note.storage}-${note.key}`)
+    const note = this.notes[0]
+    const prevKey = prevProps.location.query.key
+    const noteKey = visibleNoteKeys.includes(prevKey) ? prevKey : note && `${note.storage}-${note.key}`
 
-    if (this.notes.length > 0 && location.query.key == null) {
+    if (note && location.query.key == null) {
       const { router } = this.context
       if (!location.pathname.match(/\/searched/)) this.contextNotes = this.getContextNotes()
+
+      // A visible note is an active note
+      if (!selectedNoteKeys.includes(noteKey)) {
+        if (selectedNoteKeys.length === 1) selectedNoteKeys.pop()
+        selectedNoteKeys.push(noteKey)
+        ee.emit('list:moved')
+      }
+
       router.replace({
         pathname: location.pathname,
         query: {
-          key: this.notes[0].storage + '-' + this.notes[0].key
+          key: noteKey
         }
       })
       return

--- a/browser/main/modals/NewNoteModal.js
+++ b/browser/main/modals/NewNoteModal.js
@@ -35,14 +35,16 @@ class NewNoteModal extends React.Component {
         content: ''
       })
       .then((note) => {
+        const noteHash = `${note.storage}-${note.key}`
         dispatch({
           type: 'UPDATE_NOTE',
           note: note
         })
         hashHistory.push({
           pathname: location.pathname,
-          query: {key: note.storage + '-' + note.key}
+          query: {key: noteHash}
         })
+        ee.emit('list:jump', noteHash)
         ee.emit('detail:focus')
         this.props.close()
       })
@@ -73,14 +75,16 @@ class NewNoteModal extends React.Component {
         }]
       })
       .then((note) => {
+        const noteHash = `${note.storage}-${note.key}`
         dispatch({
           type: 'UPDATE_NOTE',
           note: note
         })
         hashHistory.push({
           pathname: location.pathname,
-          query: {key: note.storage + '-' + note.key}
+          query: {key: noteHash}
         })
+        ee.emit('list:jump', noteHash)
         ee.emit('detail:focus')
         this.props.close()
       })


### PR DESCRIPTION
This PR fixes two UX bugs:

1. The visible note should always be selected or part of a selection.
1. When navigating from a set to a superset or vice-versa, the visible (selected) note should not change if it's part of both sets.

Previously, it was confusing to follow what's going on, because the selection and note visibility were not synced. This demonstrates the old behavior. **Play close attention to the note in view on the right, and the selection in the note list:**

![peek 2018-02-10 01-23 wrong](https://user-images.githubusercontent.com/1702193/36056151-370a28e2-0e02-11e8-95f8-784a39749523.gif)

With this PR, the selected note will remain selected as long as it's part of the subset (e.g. when searching or changing storage), and if not, when the first note is automatically viewed (old behavior) the selection will be updated to match:

![peek 2018-02-10 01-20](https://user-images.githubusercontent.com/1702193/36056181-84019fa4-0e02-11e8-9743-dcae6f7c669b.gif)
