### PR TITLE
fix incorrect app closing for linux mint cinnamon

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -40,7 +40,7 @@ mainWindow.webContents.sendInputEvent({
   keyCode: '\u0008'
 })
 
-if (process.platform === 'darwin' || process.env.DESKTOP_SESSION === 'cinnamon') {
+if (process.platform === 'darwin') {
   mainWindow.on('close', function (e) {
     e.preventDefault()
     if (mainWindow.isFullScreen()) {


### PR DESCRIPTION
excluded the cinnamon desktop for the macOS-like behavior which closes the window, but does not shutdown the app processes as discussed in #1738 with @Rokt33r 