### PR TITLE
Hide copy-to-clipboard buttons when printing.

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -122,6 +122,9 @@ body p {
     color: #000;
     background-color: #fff;
   }
+  .clipboardButton {
+    display: none
+  }
 }
 `
 }


### PR DESCRIPTION
It is less confusing when printing because the pdf file does not have the function to copy.