### PR TITLE
Display filename in codeblock (resend)

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -220,6 +220,7 @@ pre
     background-color white
   &.CodeMirror
     height initial
+    flex-wrap wrap
     &>code
       flex 1
       overflow-x auto
@@ -229,6 +230,13 @@ pre
     padding 0
     border none
     border-radius 0
+  &>span.filename
+    width 100%
+    border-radius: 5px 0px 0px 0px
+    margin -8px 100% 8px -8px
+    padding 0px 6px
+    background-color #777;
+    color white
   &>span.lineNumber
     display none
     font-size 1em

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -9,10 +9,11 @@ import {lastFindInArray} from './utils'
 const katex = window.katex
 const config = ConfigManager.get()
 
-function createGutter (str) {
-  const lc = (str.match(/\n/g) || []).length
+function createGutter (str, fc) {
+  if(Number.isNaN(fc)) fc = 1
+  const lc = (str.match(/\n/g) || []).length + fc - 1
   const lines = []
-  for (let i = 1; i <= lc; i++) {
+  for (let i = fc; i <= lc; i++) {
     lines.push('<span class="CodeMirror-linenumber">' + i + '</span>')
   }
   return '<span class="lineNumber CodeMirror-gutters">' + lines.join('') + '</span>'
@@ -25,6 +26,12 @@ var md = markdownit({
   xhtmlOut: true,
   breaks: true,
   highlight: function (str, lang) {
+    let delimiter = ":";
+    let langinfo = lang.split(delimiter);
+    let lang = langinfo[0];
+    let filename = langinfo[1] || "";
+    let fc = parseInt(langinfo[2],10);
+
     if (lang === 'flowchart') {
       return `<pre class="flowchart">${str}</pre>`
     }
@@ -32,7 +39,8 @@ var md = markdownit({
       return `<pre class="sequence">${str}</pre>`
     }
     return '<pre class="code">' +
-      createGutter(str) +
+      '<span class="filename">' + filename + '</span>' +
+      createGutter(str, fc) +
       '<code class="' + lang + '">' +
       str +
       '</code></pre>'

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -9,11 +9,11 @@ import {lastFindInArray} from './utils'
 const katex = window.katex
 const config = ConfigManager.get()
 
-function createGutter (str, fc) {
-  if (Number.isNaN(fc)) fc = 1
-  const lc = (str.match(/\n/g) || []).length + fc - 1
+function createGutter (str, firstLineNumber) {
+  if (Number.isNaN(firstLineNumber)) firstLineNumber = 1
+  const lastLineNumber = (str.match(/\n/g) || []).length + firstLineNumber - 1
   const lines = []
-  for (let i = fc; i <= lc; i++) {
+  for (let i = firstLineNumber; i <= lastLineNumber; i++) {
     lines.push('<span class="CodeMirror-linenumber">' + i + '</span>')
   }
   return '<span class="lineNumber CodeMirror-gutters">' + lines.join('') + '</span>'

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -10,7 +10,7 @@ const katex = window.katex
 const config = ConfigManager.get()
 
 function createGutter (str, fc) {
-  if(Number.isNaN(fc)) fc = 1
+  if (Number.isNaN(fc)) fc = 1
   const lc = (str.match(/\n/g) || []).length + fc - 1
   const lines = []
   for (let i = fc; i <= lc; i++) {
@@ -26,22 +26,22 @@ var md = markdownit({
   xhtmlOut: true,
   breaks: true,
   highlight: function (str, lang) {
-    let delimiter = ":";
-    let langinfo = lang.split(delimiter);
-    let lang = langinfo[0];
-    let filename = langinfo[1] || "";
-    let fc = parseInt(langinfo[2],10);
+    const delimiter = ':'
+    const langInfo = lang.split(delimiter)
+    const langType = langInfo[0]
+    const fileName = langInfo[1] || ''
+    const fc = parseInt(langInfo[2], 10)
 
-    if (lang === 'flowchart') {
+    if (langType === 'flowchart') {
       return `<pre class="flowchart">${str}</pre>`
     }
-    if (lang === 'sequence') {
+    if (langType === 'sequence') {
       return `<pre class="sequence">${str}</pre>`
     }
     return '<pre class="code">' +
-      '<span class="filename">' + filename + '</span>' +
+      '<span class="filename">' + fileName + '</span>' +
       createGutter(str, fc) +
-      '<code class="' + lang + '">' +
+      '<code class="' + langType + '">' +
       str +
       '</code></pre>'
   }

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -30,7 +30,7 @@ var md = markdownit({
     const langInfo = lang.split(delimiter)
     const langType = langInfo[0]
     const fileName = langInfo[1] || ''
-    const fc = parseInt(langInfo[2], 10)
+    const firstLineNumber = parseInt(langInfo[2], 10)
 
     if (langType === 'flowchart') {
       return `<pre class="flowchart">${str}</pre>`
@@ -40,7 +40,7 @@ var md = markdownit({
     }
     return '<pre class="code">' +
       '<span class="filename">' + fileName + '</span>' +
-      createGutter(str, fc) +
+      createGutter(str, firstLineNumber) +
       '<code class="' + langType + '">' +
       str +
       '</code></pre>'


### PR DESCRIPTION
! Please reject my former pull request !

I've added a feature displaying file name in code block.
Additionally, I made it possible to define any first line number.
The notation is as follows.
<pre>
```[Language]:[File Name]:[First line number]

```
</pre>

Example:
<pre>
```html:something.html:10
&lt;body&gt;&lt;/body&gt;
```
</pre>
If you don't write file name and line number, it behaves originally.

![2018-02-10_04h34_44](https://user-images.githubusercontent.com/11771/36064847-c53a70cc-0ed4-11e8-907a-d039e1a6501d.png)
