### PR TITLE
Fix search value for html export path

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -225,7 +225,7 @@ export default class MarkdownPreview extends React.Component {
       const attachmentsAbsolutePaths = attachmentManagement.getAbsolutePathsOfAttachmentsInContent(noteContent, this.props.storagePath)
 
       files.forEach((file) => {
-        file = file.replace('file://', '')
+        file = file.replace('file:///', '')
         exportTasks.push({
           src: file,
           dst: 'css'

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -225,7 +225,12 @@ export default class MarkdownPreview extends React.Component {
       const attachmentsAbsolutePaths = attachmentManagement.getAbsolutePathsOfAttachmentsInContent(noteContent, this.props.storagePath)
 
       files.forEach((file) => {
-        file = file.replace('file:///', '')
+        if (global.process.platform === 'win32') {
+          file = file.replace('file:///', '')
+        } else {
+          file = file.replace('file://', '')
+        }
+
         exportTasks.push({
           src: file,
           dst: 'css'


### PR DESCRIPTION
Fixed issue: #2159

The path generated by `file-url` begins with `file:///`.

```javascript
file.replace('file://', '')  //    /C:/Users/........  wrong path.
file.replace('file:///', '') //    C:/Users/........   correct path.
```




