### PR TITLE
Fixed info panel positioning

### DIFF
--- a/browser/main/Detail/InfoPanel.styl
+++ b/browser/main/Detail/InfoPanel.styl
@@ -11,6 +11,7 @@
 .control-infoButton-panel
   z-index 200
   margin-top 0px
+  top: 50px
   right 25px
   position absolute
   padding 20px 25px 0 25px


### PR DESCRIPTION
Fix for https://github.com/BoostIO/Boostnote/issues/2043

![infopanelfix](https://user-images.githubusercontent.com/14887287/41345941-561ad77c-6f05-11e8-9312-5b1b8afc3e10.gif)
