### PR TITLE
Fixed storage preference UI

### DIFF
--- a/browser/main/modals/PreferencesModal/FolderItem.styl
+++ b/browser/main/modals/PreferencesModal/FolderItem.styl
@@ -1,4 +1,5 @@
 .folderItem
+  display flex
   height 35px
   box-sizing border-box
   padding 2.5px 15px
@@ -8,7 +9,7 @@
 .folderItem-drag-handle
   height 35px
   border none
-  padding 0 10px
+  padding-left 10px
   line-height 35px
   float left
   cursor row-resize
@@ -18,7 +19,10 @@
   border-left solid 2px transparent
   padding 0 10px
   line-height 30px
-  float left
+  display flex
+  overflow-y hidden
+  flex 1
+
 .folderItem-left-danger
   color $danger-color
   font-weight bold
@@ -39,8 +43,7 @@
   vertical-align middle
   border $ui-border
   border-radius 2px
-  margin-right 5px
-  margin-left -15px
+  margin 2px 5px 0 -10px
 
 .folderItem-left-nameInput
   height 25px
@@ -48,11 +51,12 @@
   vertical-align middle
   border $ui-border
   border-radius 2px
-  padding 0 5px
+  margin-top 2px
   outline none
+  width 100%
 
 .folderItem-right
-  float right
+  display flex
 
 .folderItem-right-button
   vertical-align middle

--- a/browser/main/modals/PreferencesModal/StorageItem.js
+++ b/browser/main/modals/PreferencesModal/StorageItem.js
@@ -103,6 +103,7 @@ class StorageItem extends React.Component {
     return (
       <div styleName='root' key={storage.key}>
         <div styleName='header'>
+          <i className='fa fa-folder-open' styleName='header-icon'/>
           {this.state.isLabelEditing
             ? <div styleName='header-label--edit'>
               <input styleName='header-label-input'
@@ -115,9 +116,9 @@ class StorageItem extends React.Component {
             : <div styleName='header-label'
               onClick={(e) => this.handleLabelClick(e)}
             >
-              <i className='fa fa-folder-open' />&nbsp;
-              {storage.name}&nbsp;
-              <span styleName='header-label-path'>({storage.path})</span>&nbsp;
+
+              <span styleName='header-label-name'>{storage.name}</span>
+              <span styleName='header-label-path'>({storage.path})</span>
               <i styleName='header-label-editButton' className='fa fa-pencil' />
             </div>
           }

--- a/browser/main/modals/PreferencesModal/StorageItem.styl
+++ b/browser/main/modals/PreferencesModal/StorageItem.styl
@@ -3,6 +3,7 @@
   margin-bottom 15px
 
 .header
+  display flex
   height 35px
   line-height 30px
   padding 0 10px 5px
@@ -10,12 +11,23 @@
   border-bottom $default-border
   margin-bottom 5px
 
+.header-icon
+  margin-top 6px
+  margin-left 2px
+
 .header-label
-  float left
+  display flex
+  flex 1
+  padding-top 0px
+  line-height 25px
+  overflow-y auto
   cursor pointer
   &:hover
     .header-label-editButton
       opacity 1
+
+.header-label-name
+  margin-left 10px
 
 .header-label-path
   color $ui-inactive-text-color
@@ -29,16 +41,19 @@
   @extend .header-label
 
 .header-label-input
+  display flex
+  flex 1
   height 25px
   box-sizing border-box
   vertical-align middle
   border $ui-border
   border-radius 2px
-  padding 0 5px
+  padding 10px 5px
+  margin 0 10px 0 10px
   outline none
 
 .header-control
-  float right
+  display flex
 
 .header-control-button
   width 30px


### PR DESCRIPTION
If you have very long folder names, the preference ui is broken.

It looks like this:
![ui_before](https://user-images.githubusercontent.com/5780247/37868577-22a80b44-2fa9-11e8-9000-90676846cd64.png)

With this fix the ui can handle large folder names:
![ui_after](https://user-images.githubusercontent.com/5780247/37868585-478b8346-2fa9-11e8-801e-3fcfe0aaf03e.png)