### PR TITLE
Fix styles of button in crowdfunding tab

### DIFF
--- a/browser/main/modals/PreferencesModal/Crowdfunding.styl
+++ b/browser/main/modals/PreferencesModal/Crowdfunding.styl
@@ -11,11 +11,12 @@ p
   font-size 16px
 
 .cf-link
-  width 250px
   height 35px
   border-radius 2px
   border none
   background-color alpha(#1EC38B, 90%)
+  padding-left 20px
+  padding-right 20px
   &:hover
     background-color #1EC38B
     transition 0.2s


### PR DESCRIPTION
The text of `Support via OpenCollective` button in Crowdfunding tab is clipped when setting language to Japanese because the width of the button is fixed to `250px`.

I think it is better to set paddings to left and right instead of fixing width.

# Before

<img width="277" alt="2018-06-09 20 17 31" src="https://user-images.githubusercontent.com/21209469/41190930-478c8eb6-6c22-11e8-8668-a64c4a4937f3.png">

# After

<img width="315" alt="2018-06-09 20 17 52" src="https://user-images.githubusercontent.com/21209469/41190939-543be404-6c22-11e8-8bbe-9ff8f94a58f2.png">
