### PR TITLE
Updated tag note count to float to the right like the storage list

### DIFF
--- a/browser/components/TagListItem.js
+++ b/browser/components/TagListItem.js
@@ -16,7 +16,7 @@ const TagListItem = ({name, handleClickTagListItem, isActive, count}) => (
   <button styleName={isActive ? 'tagList-item-active' : 'tagList-item'} onClick={() => handleClickTagListItem(name)}>
     <span styleName='tagList-item-name'>
       {`# ${name}`}
-      <span styleName='tagList-item-count'> {count}</span>
+      <span styleName='tagList-item-count'>{count}</span>
     </span>
   </button>
 )

--- a/browser/components/TagListItem.styl
+++ b/browser/components/TagListItem.styl
@@ -49,7 +49,10 @@
   text-overflow ellipsis
 
 .tagList-item-count
-  padding 0 3px
+  float right
+  line-height 26px
+  padding-right 15px
+  font-size 13px
 
 body[data-theme="white"]
   .tagList-item


### PR DESCRIPTION
If a tag has a number in the name or there are a lot of notes with a tag the current count of notes in a tag can be confusing with a single space between the tag name and the count.

This update borrows the styling from the storage item to float the count to the right side of the sidebar.