### PR TITLE
add UTF-8 tag to HTML export (fixes #1624)

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -216,6 +216,7 @@ export default class MarkdownPreview extends React.Component {
 
       return `<html>
                  <head>
+                   <meta charset="UTF-8">
                    <style id="style">${inlineStyles}</style>
                    ${styles}
                  </head>


### PR DESCRIPTION
The export to HTML feature was not including the `﻿<meta charset="UTF-8">` tag in its `<head>`, resulting in character rendering issues as described in #1624.

This commit adds that missing tag.