### PR TITLE
Fixed Keyboard tag unvisible in monokai theme[#1945]

### DIFF
--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -473,3 +473,5 @@ body[data-theme="monokai"]
         border-color themeMonokaiTableBorder
         &:last-child
           border-right solid 1px themeMonokaiTableBorder
+  kbd
+    background-color themeDarkBackground


### PR DESCRIPTION
Fixed [[kdb]] **background-color** to **themeDarkBackground** in monokai theme