### PR TITLE
Storage/folder color labelings in Side nav/Note lists

### DIFF
--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -46,51 +46,69 @@ const TagElementList = (tags) => {
  * @param {Function} handleDragStart
  * @param {string} dateDisplay
  */
-const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleNoteContextMenu, handleDragStart, pathname }) => (
-  <div styleName={isActive
+const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleNoteContextMenu, handleDragStart, pathname, storage, folder, isAllNotes }) => {
+  return (
+    <div styleName={isActive
       ? 'item--active'
       : 'item'
     }
-    key={`${note.storage}-${note.key}`}
-    onClick={e => handleNoteClick(e, `${note.storage}-${note.key}`)}
-    onContextMenu={e => handleNoteContextMenu(e, `${note.storage}-${note.key}`)}
-    onDragStart={e => handleDragStart(e, note)}
-    draggable='true'
-  >
-    <div styleName='item-wrapper'>
-      {note.type === 'SNIPPET_NOTE'
-        ? <i styleName='item-title-icon' className='fa fa-fw fa-code' />
-        : <i styleName='item-title-icon' className='fa fa-fw fa-file-text-o' />
-      }
-      <div styleName='item-title'>
-        {note.title.trim().length > 0
-          ? note.title
-          : <span styleName='item-title-empty'>Empty</span>
+      key={`${note.storage}-${note.key}`}
+      onClick={e => handleNoteClick(e, `${note.storage}-${note.key}`)}
+      onContextMenu={e => handleNoteContextMenu(e, `${note.storage}-${note.key}`)}
+      onDragStart={e => handleDragStart(e, note)}
+      draggable='true'
+    >
+      <div styleName='item-wrapper'>
+        {note.type === 'SNIPPET_NOTE'
+          ? <i styleName='item-title-icon' className='fa fa-fw fa-code' />
+          : <i styleName='item-title-icon' className='fa fa-fw fa-file-text-o' />
         }
-      </div>
-
-      <div styleName='item-bottom-time'>{dateDisplay}</div>
-      {note.isStarred
-        ? <img styleName='item-star' src='../resources/icon/icon-starred.svg' /> : ''
-      }
-      {note.isPinned && !pathname.match(/\/home|\/starred|\/trash/)
-        ? <i styleName='item-pin' className='fa fa-thumb-tack' /> : ''
-      }
-      {note.type === 'MARKDOWN_NOTE'
-        ? <TodoProcess todoStatus={getTodoStatus(note.content)} />
-        : ''
-      }
-      <div styleName='item-bottom'>
-        <div styleName='item-bottom-tagList'>
-          {note.tags.length > 0
-            ? TagElementList(note.tags)
-            : <span styleName='item-bottom-tagList-empty' />
+        <div styleName='item-title'>
+          {note.title.trim().length > 0
+            ? note.title
+            : <span styleName='item-title-empty'>Empty</span>
           }
+        </div>
+
+        <div styleName='item-middle'>
+          <div styleName='item-middle-time'>{dateDisplay}</div>
+          <div styleName='item-middle-app-meta'>
+            <div style={{ display: 'inline-block' }}>
+              <i style={{ color: !isAllNotes && folder.color, filter: 'brightness(150%)', opacity: isAllNotes && 0 }}
+                className={`fa fa-${isAllNotes ? 'folder-open-o' : 'folder-o'}`}
+              />
+              <span styleName='item-middle-app-meta-label'
+                style={{ color: isAllNotes ? storage.color : folder.color, filter: 'brightness(170%)' }}
+              >
+                {isAllNotes && storage.name}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div styleName='item-bottom'>
+          <div styleName='item-bottom-tagList'>
+            {note.tags.length > 0
+              ? TagElementList(note.tags)
+              : <span style={{ fontStyle: 'italic', opacity: 0.5 }} styleName='item-bottom-tagList-empty'>No tags</span>
+            }
+          </div>
+          <div styleName='item-bottom-reminders'>
+            {note.isStarred
+              ? <img styleName='item-star' src='../resources/icon/icon-starred.svg' /> : ''
+            }
+            {note.isPinned && !pathname.match(/\/home|\/starred|\/trash/)
+              ? <i styleName='item-pin' className='fa fa-thumb-tack' /> : ''
+            }
+            {note.type === 'MARKDOWN_NOTE'
+              ? <TodoProcess todoStatus={getTodoStatus(note.content)} />
+              : ''
+            }
+          </div>
         </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 NoteItem.propTypes = {
   isActive: PropTypes.bool.isRequired,

--- a/browser/components/NoteItem.styl
+++ b/browser/components/NoteItem.styl
@@ -117,16 +117,29 @@ $control-height = 30px
   background-color white
   color $ui-inactive-text-color
 
-.item-bottom-time
-  color $ui-inactive-text-color
+.item-bottom-reminders
+
+
+.item-middle
   font-size 13px
   padding-left 2px
   padding-bottom 2px
 
+.item-middle-time
+  color $ui-inactive-text-color
+  display inline-block
+
+.item-middle-app-meta
+  display inline-block
+  float right
+  opacity 0.8
+
+.item-middle-app-meta-label
+  color $ui-inactive-text-color
+  padding 0 3px
+
 .item-star
-  position absolute
-  right -6px
-  bottom 23px
+  position relative
   width 16px
   height 16px
   color alpha($ui-favorite-star-button-color, 60%)
@@ -135,9 +148,7 @@ $control-height = 30px
   border-radius 17px
 
 .item-pin
-  position absolute
-  right 0px
-  bottom 2px
+  position relative
   width 34px
   height 34px
   color #E54D42
@@ -192,7 +203,7 @@ body[data-theme="dark"]
       .item-bottom-tagList-item
         transition 0.15s
         background-color alpha(white, 10%)
-        color $ui-dark-text-color  
+        color $ui-dark-text-color
 
   .item-wrapper
     border-color alpha($ui-dark-button--active-backgroundColor, 60%)
@@ -266,7 +277,7 @@ body[data-theme="solarized-dark"]
       .item-bottom-tagList-item
         transition 0.15s
         background-color alpha($ui-solarized-dark-noteList-backgroundColor, 10%)
-        color $ui-solarized-dark-text-color  
+        color $ui-solarized-dark-text-color
 
   .item-wrapper
     border-color alpha($ui-solarized-dark-button--active-backgroundColor, 60%)

--- a/browser/components/NoteItemSimple.js
+++ b/browser/components/NoteItemSimple.js
@@ -14,11 +14,11 @@ import styles from './NoteItemSimple.styl'
  * @param {Function} handleNoteContextMenu
  * @param {Function} handleDragStart
  */
-const NoteItemSimple = ({ isActive, note, handleNoteClick, handleNoteContextMenu, handleDragStart, pathname }) => (
+const NoteItemSimple = ({ isActive, note, handleNoteClick, handleNoteContextMenu, handleDragStart, pathname, isAllNotes, storage, folder }) => (
   <div styleName={isActive
-      ? 'item-simple--active'
-      : 'item-simple'
-    }
+    ? 'item-simple--active'
+    : 'item-simple'
+  }
     key={`${note.storage}-${note.key}`}
     onClick={e => handleNoteClick(e, `${note.storage}-${note.key}`)}
     onContextMenu={e => handleNoteContextMenu(e, `${note.storage}-${note.key}`)}
@@ -38,6 +38,12 @@ const NoteItemSimple = ({ isActive, note, handleNoteClick, handleNoteContextMenu
         ? note.title
         : <span styleName='item-simple-title-empty'>Empty</span>
       }
+      <div styleName='item-simple-right' style={{ filter: 'brightness(210%)' }}>
+        <i style={{ color: isAllNotes ? storage.color : folder.color }} className={`fa fa-${isAllNotes ? 'folder-open-o' : 'folder-o'}`} />
+        <span style={{ color: isAllNotes ? storage.color : folder.color }} styleName='item-simple-right-storageName'>
+          {isAllNotes && storage.name}
+        </span>
+      </div>
     </div>
   </div>
 )

--- a/browser/components/NoteItemSimple.styl
+++ b/browser/components/NoteItemSimple.styl
@@ -124,7 +124,7 @@ body[data-theme="dark"]
       .item-simple-bottom-tagList-item
         transition 0.15s
         background-color alpha(white, 10%)
-        color $ui-dark-text-color  
+        color $ui-dark-text-color
 
   .item-simple--active
     border-color $ui-dark-borderColor
@@ -188,7 +188,7 @@ body[data-theme="solarized-dark"]
       .item-simple-bottom-tagList-item
         transition 0.15s
         background-color alpha(white, 10%)
-        color $ui-solarized-dark-text-color  
+        color $ui-solarized-dark-text-color
 
   .item-simple--active
     border-color $ui-solarized-dark-borderColor
@@ -207,3 +207,8 @@ body[data-theme="solarized-dark"]
       color #c0392b
       .item-simple-bottom-tagList-item
         background-color alpha(#fff, 20%)
+
+.item-simple-right
+  float right
+  .item-simple-right-storageName
+    padding-left 4px

--- a/browser/components/StorageList.js
+++ b/browser/components/StorageList.js
@@ -7,18 +7,18 @@ import styles from './StorageList.styl'
 import CSSModules from 'browser/lib/CSSModules'
 
 /**
-* @param {Array} storgaeList
+* @param {Array} storageList
 */
 
 const StorageList = ({storageList}) => (
   <div styleName='storageList'>
     {storageList.length > 0 ? storageList : (
-      <div styleName='storgaeList-empty'>No storage mount.</div>
+      <div styleName='storageList-empty'>No storage mount.</div>
     )}
   </div>
 )
 
 StorageList.propTypes = {
-  storgaeList: PropTypes.arrayOf(PropTypes.element).isRequired
+  storageList: PropTypes.arrayOf(PropTypes.element).isRequired
 }
 export default CSSModules(StorageList, styles)

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import CSSModules from 'browser/lib/CSSModules'
+import { SketchPicker } from 'react-color'
 import styles from './Main.styl'
 import { connect } from 'react-redux'
 import SideNav from './SideNav'
@@ -8,6 +9,8 @@ import TopBar from './TopBar'
 import NoteList from './NoteList'
 import Detail from './Detail'
 import dataApi from 'browser/main/lib/dataApi'
+import modal from 'browser/main/lib/modal'
+import ColorPickerModal from 'browser/main/modals/ColorPickerModal'
 import _ from 'lodash'
 import ConfigManager from 'browser/main/lib/ConfigManager'
 import mobileAnalytics from 'browser/main/lib/AwsMobileAnalyticsConfig'
@@ -40,6 +43,8 @@ class Main extends React.Component {
     }
 
     this.toggleFullScreen = () => this.handleFullScreenButton()
+    this.getColorPicker = this.getColorPicker.bind(this)
+    this.ColorPicker = this.ColorPicker.bind(this)
   }
 
   getChildContext () {
@@ -272,6 +277,18 @@ class Main extends React.Component {
     noteList.style.display = 'inline'
   }
 
+  getColorPicker (storageColor, childCallback) {
+    this.setState({ showColorPicker: true }, () => {
+      return this.ColorPicker(storageColor, function (colorObj) {
+        childCallback(colorObj.hex)
+      })
+    })
+  }
+
+  ColorPicker (color, cb) {
+    modal.open(ColorPickerModal, { color, onChangeComplete: cb }, { noOverlay: true })
+  }
+
   render () {
     const { config } = this.props
 
@@ -293,6 +310,7 @@ class Main extends React.Component {
             'location'
           ])}
           width={this.state.navWidth}
+          getColorPicker={this.getColorPicker}
         />
         {!config.isSideNavFolded &&
           <div styleName={this.state.isLeftSliderFocused ? 'slider--active' : 'slider'}

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -66,6 +66,8 @@ class NoteList extends React.Component {
     this.deleteNote = this.deleteNote.bind(this)
     this.focusNote = this.focusNote.bind(this)
     this.pinToTop = this.pinToTop.bind(this)
+    this.getNoteStorage = this.getNoteStorage.bind(this)
+    this.getNoteFolder = this.getNoteFolder.bind(this)
 
     // TODO: not Selected noteKeys but SelectedNote(for reusing)
     this.state = {
@@ -678,6 +680,19 @@ class NoteList extends React.Component {
     })
   }
 
+  getNoteStorage (note) {
+    const { data } = this.props
+    const storage = data.storageMap.toJS()[note.storage]
+    return storage
+  }
+
+  getNoteFolder (note) {
+    const { data } = this.props
+    const storage = data.storageMap.toJS()[note.storage]
+    const folder = storage.folders.find(({ key }) => key === note.folder)
+    return folder
+  }
+
   render () {
     const { location, config } = this.props
     let { notes } = this.props
@@ -732,6 +747,7 @@ class NoteList extends React.Component {
           return (
             <NoteItem
               isActive={isActive}
+              isAllNotes={location.pathname === '/home'}
               note={note}
               dateDisplay={dateDisplay}
               key={uniqueKey}
@@ -739,6 +755,8 @@ class NoteList extends React.Component {
               handleNoteClick={this.handleNoteClick.bind(this)}
               handleDragStart={this.handleDragStart.bind(this)}
               pathname={location.pathname}
+              storage={this.getNoteStorage(note)}
+              folder={this.getNoteFolder(note)}
             />
           )
         }
@@ -746,12 +764,15 @@ class NoteList extends React.Component {
         return (
           <NoteItemSimple
             isActive={isActive}
+            isAllNotes={location.pathname === '/home'}
             note={note}
             key={uniqueKey}
             handleNoteContextMenu={this.handleNoteContextMenu.bind(this)}
             handleNoteClick={this.handleNoteClick.bind(this)}
             handleDragStart={this.handleDragStart.bind(this)}
             pathname={location.pathname}
+            storage={this.getNoteStorage(note)}
+            folder={this.getNoteFolder(note)}
           />
         )
       })

--- a/browser/main/SideNav/StorageItem.js
+++ b/browser/main/SideNav/StorageItem.js
@@ -18,8 +18,10 @@ class StorageItem extends React.Component {
     super(props)
 
     this.state = {
-      isOpen: true
+      isOpen: true,
+      color: props.storage.color
     }
+    this.handleStorageColorChosen = this.handleStorageColorChosen.bind(this)
   }
 
   handleHeaderContextMenu (e) {
@@ -75,6 +77,18 @@ class StorageItem extends React.Component {
     modal.open(CreateFolderModal, {
       storage
     })
+  }
+
+  handleStorageColorChosen (color) {
+    const { storage } = this.props
+    dataApi.changeStorageColor(storage.key, color)
+      .then((newStorage) => {
+        return this.setState({ color: newStorage.color })
+      })
+      .catch((err) => {
+        console.error(err)
+        return this.setState({ showColorPicker: false })
+      })
   }
 
   handleHeaderInfoClick (e) {
@@ -234,7 +248,7 @@ class StorageItem extends React.Component {
   }
 
   render () {
-    const { storage, location, isFolded, data, dispatch } = this.props
+    const { storage, location, isFolded, data, dispatch, getColorPicker } = this.props
     const { folderNoteMap, trashedSet } = data
     const folderList = storage.folders.map((folder) => {
       const isActive = !!(location.pathname.match(new RegExp('\/storages\/' + storage.key + '\/folders\/' + folder.key)))
@@ -272,10 +286,8 @@ class StorageItem extends React.Component {
       <div styleName={isFolded ? 'root--folded' : 'root'}
         key={storage.key}
       >
-        <div styleName={isActive
-            ? 'header--active'
-            : 'header'
-          }
+        <div styleName='header'
+          style={{ backgroundColor: this.state.color }}
           onContextMenu={(e) => this.handleHeaderContextMenu(e)}
         >
           <button styleName='header-toggleButton'
@@ -284,7 +296,7 @@ class StorageItem extends React.Component {
             <img src={this.state.isOpen
               ? '../resources/icon/icon-down.svg'
               : '../resources/icon/icon-right.svg'
-              }
+            }
             />
           </button>
 
@@ -296,10 +308,17 @@ class StorageItem extends React.Component {
             </button>
           }
 
+          {!isFolded &&
+            <button title='Apply color to storage label' styleName='header-applyStorageColorButton'
+              onClick={() => getColorPicker(this.state.color, this.handleStorageColorChosen)}>
+              <i className='fa fa-paint-brush' />
+            </button>
+          }
+
           <button styleName='header-info'
             onClick={(e) => this.handleHeaderInfoClick(e)}
           >
-            <span styleName='header-info-name'>
+            <span styleName='header-info-name' style={{ color: this.state.color && 'white' }}>
               {isFolded ? _.truncate(storage.name, {length: 1, omission: ''}) : storage.name}
             </span>
             {isFolded &&
@@ -320,7 +339,8 @@ class StorageItem extends React.Component {
 }
 
 StorageItem.propTypes = {
-  isFolded: PropTypes.bool
+  isFolded: PropTypes.bool,
+  colorPicker: PropTypes.func
 }
 
 export default CSSModules(StorageItem, styles)

--- a/browser/main/SideNav/StorageItem.styl
+++ b/browser/main/SideNav/StorageItem.styl
@@ -12,17 +12,6 @@
   display flex
   align-items center
 
-.header--active
-  margin-bottom 5px
-  background-color alpha($ui-button-default--active-backgroundColor, 20%)
-  transition color background-color  0.15s
-  display flex
-  align-items center
-  .header-toggleButton
-  .header-info
-  .header-addFolderButton
-    color #1EC38B
-
 .header-toggleButton
   navButtonColor()
   position absolute
@@ -34,7 +23,6 @@
   border-radius 50%
   &:hover
     transition 0.2s
-    background-color alpha($ui-button-default--hover-backgroundColor, 40%)
     color $ui-text-color
 
 .header-info
@@ -76,6 +64,18 @@
   &:hover
     transition 0.2s
 
+.header-applyStorageColorButton
+  navButtonColor()
+  position absolute
+  right 26px
+  width 25px
+  height 25px
+  padding 0
+  border none
+  border-radius 50%
+  &:hover
+    transition 0.2s
+
 .root--folded
   @extend .root
   .header
@@ -107,7 +107,6 @@
 
 body[data-theme="white"]
   .header--active
-    background-color $ui-button--active-backgroundColor
     transition color background-color  0.15s
     .header-toggleButton
       color $ui-text-color
@@ -134,7 +133,6 @@ body[data-theme="white"]
 
 body[data-theme="dark"]
   .header--active
-    background-color $ui-dark-button--active-backgroundColor
     transition color background-color  0.15s
 
   .header--active
@@ -147,7 +145,7 @@ body[data-theme="dark"]
       background-color $ui-dark-button--active-backgroundColor
       &:active
         color $ui-dark-text-color
-        background-color $ui-dark-button--active-backgroundColor  
+        background-color $ui-dark-button--active-backgroundColor
 
   .header--active
     .header-addFolderButton
@@ -180,7 +178,3 @@ body[data-theme="dark"]
     &:active, &:active:hover
       color $ui-dark-text-color
       background-color $ui-dark-button--active-backgroundColor
-      
-
-
-

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -140,19 +140,22 @@ class SideNav extends React.Component {
   }
 
   render () {
-    const { data, location, config, dispatch } = this.props
+    const { data, location, config, dispatch, getColorPicker } = this.props
 
     const isFolded = config.isSideNavFolded
 
     const storageList = data.storageMap.map((storage, key) => {
-      return <StorageItem
-        key={storage.key}
-        storage={storage}
-        data={data}
-        location={location}
-        isFolded={isFolded}
-        dispatch={dispatch}
-      />
+      return (
+        <StorageItem
+          key={storage.key}
+          storage={storage}
+          data={data}
+          location={location}
+          isFolded={isFolded}
+          dispatch={dispatch}
+          getColorPicker={getColorPicker}
+        />
+      )
     })
     const style = {}
     if (!isFolded) style.width = this.props.width

--- a/browser/main/lib/dataApi/addStorage.js
+++ b/browser/main/lib/dataApi/addStorage.js
@@ -37,7 +37,8 @@ function addStorage (input) {
     key,
     name: input.name,
     type: input.type,
-    path: input.path
+    path: input.path,
+    color: input.color
   }
 
   return Promise.resolve(newStorage)
@@ -48,7 +49,8 @@ function addStorage (input) {
         key: newStorage.key,
         type: newStorage.type,
         name: newStorage.name,
-        path: newStorage.path
+        path: newStorage.path,
+        color: newStorage.color
       })
 
       localStorage.setItem('storages', JSON.stringify(rawStorages))

--- a/browser/main/lib/dataApi/changeStorageColor.js
+++ b/browser/main/lib/dataApi/changeStorageColor.js
@@ -1,0 +1,29 @@
+const _ = require('lodash')
+const resolveStorageData = require('./resolveStorageData')
+
+/**
+ * @param {String} key
+ * @param {String} color
+ * @return {Object} Storage meta data
+ */
+function changeStorageColor (key, color) {
+  if (!_.isString(color)) return Promise.reject(new Error('The storage color cannot be applied'))
+
+  let cachedStorageList
+  try {
+    cachedStorageList = JSON.parse(localStorage.getItem('storages'))
+    if (!_.isArray(cachedStorageList)) throw new Error('invalid storages')
+  } catch (err) {
+    console.error(err)
+    return Promise.reject(err)
+  }
+  const targetStorage = _.find(cachedStorageList, {key: key})
+  if (targetStorage == null) return Promise.reject('The storage was not found')
+
+  targetStorage.color = color
+  localStorage.setItem('storages', JSON.stringify(cachedStorageList))
+
+  return resolveStorageData(targetStorage)
+}
+
+module.exports = changeStorageColor

--- a/browser/main/lib/dataApi/index.js
+++ b/browser/main/lib/dataApi/index.js
@@ -3,6 +3,7 @@ const dataApi = {
   addStorage: require('./addStorage'),
   renameStorage: require('./renameStorage'),
   removeStorage: require('./removeStorage'),
+  changeStorageColor: require('./changeStorageColor'),
   createFolder: require('./createFolder'),
   updateFolder: require('./updateFolder'),
   deleteFolder: require('./deleteFolder'),

--- a/browser/main/lib/dataApi/resolveStorageData.js
+++ b/browser/main/lib/dataApi/resolveStorageData.js
@@ -8,7 +8,8 @@ function resolveStorageData (storageCache) {
     key: storageCache.key,
     name: storageCache.name,
     type: storageCache.type,
-    path: storageCache.path
+    path: storageCache.path,
+    color: storageCache.color
   }
 
   const boostnoteJSONPath = path.join(storageCache.path, 'boostnote.json')

--- a/browser/main/lib/modal.js
+++ b/browser/main/lib/modal.js
@@ -9,7 +9,10 @@ class ModalBase extends React.Component {
     this.state = {
       component: null,
       componentProps: {},
-      isHidden: true
+      isHidden: true,
+      config: {
+        noOverlay: false
+      }
     }
   }
 
@@ -22,7 +25,7 @@ class ModalBase extends React.Component {
 
   render () {
     return (
-      <div className={'ModalBase' + (this.state.isHidden ? ' hide' : '')}>
+      <div className={!this.state.config.noOverlay && 'ModalBase' + (this.state.isHidden ? ' hide' : '')}>
         <div onClick={(e) => this.close(e)} className='modalBack' />
         {this.state.component == null ? null : (
           <Provider store={store}>
@@ -38,13 +41,13 @@ const el = document.createElement('div')
 document.body.appendChild(el)
 const modalBase = ReactDOM.render(<ModalBase />, el)
 
-export function openModal (component, props) {
+export function openModal (component, props, config) {
   if (modalBase == null) { return }
   // Hide scrollbar by removing overflow when modal opens
   const list = document.querySelector('.NoteList__list___browser-main-NoteList-')
   list.style.overflow = 'hidden'
   document.body.setAttribute('data-modal', 'open')
-  modalBase.setState({component: component, componentProps: props, isHidden: false})
+  modalBase.setState({component: component, componentProps: props, isHidden: false, config: Object.assign({}, config)})
 }
 
 export function closeModal () {

--- a/browser/main/modals/ColorPickerModal.js
+++ b/browser/main/modals/ColorPickerModal.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import CSSModules from 'browser/lib/CSSModules'
+import styles from './ColorPickerModal.styl'
+import { SketchPicker } from 'react-color'
+
+class ColorPickerModal extends React.Component {
+  handleCloseButtonClick (e) {
+    this.props.close()
+  }
+  render () {
+    const colorPickerProps = {
+      color: this.props.color,
+      onChangeComplete: (colorObj) => {
+        this.props.onChangeComplete(colorObj)
+        this.props.close()
+      }
+    }
+    // TODO: make a function that grabs caller element's position and render next to it
+    return (
+      <div styleName='colorPicker-wrapper'>
+        <SketchPicker {...colorPickerProps} />
+      </div>
+    )
+  }
+}
+
+ColorPickerModal.propTypes = {
+}
+
+export default CSSModules(ColorPickerModal, styles)

--- a/browser/main/modals/ColorPickerModal.styl
+++ b/browser/main/modals/ColorPickerModal.styl
@@ -1,0 +1,29 @@
+.root
+  modal()
+  max-width 540px
+  overflow hidden
+  position relative
+
+.header
+  height 50px
+  font-size 18px
+  line-height 50px
+  padding 0 15px
+  color $ui-text-color
+  margin-bottom 20px
+
+.colorPicker-wrapper
+  position relative
+  display inline-block
+
+.title
+  font-size 36px
+  font-weight 600
+
+body[data-theme="dark"]
+  .header
+    color $ui-dark-text-color
+
+body[data-theme="solarized-dark"]
+  .header
+    color $ui-solarized-dark-text-color


### PR DESCRIPTION
References #1545 

Features:
1.  In the "All Notes" default view, each note item in the note list now shows their storage label in color
2. If you go to compressed view it also shows the same thing to the right
3. You are now able to customize a color given to a storage of your choice in the side navigation by clicking the color picker button (next to the + icon) --- choosing a color updates the newly added "color" key in the storage's data storage
4. Added third option for the modal---maybe we can use that to customize the modal in some ways (I used it here to disable the background when the color picker comes up)
5. Color coded folder icons show in the nav list when in storage list view

#### **This is not complete yet** but I wanted to just create a pull request and leave it here while I receive feedback or some suggestions / re-do's etc and continue developing this feature

Does anyone like where this is going or is this something that is totally not ideal to the app?
Some notable things are the modal component (I added in a 3rd prop to the ModalBase component so it now has a configuration to config the modal on the fly on load---maybe we can use that for some interesting things in future developments), the color picker modal (I had to make a separate component as a modal (ColorPickerModal) so that it gets re-used. My first approach kept making duplicate color pickers so I had to move it all the way up front to the Main component---I ended up liking this idea because now the Main component can share the one color picker to the entire component tree as well as the re-usable getColorPicker func to pass around everywhere (look at Main on methods getColorPicker() and ColorPicker())

Todos: 

- [ ] Auto refresh nav list on color change
- [ ] Render color picker next to the cursor
- [ ] Do cooler things

![storagecolorization](https://user-images.githubusercontent.com/20717348/36348853-93474532-142d-11e8-9634-7d728eea821a.gif)
