### PR TITLE
Fixed 'Focus Search' shortcut

### DIFF
--- a/browser/main/TopBar/index.js
+++ b/browser/main/TopBar/index.js
@@ -156,8 +156,7 @@ class TopBar extends React.Component {
     if (this.state.isSearching) {
       el.blur()
     } else {
-      el.focus()
-      el.setSelectionRange(0, el.value.length)
+      el.select()
     }
   }
 


### PR DESCRIPTION
Use 'select' instead of 'setSelectionRange' to avoid not focused when search input element has text in it. 
Fixed #2018 