### PR TITLE
fixed missing zoom button - #1598

### DIFF
--- a/browser/main/StatusBar/StatusBar.styl
+++ b/browser/main/StatusBar/StatusBar.styl
@@ -21,20 +21,19 @@
     color white
 
 .zoom
-  display none
-  // navButtonColor()
-  // color rgba(0,0,0,.54)
-  // height 20px
-  // display flex
-  // padding 0
-  // align-items center
-  // background-color transparent
-  // &:hover
-  //   color $ui-active-color
-  // &:active
-  //   color $ui-active-color
-  // span
-  //   margin-left 5px
+  navButtonColor()
+  color rgba(0,0,0,.54)
+  height 20px
+  display flex
+  padding 0
+  align-items center
+  background-color transparent
+  &:hover
+    color $ui-active-color
+  &:active
+    color $ui-active-color
+  span
+    margin-left 5px
   
 .update
   navButtonColor()


### PR DESCRIPTION
![screen shot 2018-02-27 at 11 19 44 pm](https://user-images.githubusercontent.com/3159256/36728418-cd55dcc2-1c14-11e8-93e4-573354756d7f.png)

Fix for #1598.

Zoom button got removed by this [PR](https://github.com/BoostIO/Boostnote/pull/1453) due to the new button toolbar layout. 

Revert the changes in `/browser/main/StatusBar/StatusBar.styl`.