### PR TITLE
open local file by shell

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -526,11 +526,6 @@ export default class MarkdownPreview extends React.Component {
     e.stopPropagation()
 
     const href = e.target.href
-    if (href.match(/^http/i)) {
-      shell.openExternal(href)
-      return
-    }
-
     const linkHash = href.split('/').pop()
 
     const regexNoteInternalLink = /main.html#(.+)/
@@ -562,6 +557,9 @@ export default class MarkdownPreview extends React.Component {
       eventEmitter.emit('list:jump', linkHash.split('-')[1])
       return
     }
+
+    // other case
+    shell.openExternal(href)
   }
 
   render () {


### PR DESCRIPTION
In #1944, I didn't care about local file link. Before #1944, local file is opened by shell. This PR supports the local file link again. In #2003, we discussed about custom url scheme. This implementation doesn't check the url before opening by shell, so actually it can handle the custom url. 

When I think about security, this implementation seems bit dangerous, but we can see the same behaviour before. 


@Rokt33r 