### PR TITLE
Fix MacOs 'M' key issue

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -277,7 +277,7 @@ class MarkdownNoteDetail extends React.Component {
 
   handleSwitchMode (type) {
     this.setState({ editorType: type }, () => {
-      this.focus();
+      this.focus()
       const newConfig = Object.assign({}, this.props.config)
       newConfig.editor.type = type
       ConfigManager.set(newConfig)

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -277,6 +277,7 @@ class MarkdownNoteDetail extends React.Component {
 
   handleSwitchMode (type) {
     this.setState({ editorType: type }, () => {
+      this.focus();
       const newConfig = Object.assign({}, this.props.config)
       newConfig.editor.type = type
       ConfigManager.set(newConfig)

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -21,8 +21,8 @@ export const DEFAULT_CONFIG = {
   listStyle: 'DEFAULT', // 'DEFAULT', 'SMALL'
   amaEnabled: true,
   hotkey: {
-    toggleMain: OSX ? 'Cmd + Alt + L' : 'Super + Alt + E',
-    toggleMode: OSX ? 'Cmd + M' : 'Ctrl + M'
+    toggleMain: OSX ? 'Command + Alt + L' : 'Super + Alt + E',
+    toggleMode: OSX ? 'Command + M' : 'Ctrl + M'
   },
   ui: {
     language: 'en',

--- a/browser/main/lib/shortcutManager.js
+++ b/browser/main/lib/shortcutManager.js
@@ -3,7 +3,7 @@ import CM from 'browser/main/lib/ConfigManager'
 import ee from 'browser/main/lib/eventEmitter'
 import { isObjectEqual } from 'browser/lib/utils'
 require('mousetrap-global-bind')
-const functions = require('./shortcut')
+import functions from './shortcut'
 
 let shortcuts = CM.get().hotkey
 


### PR DESCRIPTION
related: #2101 

# Before

In editor mode, pressing M key trigger editor mode toggle(Preview <=> Split)

# After

1. change wrong default value
2. But **those who already set hot key as 'Cmd + M' should change 'Command + M' manually**  (Because Boostnote use localStorage to save user configuration including hotkey. But It can only be changed by user)
3. change `Command + M` action to more desirable way(I make it focus after change editor mode so that It sustains focus when editing)