### PR TITLE
Fixed print font color in dark theme

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -306,6 +306,8 @@ themeDarkModalButtonDanger = #BF360C
 
 body[data-theme="dark"]
   color themeDarkText
+  @media print
+    color #000000
   border-color themeDarkBorder
   background-color themeDarkPreview
   a:hover


### PR DESCRIPTION
When using the printing option in dark theme the font color is grey and not perfectly readable. So i just tweaked the styling a little.

Before:
![before](https://user-images.githubusercontent.com/17594215/39671068-cb0eeb2a-5111-11e8-8cb2-aa74bbe49025.png)

After:
![after](https://user-images.githubusercontent.com/17594215/39671072-d3460aee-5111-11e8-9f8d-d7b37b0b923d.png)
