### PR TITLE
Fixed moving notes with images

### DIFF
--- a/browser/main/lib/dataApi/moveNote.js
+++ b/browser/main/lib/dataApi/moveNote.js
@@ -68,29 +68,27 @@ function moveNote (storageKey, noteKey, newStorageKey, newFolderKey) {
           return noteData
         })
         .then(function moveImages (noteData) {
-          if (oldStorage.path === newStorage.path) {
-            return noteData
-          } else {
-            const searchImagesRegex = /!\[.*?]\(\s*?\/:storage\/(.*\.\S*?)\)/gi
-            let match = searchImagesRegex.exec(noteData.content)
+          if (oldStorage.path === newStorage.path) return noteData
 
-            const moveTasks = []
-            while (match != null) {
-              const [, filename] = match
-              const oldPath = path.join(oldStorage.path, 'images', filename)
-              moveTasks.push(
-                  copyImage(oldPath, noteData.storage, false)
-                  .then(() => {
-                    fs.unlinkSync(oldPath)
-                  })
-              )
+          const searchImagesRegex = /!\[.*?]\(\s*?\/:storage\/(.*\.\S*?)\)/gi
+          let match = searchImagesRegex.exec(noteData.content)
 
-              // find next occurence
-              match = searchImagesRegex.exec(noteData.content)
-            }
+          const moveTasks = []
+          while (match != null) {
+            const [, filename] = match
+            const oldPath = path.join(oldStorage.path, 'images', filename)
+            moveTasks.push(
+                copyImage(oldPath, noteData.storage, false)
+                .then(() => {
+                  fs.unlinkSync(oldPath)
+                })
+            )
 
-            return Promise.all(moveTasks).then(() => noteData)
+            // find next occurence
+            match = searchImagesRegex.exec(noteData.content)
           }
+
+          return Promise.all(moveTasks).then(() => noteData)
         })
         .then(function writeAndReturn (noteData) {
           CSON.writeFileSync(path.join(newStorage.path, 'notes', noteData.key + '.cson'), _.omit(noteData, ['key', 'storage']))

--- a/browser/main/lib/dataApi/moveNote.js
+++ b/browser/main/lib/dataApi/moveNote.js
@@ -68,7 +68,7 @@ function moveNote (storageKey, noteKey, newStorageKey, newFolderKey) {
           return noteData
         })
         .then(function moveImages (noteData) {
-          if(oldStorage.path === newStorage.path) {
+          if (oldStorage.path === newStorage.path) {
             return noteData
           } else {
             const searchImagesRegex = /!\[.*?]\(\s*?\/:storage\/(.*\.\S*?)\)/gi
@@ -90,8 +90,8 @@ function moveNote (storageKey, noteKey, newStorageKey, newFolderKey) {
             }
 
             return Promise.all(moveTasks).then(() => noteData)
-        }
-      })
+          }
+        })
         .then(function writeAndReturn (noteData) {
           CSON.writeFileSync(path.join(newStorage.path, 'notes', noteData.key + '.cson'), _.omit(noteData, ['key', 'storage']))
           return noteData

--- a/browser/main/lib/dataApi/moveNote.js
+++ b/browser/main/lib/dataApi/moveNote.js
@@ -68,26 +68,30 @@ function moveNote (storageKey, noteKey, newStorageKey, newFolderKey) {
           return noteData
         })
         .then(function moveImages (noteData) {
-          const searchImagesRegex = /!\[.*?]\(\s*?\/:storage\/(.*\.\S*?)\)/gi
-          let match = searchImagesRegex.exec(noteData.content)
+          if(oldStorage.path === newStorage.path) {
+            return noteData
+          } else {
+            const searchImagesRegex = /!\[.*?]\(\s*?\/:storage\/(.*\.\S*?)\)/gi
+            let match = searchImagesRegex.exec(noteData.content)
 
-          const moveTasks = []
-          while (match != null) {
-            const [, filename] = match
-            const oldPath = path.join(oldStorage.path, 'images', filename)
-            moveTasks.push(
-                copyImage(oldPath, noteData.storage, false)
-                .then(() => {
-                  fs.unlinkSync(oldPath)
-                })
-            )
+            const moveTasks = []
+            while (match != null) {
+              const [, filename] = match
+              const oldPath = path.join(oldStorage.path, 'images', filename)
+              moveTasks.push(
+                  copyImage(oldPath, noteData.storage, false)
+                  .then(() => {
+                    fs.unlinkSync(oldPath)
+                  })
+              )
 
-            // find next occurence
-            match = searchImagesRegex.exec(noteData.content)
-          }
+              // find next occurence
+              match = searchImagesRegex.exec(noteData.content)
+            }
 
-          return Promise.all(moveTasks).then(() => noteData)
-        })
+            return Promise.all(moveTasks).then(() => noteData)
+        }
+      })
         .then(function writeAndReturn (noteData) {
           CSON.writeFileSync(path.join(newStorage.path, 'notes', noteData.key + '.cson'), _.omit(noteData, ['key', 'storage']))
           return noteData


### PR DESCRIPTION
Fixes #1788

How it works:
Moving note from one folder to another folder at the same storage -> don't touch the images
Moving note from one folder to another folder at different storages -> copy the images to the new storage, delete the images from the old storage

Limits: 
If the same image is referenced in multiple notes at the old storage, moving only one note (with the image) will result in deleting the image at the old storage. But this is another bug.