### PR TITLE
Mermaid dark theme rendering fix

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -556,7 +556,7 @@ export default class MarkdownPreview extends React.Component {
     _.forEach(
       this.refs.root.contentWindow.document.querySelectorAll('.mermaid'),
       (el) => {
-        mermaidRender(el, htmlTextHelper.decodeEntities(el.innerHTML))
+        mermaidRender(el, htmlTextHelper.decodeEntities(el.innerHTML), theme)
       }
     )
   }

--- a/browser/components/render/MermaidRender.js
+++ b/browser/components/render/MermaidRender.js
@@ -1,5 +1,11 @@
 import mermaidAPI from 'mermaid'
 
+// fixes bad styling in the mermaid dark theme
+const darkThemeStyling = `
+.loopText tspan { 
+  fill: white; 
+}`
+
 function getRandomInt (min, max) {
   return Math.floor(Math.random() * (max - min)) + min
 }
@@ -13,8 +19,13 @@ function getId () {
   return id
 }
 
-function render (element, content) {
+function render (element, content, theme) {
   try {
+    let isDarkTheme = theme === "dark" || theme === "solarized-dark" || theme === "monokai"
+    mermaidAPI.initialize({
+      theme: isDarkTheme ? "dark" : "default",
+      themeCSS: isDarkTheme ? darkThemeStyling : ""
+    })
     mermaidAPI.render(getId(), content, (svgGraph) => {
       element.innerHTML = svgGraph
     })

--- a/browser/components/render/MermaidRender.js
+++ b/browser/components/render/MermaidRender.js
@@ -21,10 +21,10 @@ function getId () {
 
 function render (element, content, theme) {
   try {
-    let isDarkTheme = theme === "dark" || theme === "solarized-dark" || theme === "monokai"
+    let isDarkTheme = theme === 'dark' || theme === 'solarized-dark' || theme === 'monokai'
     mermaidAPI.initialize({
-      theme: isDarkTheme ? "dark" : "default",
-      themeCSS: isDarkTheme ? darkThemeStyling : ""
+      theme: isDarkTheme ? 'dark' : 'default',
+      themeCSS: isDarkTheme ? darkThemeStyling : ''
     })
     mermaidAPI.render(getId(), content, (svgGraph) => {
       element.innerHTML = svgGraph


### PR DESCRIPTION
Fix for https://github.com/BoostIO/Boostnote/issues/2215

![mermaiddarkfix](https://user-images.githubusercontent.com/14887287/43034361-79527da8-8d1e-11e8-999d-c2fc9aad0f63.gif)

Mermaid theme will change depending on whether the overall theme is light or dark.



