### PR TITLE
Replace shortcut for 'Next Note' and 'Previous Note'

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -235,14 +235,14 @@ const view = {
     },
     {
       label: 'Next Note',
-      accelerator: 'Control+J',
+      accelerator: 'CommandOrControl+]',
       click () {
         mainWindow.webContents.send('list:next')
       }
     },
     {
       label: 'Previous Note',
-      accelerator: 'Control+K',
+      accelerator: 'CommandOrControl+[',
       click () {
         mainWindow.webContents.send('list:prior')
       }


### PR DESCRIPTION
**Why**
Now shortcut key for **Next Note**(<kbd>ctrl+J</kbd>) and **Previous Note**(<kbd>ctrl+k</kbd>)had been conflicted with **Emac** Key map setting or **sublime** or **vim**, one of these key map settings also had It's inner use of key.   like **Emac** using  <kbd>ctrl+k</kbd> for repeatedly to kill multiple lines, but **sublime** using <kbd>ctrl+k</kbd> for combine action key. 
also see #2133 

**Do**
as above said, we need to change key map binding for 'Next Note' and 'Previous Note', I suggested that using <kbd>CommandOrCtrl+]</kbd> for 'Next Note', <kbd>CommandOrCtrl+[</kbd> for 'Previous Note'.
please review. 