### PR TITLE
Fix Copy Note Link in Context Menu

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -671,7 +671,7 @@ class NoteList extends React.Component {
   }
 
   copyNoteLink (note) {
-    const noteLink = `[${note.title}](${note.key})`
+    const noteLink = `[${note.title}](:note:${note.key})`
     return copy(noteLink)
   }
 


### PR DESCRIPTION
"Copy Note Link" generated by Context Menu at NoteList did not work.

<img width="430" alt="copy_note_link" src="https://user-images.githubusercontent.com/5780247/37564830-15ced6ba-2a9e-11e8-87ec-ccecd1538b87.png">

before:
<img width="342" alt="link_before" src="https://user-images.githubusercontent.com/5780247/37564839-3ffbb552-2a9e-11e8-9cee-bbe23035f1bd.png">

after:
<img width="378" alt="link_after" src="https://user-images.githubusercontent.com/5780247/37564840-45b8df4c-2a9e-11e8-9dd0-6ff12e4ef285.png">

