### PR TITLE
Fix wrong path of snippets.json

### DIFF
--- a/browser/lib/consts.js
+++ b/browser/lib/consts.js
@@ -13,7 +13,7 @@ const themes = fs.readdirSync(themePath)
 themes.splice(themes.indexOf('solarized'), 1, 'solarized dark', 'solarized light')
 
 const snippetFile = process.env.NODE_ENV !== 'test'
-  ? path.join(app.getPath('appData'), 'Boostnote', 'snippets.json')
+  ? path.join(app.getPath('userData'), 'snippets.json')
   : '' // return nothing as we specified different path to snippets.json in test
 
 const consts = {


### PR DESCRIPTION
@ZeroX-DG It seems using `appData` doesn't work on some other OSs(including macOS). So I think that's the reason why you couldn't repopulate this bug.