### PR TITLE
added zoom in & zoom out window feature

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -266,6 +266,13 @@ const view = {
       click () {
         mainWindow.setFullScreen(!mainWindow.isFullScreen())
       }
+    },
+    {
+      role: 'zoomin',
+      accelerator: macOS ? 'CommandOrControl+Plus' : 'Control+='
+    },
+    {
+      role: 'zoomout'
     }
   ]
 }


### PR DESCRIPTION
The zoom in & zoom out window feature has been requested here: https://github.com/BoostIo/Boostnote/issues/1907

Now, users can zoom in and zoom out the boostnote window using `ctrl + '+'` and `ctrl + '-'`, respectively.

I have tested this feature on linux mint, I think it'll work on window too (I'm not very sure) and I haven't tested on mac (for obvious reason, I'm poor and can't afford a macbook :smile: )