### PR TITLE
Prevent generating a link tag when pasting URL to inside of a link tag.

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -287,6 +287,19 @@ export default class CodeEditor extends React.Component {
       const matcher = /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/
       return matcher.test(str)
     }
+    const isInLinkTag = (editor) => {
+      const startCursor = editor.getCursor('start')
+      const prevChar = editor.getRange(
+        { line: startCursor.line, ch: startCursor.ch - 2 },
+        { line: startCursor.line, ch: startCursor.ch }
+      )
+      const endCursor = editor.getCursor('end')
+      const nextChar = editor.getRange(
+        { line: endCursor.line, ch: endCursor.ch },
+        { line: endCursor.line, ch: endCursor.ch + 1 }
+      )
+      return prevChar === '](' && nextChar === ')'
+    }
     if (dataTransferItem.type.match('image')) {
       const blob = dataTransferItem.getAsFile()
       const reader = new FileReader()
@@ -306,7 +319,7 @@ export default class CodeEditor extends React.Component {
         const imageMd = `![${imageName}](${path.join('/:storage', `${imageName}.png`)})`
         this.insertImageMd(imageMd)
       }
-    } else if (this.props.fetchUrlTitle && isURL(pastedTxt)) {
+    } else if (this.props.fetchUrlTitle && isURL(pastedTxt) && !isInLinkTag(editor)) {
       this.handlePasteUrl(e, editor, pastedTxt)
     }
   }


### PR DESCRIPTION
closes #1680

When pasting URL to inside of a link tag, the title not fetched anymore.

## before

![boostnote](https://user-images.githubusercontent.com/21209469/37472498-961f958e-28af-11e8-8529-ed6eec0505cf.gif)

## after

![boostnote2](https://user-images.githubusercontent.com/21209469/37472510-9e54bbe4-28af-11e8-9128-06a27f357466.gif)
