### PR TITLE
New Feature: Shortcuts for focusing tag editor(CmdOrControl+Shift+T)(#2132)

### DIFF
--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -441,7 +441,7 @@ class SnippetNoteDetail extends React.Component {
           const isSuper = global.process.platform === 'darwin'
             ? e.metaKey
             : e.ctrlKey
-          if (isSuper) {
+          if (isSuper && !e.shiftKey) {
             e.preventDefault()
             this.addSnippet()
           }

--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -5,6 +5,7 @@ import styles from './TagSelect.styl'
 import _ from 'lodash'
 import AwsMobileAnalyticsConfig from 'browser/main/lib/AwsMobileAnalyticsConfig'
 import i18n from 'browser/lib/i18n'
+import ee from 'browser/main/lib/eventEmitter'
 
 class TagSelect extends React.Component {
   constructor (props) {
@@ -13,14 +14,24 @@ class TagSelect extends React.Component {
     this.state = {
       newTag: ''
     }
+    this.addtagHandler = this.handleAddTag.bind(this)
   }
 
   componentDidMount () {
     this.value = this.props.value
+    ee.on('editor:add-tag', this.addtagHandler)
   }
 
   componentDidUpdate () {
     this.value = this.props.value
+  }
+
+  componentWillUnmount () {
+    ee.off('editor:add-tag', this.addtagHandler)
+  }
+
+  handleAddTag () {
+    this.refs.newTag.focus()
   }
 
   handleNewTagInputKeyDown (e) {

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -218,6 +218,16 @@ const edit = {
       label: 'Select All',
       accelerator: 'Command+A',
       selector: 'selectAll:'
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Add Tag',
+      accelerator: 'CommandOrControl+Shift+T',
+      click () {
+        mainWindow.webContents.send('editor:add-tag')
+      }
     }
   ]
 }


### PR DESCRIPTION
Add shortcuts for focusing tag editor. Also see #2132 
Because <kbd>Control+T</kbd> is used for create new snippet.
So use:
<kbd>Command+Shift+T</kbd> for MacOSX
<kbd>Control+Shift+T</kbd> for others.

Please review.