### PR TITLE
Add folding to CodeEditor

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -113,9 +113,6 @@ export default class CodeEditor extends React.Component {
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
       autoCloseBrackets: true,
       extraKeys: {
-        'Ctrl-G': function (cm) {
-          cm.foldCode(cm.getCursor())
-        },
         Tab: function (cm) {
           const cursor = cm.getCursor()
           const line = cm.getLine(cursor.line)

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -109,8 +109,13 @@ export default class CodeEditor extends React.Component {
       scrollPastEnd: this.props.scrollPastEnd,
       inputStyle: 'textarea',
       dragDrop: false,
+      foldGutter: true,
+      gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
       autoCloseBrackets: true,
       extraKeys: {
+        'Ctrl-G': function (cm) {
+          cm.foldCode(cm.getCursor())
+        },
         Tab: function (cm) {
           const cursor = cm.getCursor()
           const line = cm.getLine(cursor.line)

--- a/browser/main/global.styl
+++ b/browser/main/global.styl
@@ -114,10 +114,9 @@ body[data-theme="dark"]
 .CodeMirror-foldgutter
   width: .7em
 
-//.CodeMirror-foldgutter-open,
-//.CodeMirror-foldgutter-folded
-//  color: #555
-//  cursor: pointer
+.CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded
+  cursor: pointer
 
 .CodeMirror-foldgutter-open:after
   content: "\25BE"

--- a/browser/main/global.styl
+++ b/browser/main/global.styl
@@ -108,6 +108,22 @@ body[data-theme="dark"]
   background #B1D7FE
 ::selection
   background #B1D7FE
+.CodeMirror-foldmarker
+  font-family: arial
+
+.CodeMirror-foldgutter
+  width: .7em
+
+//.CodeMirror-foldgutter-open,
+//.CodeMirror-foldgutter-folded
+//  color: #555
+//  cursor: pointer
+
+.CodeMirror-foldgutter-open:after
+  content: "\25BE"
+
+.CodeMirror-foldgutter-folded:after
+  content: "\25B8"
 
 .sortableItemHelper
   z-index modalZIndex + 5

--- a/lib/main.html
+++ b/lib/main.html
@@ -92,6 +92,11 @@
   <script src="../node_modules/codemirror/addon/scroll/scrollpastend.js"></script>
   <script src="../node_modules/codemirror/addon/search/matchesonscrollbar.js"></script>
   <script src="../node_modules/codemirror/addon/search/jump-to-line.js"></script>
+
+  <script src="../node_modules/codemirror/addon/fold/brace-fold.js"></script>
+  <script src="../node_modules/codemirror/addon/fold/foldgutter.js"></script>
+  <script src="../node_modules/codemirror/addon/fold/foldcode.js"></script>
+
   <script src="../node_modules/codemirror/addon/dialog/dialog.js"></script>
   <script src="../node_modules/codemirror/addon/display/rulers.js"></script>
 


### PR DESCRIPTION
This PR adds (much needed 😄) Code folding functionality to `code editor` by passing additional `options` to the `CodeMirror`

![Folding](https://i.imgur.com/bsEkwPZ.gif)