### PR TITLE
fixed missing classname in lib/markdown highlight render function

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -41,7 +41,7 @@ class Markdown {
         if (langType === 'sequence') {
           return `<pre class="sequence">${str}</pre>`
         }
-        return '<pre class="code">' +
+        return '<pre class="code CodeMirror">' +
           '<span class="filename">' + fileName + '</span>' +
           createGutter(str, firstLineNumber) +
           '<code class="' + langType + '">' +


### PR DESCRIPTION
Fixed missing classname in lib/markdown due to the same file was modified in multiple commits. Related to #1609 