### PR TITLE
Hotkey for toggle editor fullscreen

### DIFF
--- a/browser/main/Detail/FullscreenButton.js
+++ b/browser/main/Detail/FullscreenButton.js
@@ -4,12 +4,14 @@ import CSSModules from 'browser/lib/CSSModules'
 import styles from './FullscreenButton.styl'
 import i18n from 'browser/lib/i18n'
 
+const OSX = global.process.platform === 'darwin'
+const hotkey = (OSX ? i18n.__('Command(⌘)') : i18n.__('Ctrl(^)')) + '+B'
 const FullscreenButton = ({
  onClick
 }) => (
   <button styleName='control-fullScreenButton' title={i18n.__('Fullscreen')} onMouseDown={(e) => onClick(e)}>
     <img styleName='iconInfo' src='../resources/icon/icon-full.svg' />
-    <span styleName='tooltip'>{i18n.__('Fullscreen')}</span>
+    <span styleName='tooltip'>{i18n.__('Fullscreen')}({hotkey})</span>
   </button>
 )
 

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -268,6 +268,19 @@ const view = {
       }
     },
     {
+      type: 'separator'
+    },
+    {
+      label: 'Toggle Side Bar',
+      accelerator: 'CommandOrControl+B',
+      click () {
+        mainWindow.webContents.send('editor:fullscreen')
+      }
+    },
+    {
+      type: 'separator'
+    },
+    {
       role: 'zoomin',
       accelerator: macOS ? 'CommandOrControl+Plus' : 'Control+='
     },


### PR DESCRIPTION
Add hotkey for toggle side bar
> <kbd>Command+B</kbd> for macos
> <kbd>Ctrl+B</kbd> for others

The **B** abbreviation for 'Side  **B**ar'.
#2165 
![kapture 2018-07-04 at 12 08 19](https://user-images.githubusercontent.com/40362568/42257197-11fea954-7f88-11e8-812c-864b1e9dea5e.gif)
