### PR TITLE
Fix font color in code block(markdown preview)

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -199,7 +199,6 @@ ol
   &>li>ul, &>li>ol
     margin 0
 code
-  color #CC305F
   padding 0.2em 0.4em
   background-color #f7f7f7
   border-radius 3px


### PR DESCRIPTION
# Fix:
font color in code block unusual when preview markdown

# Current behavior
<img width="1119" alt="2018-04-25 6 07 08" src="https://user-images.githubusercontent.com/9927029/39239486-9a166cc0-48b3-11e8-9265-b177849239c8.png">

# Expected behavior
<img width="998" alt="2018-04-25 6 10 16" src="https://user-images.githubusercontent.com/9927029/39239592-ed579be8-48b3-11e8-8cdb-3755177fe09e.png">

# More
[kazup01 fix same bug on 24 Sep 2017](https://github.com/BoostIO/Boostnote/commit/ec8fac11993aa4308111a47a481bc7ee35901e72#diff-a54dec67725b3e604a34d39a7fcb72f6)

<img width="981" alt="2018-04-25 6 12 29" src="https://user-images.githubusercontent.com/9927029/39239724-5b416378-48b4-11e8-9316-b577a58c075c.png">

[but bring in same bug on 4 Oct 2017](https://github.com/BoostIO/Boostnote/commit/d8e19d9c17611efced990255e35a69242e15df58#diff-8ea283d669e20ef48dfcd6839e92c02a)
<img width="983" alt="2018-04-25 6 16 57" src="https://user-images.githubusercontent.com/9927029/39239901-df34ee20-48b4-11e8-9cba-843a82a2182a.png">



