### PR TITLE
fix tooltip word wrap

### DIFF
--- a/browser/main/SideNav/PreferenceButton.styl
+++ b/browser/main/SideNav/PreferenceButton.styl
@@ -49,3 +49,4 @@ body[data-theme="dark"]
   border-radius 2px
   opacity 0
   transition 0.1s
+  white-space nowrap

--- a/browser/main/SideNav/SwitchButton.styl
+++ b/browser/main/SideNav/SwitchButton.styl
@@ -27,7 +27,7 @@
   padding 5px
   line-height normal
   border-radius 2px
-  opacity 1
+  opacity 0
   transition 0.1s
   white-space nowrap
 

--- a/browser/main/SideNav/SwitchButton.styl
+++ b/browser/main/SideNav/SwitchButton.styl
@@ -27,8 +27,9 @@
   padding 5px
   line-height normal
   border-radius 2px
-  opacity 0
+  opacity 1
   transition 0.1s
+  white-space nowrap
 
 body[data-theme="white"]
   .non-active-button


### PR DESCRIPTION
![test](https://user-images.githubusercontent.com/8096997/40251199-37333fec-5b0b-11e8-9492-c928954ec277.gif)

chrome will newline on one chinese/japanese word or  a space
https://codepen.io/hooklife/pen/YLdNba