### PR TITLE
[Dark Theme]: Fixes the text color for an active note with an empty title

### DIFF
--- a/browser/components/NoteItemSimple.styl
+++ b/browser/components/NoteItemSimple.styl
@@ -134,6 +134,7 @@ body[data-theme="dark"]
     .item-simple-wrapper
       border-color transparent
     .item-simple-title
+    .item-simple-title-empty
     .item-simple-title-icon
     .item-simple-bottom-time
       color $ui-dark-text-color


### PR DESCRIPTION
This was bugging me so I fixed it :)

Before:
![screen shot 2018-06-09 at 2 35 48 pm](https://user-images.githubusercontent.com/14887287/41191616-99c40572-6bf2-11e8-9f6d-aea6cd56b5b6.png)

After:
![screen shot 2018-06-09 at 2 35 12 pm](https://user-images.githubusercontent.com/14887287/41191618-a26c91b2-6bf2-11e8-8946-2ebdbfe90dd9.png)

