### PR TITLE
fix "copy note link from note list" link format

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -669,7 +669,7 @@ class NoteList extends React.Component {
   }
 
   copyNoteLink (note) {
-    const noteLink = `[${note.title}](${note.storage}-${note.key})`
+    const noteLink = `[${note.title}](${note.key})`
     return copy(noteLink)
   }
 


### PR DESCRIPTION
fixes "copy note link from note list" introduced in #1583 to reflect changes from #1636