### PR TITLE
Refresh taglist to remove unused tags on deleting

### DIFF
--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -44,16 +44,9 @@ class TagSelect extends React.Component {
   }
 
   removeLastTag () {
-    let { value } = this.props
-
-    value = _.isArray(value)
-      ? value.slice()
-      : []
-    value.pop()
-    value = _.uniq(value)
-
-    this.value = value
-    this.props.onChange()
+    this.removeTagByCallback((value) => {
+      value.pop()
+    })
   }
 
   reset () {
@@ -96,12 +89,18 @@ class TagSelect extends React.Component {
   }
 
   handleTagRemoveButtonClick (tag) {
+    this.removeTagByCallback((value, tag) => {
+      value.splice(value.indexOf(tag), 1)
+    }, tag)
+  }
+
+  removeTagByCallback (callback, tag = null) {
     let { value } = this.props
 
     value = _.isArray(value)
       ? value.slice()
       : []
-    value.splice(value.indexOf(tag), 1)
+    callback(value, tag)
     value = _.uniq(value)
 
     this.value = value

--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -96,15 +96,16 @@ class TagSelect extends React.Component {
   }
 
   handleTagRemoveButtonClick (tag) {
-    return (e) => {
-      let { value } = this.props
+    let { value } = this.props
 
-      value.splice(value.indexOf(tag), 1)
-      value = _.uniq(value)
+    value = _.isArray(value)
+      ? value.slice()
+      : []
+    value.splice(value.indexOf(tag), 1)
+    value = _.uniq(value)
 
-      this.value = value
-      this.props.onChange()
-    }
+    this.value = value
+    this.props.onChange()
   }
 
   render () {
@@ -118,7 +119,7 @@ class TagSelect extends React.Component {
           >
             <span styleName='tag-label'>#{tag}</span>
             <button styleName='tag-removeButton'
-              onClick={(e) => this.handleTagRemoveButtonClick(tag)(e)}
+              onClick={(e) => this.handleTagRemoveButtonClick(tag)}
             >
               <img className='tag-removeButton-icon' src='../resources/icon/icon-x.svg' width='8px' />
             </button>


### PR DESCRIPTION
When a tag  is deleted from a note, the taglist did not updated: the deleted tag was still in the list. If the
tag was created in the current session, it was removed, worked as expected.

The reason is: until the note is not updated, the tag list is not
initialized for first in the "delete tag button" handler, but it works
in the second case. Tried out using backspace to delete the tag, it
works.

Before:

![screencast](https://i.imgur.com/o18WmUz.gif)

After:

![screencast](https://i.imgur.com/eUyUB9G.gif)
