### PR TITLE
fix drag drop more than one note bug

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -455,7 +455,14 @@ class NoteList extends React.Component {
   }
 
   handleDragStart (e, note) {
-    const { selectedNoteKeys } = this.state
+    let { selectedNoteKeys } = this.state
+    const noteKey = getNoteKey(note)
+
+    if (!selectedNoteKeys.includes(noteKey)) {
+      selectedNoteKeys = []
+      selectedNoteKeys.push(noteKey)
+    }
+
     const notes = this.notes.map((note) => Object.assign({}, note))
     const selectedNotes = findNotesByKeys(notes, selectedNoteKeys)
     const noteData = JSON.stringify(selectedNotes)

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -460,7 +460,7 @@ class NoteList extends React.Component {
     const selectedNotes = findNotesByKeys(notes, selectedNoteKeys)
     const noteData = JSON.stringify(selectedNotes)
     e.dataTransfer.setData('note', noteData)
-    this.setState({ selectedNoteKeys: [] })
+    this.selectNextNote()
   }
 
   handleNoteContextMenu (e, uniqueKey) {


### PR DESCRIPTION
fix #1869 

I found one more bug during investigation of this issue. 
When the dragged note is not the focused note(s), the focused note(s) are moved to the target folder, but the dragged note is still in the same folder. 
[this commit](https://github.com/BoostIO/Boostnote/commit/2d0f7589eaa1c6ecc47624fcb67ac30a6589c887) handles this issue.