### PR TITLE
Adds the ability to copy the note link from the note list

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -13,6 +13,7 @@ import searchFromNotes from 'browser/lib/search'
 import fs from 'fs'
 import path from 'path'
 import { hashHistory } from 'react-router'
+import copy from 'copy-to-clipboard'
 import AwsMobileAnalyticsConfig from 'browser/main/lib/AwsMobileAnalyticsConfig'
 
 const { remote } = require('electron')
@@ -70,6 +71,7 @@ class NoteList extends React.Component {
     this.getNoteFolder = this.getNoteFolder.bind(this)
     this.getViewType = this.getViewType.bind(this)
     this.restoreNote = this.restoreNote.bind(this)
+    this.copyNoteLink = this.copyNoteLink.bind(this)
 
     // TODO: not Selected noteKeys but SelectedNote(for reusing)
     this.state = {
@@ -458,6 +460,7 @@ class NoteList extends React.Component {
     const deleteLabel = 'Delete Note'
     const cloneNote = 'Clone Note'
     const restoreNote = 'Restore Note'
+    const copyNoteLink = 'Copy Note Link'
 
     const menu = new Menu()
     if (!location.pathname.match(/\/starred|\/trash/)) {
@@ -481,6 +484,10 @@ class NoteList extends React.Component {
     menu.append(new MenuItem({
       label: cloneNote,
       click: this.cloneNote.bind(this)
+    }))
+    menu.append(new MenuItem({
+      label: copyNoteLink,
+      click: this.copyNoteLink(note)
     }))
     menu.popup()
   }
@@ -628,6 +635,11 @@ class NoteList extends React.Component {
           query: {key: uniqueKey}
         })
       })
+  }
+
+  copyNoteLink (note) {
+    const noteLink = `[${note.title}](${note.storage}-${note.key})`
+    return copy(noteLink)
   }
 
   importFromFile () {


### PR DESCRIPTION
Resolves #1582 

This will reduce user time and increase productivity by quickly copying  note links directly from the note list rather than having to go to the note details and the info panel to do it themselves

![copynotelink](https://user-images.githubusercontent.com/20717348/36643134-7ea93eb2-19fc-11e8-90f6-151bb6139d35.gif)