### PR TITLE
Changed the minimum count of dummy data (folders and notes)

### DIFF
--- a/tests/fixtures/TestDummy.js
+++ b/tests/fixtures/TestDummy.js
@@ -105,7 +105,7 @@ function dummyStorage (storagePath, override = {}) {
 
   sander.writeFileSync(path.join(storagePath, 'boostnote.json'), JSON.stringify(jsonData))
   var notesData = []
-  var noteCount = Math.floor((Math.random() * 15)) + 1
+  var noteCount = Math.floor((Math.random() * 15)) + 2
   for (var i = 0; i < noteCount; i++) {
     var key = keygen()
     while (notesData.some((note) => note.key === key)) {

--- a/tests/fixtures/TestDummy.js
+++ b/tests/fixtures/TestDummy.js
@@ -22,7 +22,7 @@ function dummyBoostnoteJSONData (override = {}, isLegacy = false) {
   if (override.folders == null) {
     data.folders = []
 
-    var folderCount = Math.floor((Math.random() * 5)) + 1
+    var folderCount = Math.floor((Math.random() * 5)) + 2
     for (var i = 0; i < folderCount; i++) {
       var key = keygen()
       while (data.folders.some((folder) => folder.key === key)) {


### PR DESCRIPTION
Fix #1562 

At least two dummy folders/notes are required for reordering folders and moving notes in the test. Current dummy data implementation might result in generate only one folder / note.

Please see code below.

[TestDummy.js](https://github.com/BoostIO/Boostnote/blob/master/tests/fixtures/TestDummy.js#L25)
```js
var folderCount = Math.floor((Math.random() * 5)) + 1
/* ... */
var noteCount = Math.floor((Math.random() * 15)) + 1
```

However, following tests access to the second item in the folders/notes array.

[reorderFolder-test.js](https://github.com/BoostIO/Boostnote/blob/master/tests/dataApi/reorderFolder-test.js#L27)
```js
  const secondFolderKey = t.context.storage.json.folders[1].key
```

[moveNote-test.js](https://github.com/BoostIO/Boostnote/blob/master/tests/dataApi/moveNote-test.js#L29)
```js
  const note2 = t.context.storage1.notes[1]
```

Increased the minimum count to 2 resolve the issue.