### PR TITLE
Escape html characters before convert to HTML

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -13,6 +13,7 @@ import htmlTextHelper from 'browser/lib/htmlTextHelper'
 import copy from 'copy-to-clipboard'
 import mdurl from 'mdurl'
 import exportNote from 'browser/main/lib/dataApi/exportNote'
+import {escapeHtmlCharacters} from 'browser/lib/utils'
 
 const { remote } = require('electron')
 const { app } = remote
@@ -208,7 +209,7 @@ export default class MarkdownPreview extends React.Component {
       const {fontFamily, fontSize, codeBlockFontFamily, lineNumber, codeBlockTheme} = this.getStyleParams()
 
       const inlineStyles = buildStyle(fontFamily, fontSize, codeBlockFontFamily, lineNumber, codeBlockTheme, lineNumber)
-      const body = this.markdown.render(noteContent)
+      const body = this.markdown.render(escapeHtmlCharacters(noteContent))
       const files = [this.GetCodeThemeLink(codeBlockTheme), ...CSS_FILES]
 
       files.forEach((file) => {

--- a/browser/lib/utils.js
+++ b/browser/lib/utils.js
@@ -6,6 +6,55 @@ export function lastFindInArray (array, callback) {
   }
 }
 
+export function escapeHtmlCharacters (text) {
+  const matchHtmlRegExp = /["'&<>]/
+  const str = '' + text
+  const match = matchHtmlRegExp.exec(str)
+
+  if (!match) {
+    return str
+  }
+
+  let escape
+  let html = ''
+  let index = 0
+  let lastIndex = 0
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = '&quot;'
+        break
+      case 38: // &
+        escape = '&amp;'
+        break
+      case 39: // '
+        escape = '&#39;'
+        break
+      case 60: // <
+        escape = '&lt;'
+        break
+      case 62: // >
+        escape = '&gt;'
+        break
+      default:
+        continue
+    }
+
+    if (lastIndex !== index) {
+      html += str.substring(lastIndex, index)
+    }
+
+    lastIndex = index + 1
+    html += escape
+  }
+
+  return lastIndex !== index
+      ? html + str.substring(lastIndex, index)
+      : html
+}
+
 export default {
-  lastFindInArray
+  lastFindInArray,
+  escapeHtmlCharacters
 }


### PR DESCRIPTION
Export to HTML used to export html-like text in the note as is. The content of the note could disappear because of that. 

I've added a util function `escapeHtmlCharacters` and use it before export. The function convert symbols `"'&<>` to theirs html representation: `&quot;`, `&#39;`, etc.

Fixes #1728