### PR TITLE
Fix yarn.lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,12 +2382,6 @@ doctrine@^2.0.0, doctrine@^2.0.2:
   dependencies:
     esutils "^2.0.2"
 
-doctrine@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
-  dependencies:
-    esutils "^2.0.2"
-
 dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,11 +2777,7 @@ eslint-plugin-promise@~3.4.0:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.2.tgz#1be2793eafe2d18b5b123b8136c269f804fe7122"
 
-<<<<<<< HEAD
 eslint-plugin-react@^7.8.2:
-=======
-eslint-plugin-react@^7.2.0:
->>>>>>> ca0b03e97ce59824c9730f08c15590c5f31ebfb0
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz#e95c9c47fece55d2303d1a67c9d01b930b88a51d"
   dependencies:


### PR DESCRIPTION
It seems the yarn.lock file is still conflicted.
This PR's diffs have been automatically produced by `yarn` command. 