### PR TITLE
fixed code block style in exported HTML file

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -421,9 +421,9 @@ export default class MarkdownPreview extends React.Component {
         el.innerHTML = ''
         if (codeBlockTheme.indexOf('solarized') === 0) {
           const [refThema, color] = codeBlockTheme.split(' ')
-          el.parentNode.className += ` cm-s-${refThema} cm-s-${color} CodeMirror`
+          el.parentNode.className += ` cm-s-${refThema} cm-s-${color}`
         } else {
-          el.parentNode.className += ` cm-s-${codeBlockTheme} CodeMirror`
+          el.parentNode.className += ` cm-s-${codeBlockTheme}`
         }
         CodeMirror.runMode(content, syntax.mime, el, {
           tabSize: indentSize

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -39,7 +39,7 @@ var md = markdownit({
     if (langType === 'sequence') {
       return `<pre class="sequence">${str}</pre>`
     }
-    return '<pre class="code">' +
+    return '<pre class="code CodeMirror">' +
       '<span class="filename">' + fileName + '</span>' +
       createGutter(str, firstLineNumber) +
       '<code class="' + langType + '">' +


### PR DESCRIPTION
Quick and dirty fix for #1609.

__Code block in editor__
![Code block in editor](https://user-images.githubusercontent.com/3159256/37151692-b8b2df46-232a-11e8-8230-192d376aba7b.png)

__Code block in exported HTML__
![Code block in exported HTML](https://user-images.githubusercontent.com/3159256/37151719-d79309e0-232a-11e8-8882-ebc03d088163.png)

I will make some tweaks to the render function as lots of functionalities are missing in `handleSaveAsHtml` function, such as syntax highlight, code block theme (dracula), HTML entities #1647.

It would be a good idea to use the same render function in `rewriteIframe` and `handleSaveAsHtml` to keep everything consistent and most importantly, DRY.