### PR TITLE
Export responsive html, fixes #1442

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -217,6 +217,7 @@ export default class MarkdownPreview extends React.Component {
       return `<html>
                  <head>
                    <meta charset="UTF-8">
+                   <meta name = "viewport" content = "width = device-width, initial-scale = 1, maximum-scale = 1">
                    <style id="style">${inlineStyles}</style>
                    ${styles}
                  </head>


### PR DESCRIPTION
Add "viewport" meta-data to HTML export.
See #1442 for details.