### PR TITLE
Added option Empty Trash

### DIFF
--- a/browser/components/SideNavFilter.js
+++ b/browser/components/SideNavFilter.js
@@ -17,7 +17,7 @@ import styles from './SideNavFilter.styl'
 const SideNavFilter = ({
   isFolded, isHomeActive, handleAllNotesButtonClick,
   isStarredActive, handleStarredButtonClick, isTrashedActive, handleTrashedButtonClick, counterDelNote,
-  counterTotalNote, counterStarredNote
+  counterTotalNote, counterStarredNote, handleFilterButtonContextMenu
 }) => (
   <div styleName={isFolded ? 'menu--folded' : 'menu'}>
 
@@ -26,9 +26,9 @@ const SideNavFilter = ({
     >
       <div styleName='iconWrap'>
         <img src={isHomeActive
-            ? '../resources/icon/icon-all-active.svg'
-            : '../resources/icon/icon-all.svg'
-          }
+          ? '../resources/icon/icon-all-active.svg'
+          : '../resources/icon/icon-all.svg'
+        }
         />
       </div>
       <span styleName='menu-button-label'>All Notes</span>
@@ -40,9 +40,9 @@ const SideNavFilter = ({
     >
       <div styleName='iconWrap'>
         <img src={isStarredActive
-            ? '../resources/icon/icon-star-active.svg'
-            : '../resources/icon/icon-star-sidenav.svg'
-          }
+          ? '../resources/icon/icon-star-active.svg'
+          : '../resources/icon/icon-star-sidenav.svg'
+        }
         />
       </div>
       <span styleName='menu-button-label'>Starred</span>
@@ -54,12 +54,12 @@ const SideNavFilter = ({
     >
       <div styleName='iconWrap'>
         <img src={isTrashedActive
-            ? '../resources/icon/icon-trash-active.svg'
-            : '../resources/icon/icon-trash-sidenav.svg'
-          }
+          ? '../resources/icon/icon-trash-active.svg'
+          : '../resources/icon/icon-trash-sidenav.svg'
+        }
         />
       </div>
-      <span styleName='menu-button-label'>Trash</span>
+      <span onContextMenu={handleFilterButtonContextMenu} styleName='menu-button-label'>Trash</span>
       <span styleName='counters'>{counterDelNote}</span>
     </button>
 

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import CSSModules from 'browser/lib/CSSModules'
+const { remote } = require('electron')
+const { Menu } = remote
+import dataApi from 'browser/main/lib/dataApi'
 import styles from './SideNav.styl'
 import { openModal } from 'browser/main/lib/modal'
 import PreferencesModal from '../modals/PreferencesModal'
@@ -89,6 +92,7 @@ class SideNav extends React.Component {
             counterTotalNote={data.noteMap._map.size - data.trashedSet._set.size}
             counterStarredNote={data.starredSet._set.size}
             counterDelNote={data.trashedSet._set.size}
+            handleFilterButtonContextMenu={this.handleFilterButtonContextMenu.bind(this)}
           />
 
           <StorageList storageList={storageList} />
@@ -137,6 +141,36 @@ class SideNav extends React.Component {
   handleClickTagListItem (name) {
     const { router } = this.context
     router.push(`/tags/${name}`)
+  }
+
+  emptyTrash (entries) {
+    const { dispatch } = this.props
+    const deletionPromises = entries.map((storageAndNoteKey) => {
+      const storageKey = storageAndNoteKey.split('-')[0]
+      const noteKey = storageAndNoteKey.split('-')[1]
+      return dataApi.deleteNote(storageKey, noteKey)
+    })
+    Promise.all(deletionPromises)
+    .then((arrayOfStorageAndNoteKeys) => {
+      arrayOfStorageAndNoteKeys.forEach(({ storageKey, noteKey }) => {
+        dispatch({ type: 'DELETE_NOTE', storageKey, noteKey })
+      })
+    })
+    .catch((err) => {
+      console.error('Cannot Delete note: ' + err)
+    })
+    console.log('Trash emptied')
+  }
+
+  handleFilterButtonContextMenu (event) {
+    const { location, data } = this.props
+    if (location.pathname === '/trashed') {
+      const entries = data.trashedSet.toJS()
+      const menu = Menu.buildFromTemplate([
+        { label: 'Empty Trash', click: () => this.emptyTrash(entries) }
+      ])
+      menu.popup()
+    }
   }
 
   render () {

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -163,14 +163,12 @@ class SideNav extends React.Component {
   }
 
   handleFilterButtonContextMenu (event) {
-    const { location, data } = this.props
-    if (location.pathname === '/trashed') {
-      const entries = data.trashedSet.toJS()
-      const menu = Menu.buildFromTemplate([
-        { label: 'Empty Trash', click: () => this.emptyTrash(entries) }
-      ])
-      menu.popup()
-    }
+    const { data } = this.props
+    const entries = data.trashedSet.toJS()
+    const menu = Menu.buildFromTemplate([
+      { label: 'Empty Trash', click: () => this.emptyTrash(entries) }
+    ])
+    menu.popup()
   }
 
   render () {


### PR DESCRIPTION
Feature request from #1555 

I was contemplating to add a window to allow the user to "confirm" the deletion, but I think that wouldn't be needed since the user already technically "confirmed" that decision when deleting a single note beforehand. Apps nowadays don't really give the user any notification of emptying the trash anyways because 99% of the time the user never really empties the trash on accident. nor would the notes being deleted from the trash be of importance anyway, being the reason they got there in the first place

![emptytrash](https://user-images.githubusercontent.com/20717348/36396048-01be0b9c-1571-11e8-8177-11c27cdc6992.gif)
