### PR TITLE
Fix highlighting of active tag

### DIFF
--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -139,7 +139,7 @@ class SideNav extends React.Component {
           <TagListItem
             name={tag.name}
             handleClickTagListItem={this.handleClickTagListItem.bind(this)}
-            isActive={this.getTagActive(location.pathname, tag)}
+            isActive={this.getTagActive(location.pathname, tag.name)}
             key={tag.name}
             count={tag.size}
           />


### PR DESCRIPTION
The currently selected tag was not highlighted in the list.

Before:

![screencast](https://i.imgur.com/6JsjYk7.gif)

After:

![screencast](https://i.imgur.com/xD6fc0c.gif)