### PR TITLE
Added title attributes to elements to show information on hover --- more like a native app feel to it

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -766,16 +766,17 @@ class NoteList extends React.Component {
           <div styleName='control-sortBy'>
             <i className='fa fa-angle-down' />
             <select styleName='control-sortBy-select'
+              title='Select filter mode'
               value={config.sortBy}
               onChange={(e) => this.handleSortByChange(e)}
             >
-              <option value='UPDATED_AT'>Updated</option>
-              <option value='CREATED_AT'>Created</option>
-              <option value='ALPHABETICAL'>Alphabetically</option>
+              <option title='Sort by update time' value='UPDATED_AT'>Updated</option>
+              <option title='Sort by create time' value='CREATED_AT'>Created</option>
+              <option title='Sort alphabetically' value='ALPHABETICAL'>Alphabetically</option>
             </select>
           </div>
           <div styleName='control-button-area'>
-            <button styleName={config.listStyle === 'DEFAULT'
+            <button title='Default View' styleName={config.listStyle === 'DEFAULT'
                 ? 'control-button--active'
                 : 'control-button'
               }
@@ -783,7 +784,7 @@ class NoteList extends React.Component {
             >
               <img styleName='iconTag' src='../resources/icon/icon-column.svg' />
             </button>
-            <button styleName={config.listStyle === 'SMALL'
+            <button title='Compressed View' styleName={config.listStyle === 'SMALL'
                 ? 'control-button--active'
                 : 'control-button'
               }


### PR DESCRIPTION
This gives a more native feel to it and is more helpful to users to quickly get used to the app without clicking on the buttons:

Before commit changes (when hovering):

![defaultviewwithouthover](https://user-images.githubusercontent.com/20717348/36082685-7b63e910-0f60-11e8-81c5-be7479f409d3.png)

After commit changes (when hovering):

![defaultviewwithhover](https://user-images.githubusercontent.com/20717348/36082688-822c2dfc-0f60-11e8-923f-f96daaa63b41.png)

More examples
![comprviewwithhover](https://user-images.githubusercontent.com/20717348/36082691-86a9e022-0f60-11e8-945d-6fbf09563afb.png)
![sortbywithhover](https://user-images.githubusercontent.com/20717348/36082692-86c19938-0f60-11e8-9cc1-f64edf3a6994.png)
