### PR TITLE
Fix for BoostIO/Boostnote#2204

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lodash": "^4.11.1",
     "lodash-move": "^1.1.1",
     "markdown-it": "^6.0.1",
-    "markdown-it-admonition": "https://github.com/johannbre/markdown-it-admonition.git",
+    "markdown-it-admonition": "^1.0.4",
     "markdown-it-emoji": "^1.1.1",
     "markdown-it-footnote": "^3.0.0",
     "markdown-it-imsize": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5650,9 +5650,9 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-"markdown-it-admonition@https://github.com/johannbre/markdown-it-admonition.git":
-  version "1.0.2"
-  resolved "https://github.com/johannbre/markdown-it-admonition.git#e0c0fcd59e9119d6d60ed209aa3d0f1177ec0166"
+markdown-it-admonition@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-it-admonition/-/markdown-it-admonition-1.0.4.tgz#d7bbc7eb1fe6168fc8cc304de7a9d8c993acb2f5"
 
 markdown-it-emoji@^1.1.1:
   version "1.4.0"


### PR DESCRIPTION
A few others and myself were having some issues compiling from source. This was fixed when I swapped out the `markdown-it-admonition` repo to use whatever is in the yarn registry rather than the custom github repo for it, so I'm submitting that change.