### PR TITLE
SECURITY HOTFIX - Remove XSS attack

### DIFF
--- a/browser/lib/markdown-it-sanitize-html.js
+++ b/browser/lib/markdown-it-sanitize-html.js
@@ -1,0 +1,23 @@
+'use strict'
+
+import sanitizeHtml from 'sanitize-html'
+
+module.exports = function sanitizePlugin (md, options) {
+  options = options || {}
+
+  md.core.ruler.after('linkify', 'sanitize_inline', state => {
+    for (let tokenIdx = 0; tokenIdx < state.tokens.length; tokenIdx++) {
+      if (state.tokens[tokenIdx].type === 'html_block') {
+        state.tokens[tokenIdx].content = sanitizeHtml(state.tokens[tokenIdx].content, options)
+      }
+      if (state.tokens[tokenIdx].type === 'inline') {
+        const inlineTokens = state.tokens[tokenIdx].children
+        for (let childIdx = 0; childIdx < inlineTokens.length; childIdx++) {
+          if (inlineTokens[childIdx].type === 'html_inline') {
+            inlineTokens[childIdx].content = sanitizeHtml(inlineTokens[childIdx].content, options)
+          }
+        }
+      }
+    }
+  })
+}

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -1,4 +1,5 @@
 import markdownit from 'markdown-it'
+import sanitize from './markdown-it-sanitize-html'
 import emoji from 'markdown-it-emoji'
 import math from '@rokt33r/markdown-it-math'
 import _ from 'lodash'
@@ -45,6 +46,16 @@ var md = markdownit({
       str +
       '</code></pre>'
   }
+})
+// Sanitize use rinput before other plugins
+md.use(sanitize, {
+  allowedTags: ['img', 'iframe'],
+  allowedAttributes: {
+    '*': ['alt', 'style'],
+    'img': ['src', 'height', 'width'],
+    'iframe': ['src']
+  },
+  allowedIframeHostnames: ['www.youtube.com']
 })
 md.use(emoji, {
   shortcuts: {}

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -52,8 +52,8 @@ md.use(sanitize, {
   allowedTags: ['img', 'iframe'],
   allowedAttributes: {
     '*': ['alt', 'style'],
-    'img': ['src', 'height', 'width'],
-    'iframe': ['src']
+    'img': ['src', 'width', 'height'],
+    'iframe': ['src', 'width', 'height', 'frameborder', 'allowfullscreen']
   },
   allowedIframeHostnames: ['www.youtube.com']
 })

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-sortable-hoc": "^0.6.7",
     "redux": "^3.5.2",
     "sander": "^0.5.1",
+    "sanitize-html": "^1.18.2",
     "striptags": "^2.2.1",
     "superagent": "^1.2.0",
     "superagent-promise": "^1.0.3"


### PR DESCRIPTION
This will address #1443 at least partially by restricting the type of html tags and attributes that user is allowed to use.

`markdown-it` themselves [advise against enabling html](https://github.com/markdown-it/markdown-it/blob/master/docs/security.md) (and it was not my choice to enable it(1)), but I've seen youtube-iframes and img-tags used in the wild.

The set is pretty restrictive because I don't know what kind of html is legitimately used in the wild. This PR is **an important first step** and more tags can be allowed later if they turn out to be used by a lot of people. I _recommend to merge this first_ because it's a security issue, and wait for upset people that want to use html tag x-y-z later, and consider adding them back one by one.

---

(1): I think no html should be allowed. If people want to e.g. embed youtube-movies, a markdown extension should be made for that. Currently, this is done by means of `iframe`, so this PR restricts the urls `iframe` is allowed to load to youtube.com. More allowed urls can be added later if they turn out to be used a lot.

I think `img` tags should be disallowed too because there are markdown alternatives, but this way at least the `onerror` the harm is gone.