### PR TITLE
Fixed smart quotes when posting a note to blog

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -8,7 +8,6 @@ import {lastFindInArray} from './utils'
 
 // FIXME We should not depend on global variable.
 const katex = window.katex
-const config = ConfigManager.get()
 
 function createGutter (str, firstLineNumber) {
   if (Number.isNaN(firstLineNumber)) firstLineNumber = 1
@@ -22,6 +21,7 @@ function createGutter (str, firstLineNumber) {
 
 class Markdown {
   constructor (options = {}) {
+    const config = ConfigManager.get()
     const defaultOptions = {
       typographer: true,
       linkify: true,

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -23,7 +23,7 @@ class Markdown {
   constructor (options = {}) {
     const config = ConfigManager.get()
     const defaultOptions = {
-      typographer: true,
+      typographer: config.preview.smartQuotes,
       linkify: true,
       html: true,
       xhtmlOut: true,

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -1,3 +1,4 @@
+/* global electron */
 import PropTypes from 'prop-types'
 import React from 'react'
 import CSSModules from 'browser/lib/CSSModules'

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -21,7 +21,6 @@ import Markdown from '../../lib/markdown'
 const { remote } = require('electron')
 const { Menu, MenuItem, dialog } = remote
 const WP_POST_PATH = '/wp/v2/posts'
-const markdown = new Markdown()
 
 function sortByCreatedAt (a, b) {
   return new Date(b.createdAt) - new Date(a.createdAt)
@@ -710,6 +709,7 @@ class NoteList extends React.Component {
       authToken = `Bearer ${token}`
     }
     const contentToRender = firstNote.content.replace(`# ${firstNote.title}`, '')
+    const markdown = new Markdown()
     const data = {
       title: firstNote.title,
       content: markdown.render(contentToRender),


### PR DESCRIPTION
Hi @lijinglue,

the default smart quote setting of `lib/markdown` was `true` and didn't follow global config in ConfigManager. I have modified `lib/markdown` to use `config.preview.smartQuotes` value as default. 

`markdown` instance was created at the beginning in `NoteList/index.js` and never reloads, when user changes `Smart Quotes` setting, markdown instance in `NoteList/index.js` won't be updated.

So I changed the markdown init behavior to only initiate when it's needed for `Post to Blog` feature.

**Before:**
![mar-16-2018 23-19-07](https://user-images.githubusercontent.com/3159256/37521309-627bd84e-2974-11e8-93b3-c3dbc688137d.gif)

**After:**
![mar-16-2018 23-47-59](https://user-images.githubusercontent.com/3159256/37521377-9dd2d2a8-2974-11e8-946b-1d137c7dda92.gif)

