### PR TITLE
fixed menu popup on alt key pressed

### DIFF
--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -24,6 +24,46 @@ document.addEventListener('dragover', function (e) {
   e.stopPropagation()
 })
 
+// prevent menu from popup when alt pressed
+// but still able to toggle menu when only alt is pressed
+let isAltPressing = false
+let isAltWithMouse = false
+let isAltWithOtherKey = false
+let isOtherKey = false
+
+document.addEventListener('keydown', function (e) {
+  if (e.key === 'Alt') {
+    isAltPressing = true
+    if (isOtherKey) {
+      isAltWithOtherKey = true
+    }
+  } else {
+    if (isAltPressing) {
+      isAltWithOtherKey = true
+    }
+    isOtherKey = true
+  }
+})
+
+document.addEventListener('mousedown', function (e) {
+  if (isAltPressing) {
+    isAltWithMouse = true
+  }
+})
+
+document.addEventListener('keyup', function (e) {
+  if (e.key === 'Alt') {
+    if (isAltWithMouse || isAltWithOtherKey) {
+      console.log(isAltWithMouse, isAltWithOtherKey)
+      e.preventDefault()
+    }
+    isAltWithMouse = false
+    isAltWithOtherKey = false
+    isAltPressing = false
+    isOtherKey = false
+  }
+})
+
 document.addEventListener('click', function (e) {
   const className = e.target.className
   if (!className && typeof (className) !== 'string') return

--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -54,7 +54,6 @@ document.addEventListener('mousedown', function (e) {
 document.addEventListener('keyup', function (e) {
   if (e.key === 'Alt') {
     if (isAltWithMouse || isAltWithOtherKey) {
-      console.log(isAltWithMouse, isAltWithOtherKey)
       e.preventDefault()
     }
     isAltWithMouse = false


### PR DESCRIPTION
Hi boostnote team,
This is a fix for the issue https://github.com/BoostIO/Boostnote/issues/1808

Basically, this PR help prevent the top menu to appear when you hit the alt key with other key (like alt + arrow key to switch workspace on linux) or with mouse click to avoid conflict with boostnote shortcut but also enable user to toggle top menu by only pressing the alt key.