### PR TITLE
Add tray icon with (up to) 10 last updated notes

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -109,6 +109,7 @@ class NoteList extends React.Component {
 
   componentDidUpdate (prevProps) {
     const { location } = this.props
+    ee.emitIpc('tray:update', _.sortBy(this.notes, note => new Date(note.updatedAt).getTime()).reverse().slice(0, 10))
 
     if (this.notes.length > 0 && location.query.key == null) {
       const { router } = this.context

--- a/browser/main/lib/eventEmitter.js
+++ b/browser/main/lib/eventEmitter.js
@@ -18,9 +18,14 @@ function emit (name, ...args) {
   remote.getCurrentWindow().webContents.send(name, ...args)
 }
 
+function emitIpc (name, ...args) {
+  ipcRenderer.send(name, ...args)
+}
+
 export default {
   emit,
   on,
   off,
-  once
+  once,
+  emitIpc
 }

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -1,11 +1,12 @@
 const electron = require('electron')
-const app = electron.app
-const BrowserWindow = electron.BrowserWindow
+const { app, BrowserWindow, Menu, MenuItem, Tray, ipcMain } = electron
 const path = require('path')
 const Config = require('electron-config')
 const config = new Config()
 const _ = require('lodash')
+const manifest = require('../package.json')
 
+var menu
 var showMenu = process.platform !== 'win32'
 const windowSize = config.get('windowsize') || { width: 1080, height: 720 }
 
@@ -75,6 +76,54 @@ function storeWindowSize () {
 app.on('activate', function () {
   if (mainWindow == null) return null
   mainWindow.show()
+})
+
+ipcMain.on('tray:update', function (e, notes) {
+  updateTray(notes)
+})
+
+function updateTray (notes) {
+  const menu = new Menu()
+
+  menu.append(new MenuItem({
+    label: 'Open Boostnote',
+    click: function () {
+      mainWindow.show()
+    }
+  }))
+
+  if (notes && notes.length) {
+    menu.append(new MenuItem({type: 'separator'}))
+    notes.forEach(note => {
+      menu.append(new MenuItem({
+        label: note.title,
+        click: function () {
+          mainWindow.webContents.send('list:jump', `${note.storage}-${note.key}`)
+          mainWindow.show()
+        }
+      }))
+    })
+    menu.append(new MenuItem({type: 'separator'}))
+  }
+
+  menu.append(new MenuItem({
+    label: 'Quit',
+    click: function () {
+      app.quit()
+    }
+  }))
+
+  tray.setContextMenu(menu)
+
+  return menu
+}
+
+const tray = new Tray(path.join(__dirname, '../resources/tray-icon-dark@2x.png'))
+menu = updateTray()
+tray.setToolTip(`${manifest.productName} ${manifest.version}`)
+tray.on('click', function (e) {
+  e.preventDefault()
+  tray.popUpContextMenu(menu)
 })
 
 module.exports = mainWindow


### PR DESCRIPTION
Here is a feature I'm missing from Tomboy Notes, showing the last edited items in the system tray.

![image](https://user-images.githubusercontent.com/1702193/36076970-2e721c36-0f64-11e8-9bcc-084cfc322718.png)

Personally I would like to (have the option to) hide the app from the taskbar and keep it open in the system tray when the main window is closed, so I can always access my latest notes from the tray like you do in Tomboy Notes, but this type of change is perhaps more drastic and beyond the scope of this PR.

A hook is placed in the same location as #1528 so there will be a merge conflict; please consider that PR first.