### PR TITLE
Fixes UI overlapping in the snippet editor (bottom options)

### DIFF
--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -5,7 +5,7 @@ $danger-color = #c9302c
 $danger-lighten-color = lighten(#c9302c, 5%)
 
 // Layouts
-$statusBar-height = 0px
+$statusBar-height = 22px
 $sideNav-width = 200px
 $sideNav--folded-width = 44px
 $topBar-height = 60px


### PR DESCRIPTION
Fixes #1580 

UI overlapping in the snippet editor (bottom options)

![overlapping-ui](https://user-images.githubusercontent.com/20717348/36643414-bd7ee602-19ff-11e8-9d94-48e16c1a7896.gif)
