### PR TITLE
Fix tag filtering in search entry

### DIFF
--- a/browser/lib/search.js
+++ b/browser/lib/search.js
@@ -7,7 +7,7 @@ export default function searchFromNotes (notes, search) {
   let foundNotes = notes
   searchBlocks.forEach((block) => {
     if (block.match(/^#.+/)) {
-      foundNotes = findByTag(foundNotes, block)
+      foundNotes = findByTag(foundNotes.slice(0), block).concat(findByWord(foundNotes.slice(0), block))
     } else {
       foundNotes = findByWord(foundNotes, block)
     }

--- a/browser/lib/search.js
+++ b/browser/lib/search.js
@@ -4,11 +4,12 @@ export default function searchFromNotes (notes, search) {
   if (search.trim().length === 0) return []
   const searchBlocks = search.split(' ').filter(block => { return block !== '' })
 
-  let foundNotes = findByWord(notes, searchBlocks[0])
+  let foundNotes = notes
   searchBlocks.forEach((block) => {
-    foundNotes = findByWord(foundNotes, block)
     if (block.match(/^#.+/)) {
-      foundNotes = foundNotes.concat(findByTag(notes, block))
+      foundNotes = findByTag(foundNotes, block)
+    } else {
+      foundNotes = findByWord(foundNotes, block)
     }
   })
   return foundNotes

--- a/browser/lib/search.js
+++ b/browser/lib/search.js
@@ -6,38 +6,28 @@ export default function searchFromNotes (notes, search) {
 
   let foundNotes = notes
   searchBlocks.forEach((block) => {
-    if (block.match(/^#.+/)) {
-      foundNotes = findByTag(foundNotes.slice(0), block).concat(findByWord(foundNotes.slice(0), block))
-    } else {
-      foundNotes = findByWord(foundNotes, block)
-    }
+    foundNotes = findByWordOrTag(foundNotes, block)
   })
   return foundNotes
 }
 
-function findByTag (notes, block) {
-  const tag = block.match(/#(.+)/)[1]
-  const regExp = new RegExp(_.escapeRegExp(tag), 'i')
-  return notes.filter((note) => {
-    if (!_.isArray(note.tags)) return false
-    return note.tags.some((_tag) => {
-      return _tag.match(regExp)
-    })
-  })
-}
-
-function findByWord (notes, block) {
-  const regExp = new RegExp(_.escapeRegExp(block), 'i')
+function findByWordOrTag (notes, block) {
+  let tag = block
+  if (tag.match(/^#.+/)) {
+    tag = tag.match(/#(.+)/)[1]
+  }
+  const tagRegExp = new RegExp(_.escapeRegExp(tag), 'i')
+  const wordRegExp = new RegExp(_.escapeRegExp(block), 'i')
   return notes.filter((note) => {
     if (_.isArray(note.tags) && note.tags.some((_tag) => {
-      return _tag.match(regExp)
+      return _tag.match(tagRegExp)
     })) {
       return true
     }
     if (note.type === 'SNIPPET_NOTE') {
-      return note.description.match(regExp)
+      return note.description.match(wordRegExp)
     } else if (note.type === 'MARKDOWN_NOTE') {
-      return note.content.match(regExp)
+      return note.content.match(wordRegExp)
     }
     return false
   })

--- a/browser/lib/search.js
+++ b/browser/lib/search.js
@@ -19,9 +19,7 @@ function findByWordOrTag (notes, block) {
   const tagRegExp = new RegExp(_.escapeRegExp(tag), 'i')
   const wordRegExp = new RegExp(_.escapeRegExp(block), 'i')
   return notes.filter((note) => {
-    if (_.isArray(note.tags) && note.tags.some((_tag) => {
-      return _tag.match(tagRegExp)
-    })) {
+    if (_.isArray(note.tags) && note.tags.some((_tag) => _tag.match(tagRegExp))) {
       return true
     }
     if (note.type === 'SNIPPET_NOTE') {

--- a/tests/lib/search-test.js
+++ b/tests/lib/search-test.js
@@ -22,7 +22,7 @@ test.before(t => {
 
 test('it can find notes by tags and words', t => {
   // [input, expected content (Array)]
-  const testCases = [
+  const testWithTags = [
     ['#tag1', [note1.content, note2.content, note3.content]],
     ['#tag1 #tag2', [note2.content]],
     ['#tag2 #tag1', [note2.content]],
@@ -34,7 +34,11 @@ test('it can find notes by tags and words', t => {
     ['#tag2 content1', [note2.content]],
     ['content1 #tag2', [note2.content]]
   ]
+  const testWithTagsWithoutHash = testWithTags.map(function (testCase) {
+    return [testCase[0].replace(/#/g, ''), testCase[1]]
+  })
 
+  const testCases = testWithTags.concat(testWithTagsWithoutHash)
   testCases.forEach((testCase) => {
     const [input, expectedContents] = testCase
     const results = searchFromNotes(notes, input)

--- a/tests/lib/search-test.js
+++ b/tests/lib/search-test.js
@@ -20,16 +20,19 @@ test.before(t => {
   notes = [note1, note2, note3]
 })
 
-test('it can find notes by tags or words', t => {
+test('it can find notes by tags and words', t => {
   // [input, expected content (Array)]
   const testCases = [
     ['#tag1', [note1.content, note2.content, note3.content]],
     ['#tag1 #tag2', [note2.content]],
+    ['#tag2 #tag1', [note2.content]],
     ['#tag1 #tag2 #tag3', []],
     ['content1', [note1.content, note2.content]],
     ['content1 content2', [note2.content]],
     ['content1 content2 content3', []],
-    ['#content4', [note3.content]]
+    ['#content4', [note3.content]],
+    ['#tag2 content1', [note2.content]],
+    ['content1 #tag2', [note2.content]]
   ]
 
   testCases.forEach((testCase) => {


### PR DESCRIPTION
Some issues introduced in #954 (https://github.com/BoostIO/Boostnote/pull/954#issuecomment-336344915):

- search by `#tag1 #tag2` returns the results of only `#tag2`
- search by `#tag1 content` is as same as AND search by `#tag1 content` (and `#tag1` is regarded a word, not a tag)
- search by `content #tag1` returns the results of only `#tag1`

This commit fixing these:

- search by `#tag1 #tag2` returns the results of only `#tag2`

  ![screencast](https://i.imgur.com/SjhQIhl.gif)

- search by `#tag1 content` is as same as AND search by `#tag1 content` (and `#tag1` is regarded a word, not a tag)

  ![screencast](https://i.imgur.com/G0Tmd8c.gif)

- search by `content #tag1` returns the results of only `#tag1`

  ![screencast](https://i.imgur.com/5MrMbE6.gif)

NOTE: the examples works without `#` character too, because `findByWord()` checks the tags too.

### Related issues:
* #1499 
* #1683 