### PR TITLE
fixed NoteItemSimple styling for the dark themes

### DIFF
--- a/browser/components/NoteItemSimple.styl
+++ b/browser/components/NoteItemSimple.styl
@@ -104,6 +104,7 @@ body[data-theme="dark"]
       background-color alpha($ui-dark-button--active-backgroundColor, 20%)
       color $ui-dark-text-color
       .item-simple-title
+      .item-simple-title-empty
       .item-simple-title-icon
       .item-simple-bottom-time
         transition 0.15s
@@ -117,6 +118,7 @@ body[data-theme="dark"]
       background-color $ui-dark-button--active-backgroundColor
       color $ui-dark-text-color
       .item-simple-title
+      .item-simple-title-empty
       .item-simple-title-icon
       .item-simple-bottom-time
         transition 0.15s
@@ -165,9 +167,10 @@ body[data-theme="solarized-dark"]
     background-color $ui-solarized-dark-noteList-backgroundColor
     &:hover
       transition 0.15s
-      // background-color alpha($ui-dark-button--active-backgroundColor, 20%)
+      background-color alpha($ui-dark-button--active-backgroundColor, 60%)
       color $ui-solarized-dark-text-color
       .item-simple-title
+      .item-simple-title-empty
       .item-simple-title-icon
       .item-simple-bottom-time
         transition 0.15s
@@ -178,9 +181,10 @@ body[data-theme="solarized-dark"]
         color $ui-solarized-dark-text-color
     &:active
       transition 0.15s
-      background-color $ui-solarized-dark-button--active-backgroundColor
-      color $ui-solarized-dark-text-color
+      // background-color $ui-solarized-dark-button--active-backgroundColor
+      color $ui-dark-text-color
       .item-simple-title
+      .item-simple-title-empty
       .item-simple-title-icon
       .item-simple-bottom-time
         transition 0.15s
@@ -192,11 +196,13 @@ body[data-theme="solarized-dark"]
 
   .item-simple--active
     border-color $ui-solarized-dark-borderColor
-    background-color $ui-solarized-dark-button--active-backgroundColor
+    background-color $ui-solarized-dark-tag-backgroundColor
     .item-simple-wrapper
       border-color transparent
     .item-simple-title
+    .item-simple-title-empty
     .item-simple-title-icon
+       color $ui-dark-text-color
     .item-simple-bottom-time
       color $ui-solarized-dark-text-color
     .item-simple-bottom-tagList-item
@@ -207,11 +213,14 @@ body[data-theme="solarized-dark"]
       color #c0392b
       .item-simple-bottom-tagList-item
         background-color alpha(#fff, 20%)
-.item-simple-right
-  float right
-  .item-simple-right-storageName
-    padding-left 4px
-    opacity 0.4
+  .item-simple-title
+    color $ui-dark-text-color
+    border-bottom $ui-dark-borderColor
+  .item-simple-right
+    float right
+    .item-simple-right-storageName
+      padding-left 4px
+      opacity 0.4
 
 body[data-theme="monokai"]
   .root
@@ -223,13 +232,14 @@ body[data-theme="monokai"]
     background-color $ui-monokai-noteList-backgroundColor
     &:hover
       transition 0.15s
-      // background-color alpha($ui-dark-button--active-backgroundColor, 20%)
+      background-color alpha($ui-monokai-button-backgroundColor, 60%)
       color $ui-monokai-text-color
       .item-simple-title
+      .item-simple-title-empty
       .item-simple-title-icon
       .item-simple-bottom-time
         transition 0.15s
-        color $ui-monokai-text-color
+        color $ui-solarized-dark-text-color
       .item-simple-bottom-tagList-item
         transition 0.15s
         background-color alpha(#fff, 20%)
@@ -239,6 +249,7 @@ body[data-theme="monokai"]
       background-color $ui-monokai-button--active-backgroundColor
       color $ui-monokai-text-color
       .item-simple-title
+      .item-simple-title-empty
       .item-simple-title-icon
       .item-simple-bottom-time
         transition 0.15s
@@ -254,6 +265,7 @@ body[data-theme="monokai"]
     .item-simple-wrapper
       border-color transparent
     .item-simple-title
+    .item-simple-title-empty
     .item-simple-title-icon
     .item-simple-bottom-time
       color $ui-monokai-text-color
@@ -265,8 +277,11 @@ body[data-theme="monokai"]
       color #c0392b
       .item-simple-bottom-tagList-item
         background-color alpha(#fff, 20%)
-.item-simple-right
-  float right
-  .item-simple-right-storageName
-    padding-left 4px
-    opacity 0.4
+  .item-simple-title
+    color $ui-dark-text-color
+    border-bottom $ui-dark-borderColor
+  .item-simple-right
+    float right
+    .item-simple-right-storageName
+      padding-left 4px
+      opacity 0.4


### PR DESCRIPTION
Noticed a weird styling issue with note items when they are toggled to "simple", edges became white and hovering over a note item wasn't distinct enough. This pr fixes that for all the dark themes (Dark, Solarized Dark & Monokai). Can't wait for v0.11.5! 💪 

The issue:

![border-line](https://user-images.githubusercontent.com/14887287/40018164-c9e5ba70-57bb-11e8-9ac5-6203cad76e12.gif)

New and improved:

![noteitemsimple](https://user-images.githubusercontent.com/14887287/40018243-fa82cd1c-57bb-11e8-8054-2d7028d50827.gif)
