### PR TITLE
remove broken note from note list

### DIFF
--- a/browser/main/lib/dataApi/resolveStorageNotes.js
+++ b/browser/main/lib/dataApi/resolveStorageNotes.js
@@ -27,8 +27,11 @@ function resolveStorageNotes (storage) {
         data.storage = storage.key
         return data
       } catch (err) {
-        console.error(notePath)
+        console.error(`error on note path: ${notePath}, error: ${err}`)
       }
+    })
+    .filter(function filterOnlyNoteObject (noteObj) {
+      return typeof noteObj === 'object'
     })
 
   return Promise.resolve(notes)


### PR DESCRIPTION
related #1597 #1485 #1694

I also have same behaviour reported in above issues. 

I don't know broken .cson error is made by Boostnote or not, but it is quite scary that notes seems to be disappeared. Investigating the reason why we get the broken the .cson is important, but I think quick fix is more important. 

In current implementation, when .cson is broken and catch error in processing this file,  undefined is collected in notes. If undefined is in the notes, we cannot see the broken note and following notes even they are not broken.

My implementation is just removing undefined from  the note list.