### PR TITLE
Add storage labels to 'All Notes' and figure a better solution to the dull storage notes list view

### DIFF
--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -48,14 +48,15 @@ const TagElementList = (tags) => {
  */
 const NoteItem = ({
   isActive,
-  isAllNotesView,
   note,
   dateDisplay,
   handleNoteClick,
   handleNoteContextMenu,
   handleDragStart,
   pathname,
-  storage
+  storageName,
+  folderName,
+  viewType
 }) => (
   <div styleName={isActive
     ? 'item--active'
@@ -78,12 +79,13 @@ const NoteItem = ({
           : <span styleName='item-title-empty'>Empty</span>
         }
       </div>
-      {isAllNotesView && <div styleName='item-middle'>
+      {['ALL', 'STORAGE'].includes(viewType) && <div styleName='item-middle'>
         <div styleName='item-middle-time'>{dateDisplay}</div>
         <div styleName='item-middle-app-meta'>
           <div style={{display: 'inline-block'}}>
             <span styleName='item-middle-app-meta-label'>
-              {storage.name}
+              {viewType === 'ALL' && storageName}
+              {viewType === 'STORAGE' && folderName}
             </span>
           </div>
         </div>

--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -46,11 +46,21 @@ const TagElementList = (tags) => {
  * @param {Function} handleDragStart
  * @param {string} dateDisplay
  */
-const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleNoteContextMenu, handleDragStart, pathname }) => (
+const NoteItem = ({
+  isActive,
+  isAllNotesView,
+  note,
+  dateDisplay,
+  handleNoteClick,
+  handleNoteContextMenu,
+  handleDragStart,
+  pathname,
+  storage
+}) => (
   <div styleName={isActive
-      ? 'item--active'
-      : 'item'
-    }
+    ? 'item--active'
+    : 'item'
+  }
     key={`${note.storage}-${note.key}`}
     onClick={e => handleNoteClick(e, `${note.storage}-${note.key}`)}
     onContextMenu={e => handleNoteContextMenu(e, `${note.storage}-${note.key}`)}
@@ -68,23 +78,34 @@ const NoteItem = ({ isActive, note, dateDisplay, handleNoteClick, handleNoteCont
           : <span styleName='item-title-empty'>Empty</span>
         }
       </div>
+      {isAllNotesView && <div styleName='item-middle'>
+        <div styleName='item-middle-time'>{dateDisplay}</div>
+        <div styleName='item-middle-app-meta'>
+          <div style={{display: 'inline-block'}}>
+            <span styleName='item-middle-app-meta-label'>
+              {storage.name}
+            </span>
+          </div>
+        </div>
+      </div>}
 
-      <div styleName='item-bottom-time'>{dateDisplay}</div>
-      {note.isStarred
-        ? <img styleName='item-star' src='../resources/icon/icon-starred.svg' /> : ''
-      }
-      {note.isPinned && !pathname.match(/\/starred|\/trash/)
-        ? <i styleName='item-pin' className='fa fa-thumb-tack' /> : ''
-      }
-      {note.type === 'MARKDOWN_NOTE'
-        ? <TodoProcess todoStatus={getTodoStatus(note.content)} />
-        : ''
-      }
       <div styleName='item-bottom'>
         <div styleName='item-bottom-tagList'>
           {note.tags.length > 0
             ? TagElementList(note.tags)
-            : <span styleName='item-bottom-tagList-empty' />
+            : <span style={{ fontStyle: 'italic', opacity: 0.5 }} styleName='item-bottom-tagList-empty'>No tags</span>
+          }
+        </div>
+        <div>
+          {note.isStarred
+            ? <img styleName='item-star' src='../resources/icon/icon-starred.svg' /> : ''
+          }
+          {note.isPinned && !pathname.match(/\/home|\/starred|\/trash/)
+            ? <i styleName='item-pin' className='fa fa-thumb-tack' /> : ''
+          }
+          {note.type === 'MARKDOWN_NOTE'
+            ? <TodoProcess todoStatus={getTodoStatus(note.content)} />
+            : ''
           }
         </div>
       </div>

--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -82,11 +82,9 @@ const NoteItem = ({
       {['ALL', 'STORAGE'].includes(viewType) && <div styleName='item-middle'>
         <div styleName='item-middle-time'>{dateDisplay}</div>
         <div styleName='item-middle-app-meta'>
-          <div style={{display: 'inline-block'}}>
-            <span styleName='item-middle-app-meta-label'>
-              {viewType === 'ALL' && storageName}
-              {viewType === 'STORAGE' && folderName}
-            </span>
+          <div title={viewType === 'ALL' ? storageName : viewType === 'STORAGE' ? folderName : null} styleName='item-middle-app-meta-label'>
+            {viewType === 'ALL' && storageName}
+            {viewType === 'STORAGE' && folderName}
           </div>
         </div>
       </div>}

--- a/browser/components/NoteItem.styl
+++ b/browser/components/NoteItem.styl
@@ -90,6 +90,25 @@ $control-height = 30px
   font-weight normal
   color $ui-inactive-text-color
 
+.item-middle
+  font-size 13px
+  padding-left 2px
+  padding-bottom 2px
+
+.item-middle-time
+  color $ui-inactive-text-color
+  display inline-block
+
+.item-middle-app-meta
+  display inline-block
+  float right
+  opacity 0.8
+
+.item-middle-app-meta-label
+  color $ui-inactive-text-color
+  opacity 0.6
+  padding 0 3px
+
 .item-bottom
   position relative
   bottom 0px
@@ -124,9 +143,7 @@ $control-height = 30px
   padding-bottom 2px
 
 .item-star
-  position absolute
-  right -6px
-  bottom 23px
+  position relative
   width 16px
   height 16px
   color alpha($ui-favorite-star-button-color, 60%)
@@ -135,9 +152,7 @@ $control-height = 30px
   border-radius 17px
 
 .item-pin
-  position absolute
-  right 0px
-  bottom 2px
+  position relative
   width 34px
   height 34px
   color #E54D42
@@ -192,7 +207,7 @@ body[data-theme="dark"]
       .item-bottom-tagList-item
         transition 0.15s
         background-color alpha(white, 10%)
-        color $ui-dark-text-color  
+        color $ui-dark-text-color
 
   .item-wrapper
     border-color alpha($ui-dark-button--active-backgroundColor, 60%)
@@ -266,7 +281,7 @@ body[data-theme="solarized-dark"]
       .item-bottom-tagList-item
         transition 0.15s
         background-color alpha($ui-solarized-dark-noteList-backgroundColor, 10%)
-        color $ui-solarized-dark-text-color  
+        color $ui-solarized-dark-text-color
 
   .item-wrapper
     border-color alpha($ui-solarized-dark-button--active-backgroundColor, 60%)

--- a/browser/components/NoteItem.styl
+++ b/browser/components/NoteItem.styl
@@ -100,14 +100,15 @@ $control-height = 30px
   display inline-block
 
 .item-middle-app-meta
-  display inline-block
   float right
-  opacity 0.8
-
-.item-middle-app-meta-label
-  color $ui-inactive-text-color
-  opacity 0.6
-  padding 0 3px
+  .item-middle-app-meta-label
+    opacity 0.4
+    color $ui-inactive-text-color
+    padding 0 3px
+    white-space nowrap
+    text-overflow ellipsis
+    overflow hidden
+    max-width 200px
 
 .item-bottom
   position relative

--- a/browser/components/NoteItemSimple.js
+++ b/browser/components/NoteItemSimple.js
@@ -14,11 +14,20 @@ import styles from './NoteItemSimple.styl'
  * @param {Function} handleNoteContextMenu
  * @param {Function} handleDragStart
  */
-const NoteItemSimple = ({ isActive, note, handleNoteClick, handleNoteContextMenu, handleDragStart, pathname }) => (
+const NoteItemSimple = ({
+  isActive,
+  isAllNotesView,
+  note,
+  handleNoteClick,
+  handleNoteContextMenu,
+  handleDragStart,
+  pathname,
+  storage
+}) => (
   <div styleName={isActive
-      ? 'item-simple--active'
-      : 'item-simple'
-    }
+    ? 'item-simple--active'
+    : 'item-simple'
+  }
     key={`${note.storage}-${note.key}`}
     onClick={e => handleNoteClick(e, `${note.storage}-${note.key}`)}
     onContextMenu={e => handleNoteContextMenu(e, `${note.storage}-${note.key}`)}
@@ -38,6 +47,11 @@ const NoteItemSimple = ({ isActive, note, handleNoteClick, handleNoteContextMenu
         ? note.title
         : <span styleName='item-simple-title-empty'>Empty</span>
       }
+      {isAllNotesView && <div styleName='item-simple-right'>
+        <span styleName='item-simple-right-storageName'>
+          {storage.name}
+        </span>
+      </div>}
     </div>
   </div>
 )

--- a/browser/components/NoteItemSimple.styl
+++ b/browser/components/NoteItemSimple.styl
@@ -124,7 +124,7 @@ body[data-theme="dark"]
       .item-simple-bottom-tagList-item
         transition 0.15s
         background-color alpha(white, 10%)
-        color $ui-dark-text-color  
+        color $ui-dark-text-color
 
   .item-simple--active
     border-color $ui-dark-borderColor
@@ -188,7 +188,7 @@ body[data-theme="solarized-dark"]
       .item-simple-bottom-tagList-item
         transition 0.15s
         background-color alpha(white, 10%)
-        color $ui-solarized-dark-text-color  
+        color $ui-solarized-dark-text-color
 
   .item-simple--active
     border-color $ui-solarized-dark-borderColor
@@ -207,3 +207,8 @@ body[data-theme="solarized-dark"]
       color #c0392b
       .item-simple-bottom-tagList-item
         background-color alpha(#fff, 20%)
+.item-simple-right
+  float right
+  .item-simple-right-storageName
+    padding-left 4px
+    opacity 0.4

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -66,6 +66,7 @@ class NoteList extends React.Component {
     this.deleteNote = this.deleteNote.bind(this)
     this.focusNote = this.focusNote.bind(this)
     this.pinToTop = this.pinToTop.bind(this)
+    this.getNoteStorage = this.getNoteStorage.bind(this)
 
     // TODO: not Selected noteKeys but SelectedNote(for reusing)
     this.state = {
@@ -691,6 +692,10 @@ class NoteList extends React.Component {
     })
   }
 
+  getNoteStorage (note) { // note.storage = storage key
+    return this.props.data.storageMap.toJS()[note.storage]
+  }
+
   render () {
     const { location, config } = this.props
     let { notes } = this.props
@@ -745,6 +750,7 @@ class NoteList extends React.Component {
           return (
             <NoteItem
               isActive={isActive}
+              isAllNotesView={location.pathname === '/home'}
               note={note}
               dateDisplay={dateDisplay}
               key={uniqueKey}
@@ -752,6 +758,7 @@ class NoteList extends React.Component {
               handleNoteClick={this.handleNoteClick.bind(this)}
               handleDragStart={this.handleDragStart.bind(this)}
               pathname={location.pathname}
+              storage={this.getNoteStorage(note)}
             />
           )
         }
@@ -759,12 +766,14 @@ class NoteList extends React.Component {
         return (
           <NoteItemSimple
             isActive={isActive}
+            isAllNotesView={location.pathname === '/home'}
             note={note}
             key={uniqueKey}
             handleNoteContextMenu={this.handleNoteContextMenu.bind(this)}
             handleNoteClick={this.handleNoteClick.bind(this)}
             handleDragStart={this.handleDragStart.bind(this)}
             pathname={location.pathname}
+            storage={this.getNoteStorage(note)}
           />
         )
       })

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -67,6 +67,8 @@ class NoteList extends React.Component {
     this.focusNote = this.focusNote.bind(this)
     this.pinToTop = this.pinToTop.bind(this)
     this.getNoteStorage = this.getNoteStorage.bind(this)
+    this.getNoteFolder = this.getNoteFolder.bind(this)
+    this.getViewType = this.getViewType.bind(this)
 
     // TODO: not Selected noteKeys but SelectedNote(for reusing)
     this.state = {
@@ -696,6 +698,20 @@ class NoteList extends React.Component {
     return this.props.data.storageMap.toJS()[note.storage]
   }
 
+  getNoteFolder (note) { // note.folder = folder key
+    return _.find(this.getNoteStorage(note).folders, ({ key }) => key === note.folder)
+  }
+
+  getViewType () {
+    const { pathname } = this.props.location
+    const folder = /\/folders\/[a-zA-Z0-9]+/.test(pathname)
+    const storage = /\/storages\/[a-zA-Z0-9]+/.test(pathname) && !folder
+    const allNotes = pathname === '/home'
+    if (allNotes) return 'ALL'
+    if (folder) return 'FOLDER'
+    if (storage) return 'STORAGE'
+  }
+
   render () {
     const { location, config } = this.props
     let { notes } = this.props
@@ -750,7 +766,6 @@ class NoteList extends React.Component {
           return (
             <NoteItem
               isActive={isActive}
-              isAllNotesView={location.pathname === '/home'}
               note={note}
               dateDisplay={dateDisplay}
               key={uniqueKey}
@@ -758,7 +773,9 @@ class NoteList extends React.Component {
               handleNoteClick={this.handleNoteClick.bind(this)}
               handleDragStart={this.handleDragStart.bind(this)}
               pathname={location.pathname}
-              storage={this.getNoteStorage(note)}
+              folderName={this.getNoteFolder(note).name}
+              storageName={this.getNoteStorage(note).name}
+              viewType={this.getViewType()}
             />
           )
         }
@@ -766,14 +783,15 @@ class NoteList extends React.Component {
         return (
           <NoteItemSimple
             isActive={isActive}
-            isAllNotesView={location.pathname === '/home'}
             note={note}
             key={uniqueKey}
             handleNoteContextMenu={this.handleNoteContextMenu.bind(this)}
             handleNoteClick={this.handleNoteClick.bind(this)}
             handleDragStart={this.handleDragStart.bind(this)}
             pathname={location.pathname}
-            storage={this.getNoteStorage(note)}
+            folderName={this.getNoteFolder(note).name}
+            storageName={this.getNoteStorage(note).name}
+            viewType={this.getViewType()}
           />
         )
       })

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -780,6 +780,8 @@ class NoteList extends React.Component {
       }
     })
 
+    const viewType = this.getViewType()
+
     const noteList = notes
       .map(note => {
         if (note == null) {
@@ -807,7 +809,7 @@ class NoteList extends React.Component {
               pathname={location.pathname}
               folderName={this.getNoteFolder(note).name}
               storageName={this.getNoteStorage(note).name}
-              viewType={this.getViewType()}
+              viewType={viewType}
             />
           )
         }
@@ -823,7 +825,7 @@ class NoteList extends React.Component {
             pathname={location.pathname}
             folderName={this.getNoteFolder(note).name}
             storageName={this.getNoteStorage(note).name}
-            viewType={this.getViewType()}
+            viewType={viewType}
           />
         )
       })


### PR DESCRIPTION
### Edit 02/20/2018 : Will progress this pull request fully this coming weekend (Fri/sat/sun) for sure
#### Edit 02/19/2018: I think I am going to also proceed to the storage view and implement some color labeling to storage view. So this pull request isn't finished yet

Added storage labelings to 'All Notes' (this serves as a starting point for building the rest of #1545)

Works for:
- Default view
- Compressed view

Previously when we were viewing notes in the All Notes view, we could not tell which storage the notes came from. This was confusing to the user. So we need a way to show to the user which storage the notes are in. This pull request provides storage labels to solve that as shown in the screenshot below

This is a re-make in reference to #1551 and originated from #1545  without any color integration implemented, with the purpose of serving as a starting point

I re-made the pull request to make this more simple because the previous pull request had unrelated changes (it barged into the folder labelings when this was originated for storage labelings)

I tried to keep it as simple as possible, without breaking any code. 

Screenshot:

![storagecolorization](https://user-images.githubusercontent.com/20717348/36392267-4311b042-155f-11e8-9ed6-f54fc3bb5969.gif)

## TODOS:

- [x] Handle long folder titles in the storage view
