### PR TITLE
Fix for issue #2088 :  snippet notes are not displaying in markdown 

### DIFF
--- a/browser/main/lib/dataApi/attachmentManagement.js
+++ b/browser/main/lib/dataApi/attachmentManagement.js
@@ -84,7 +84,7 @@ function createAttachmentDestinationFolder (destinationStoragePath, noteKey) {
 function migrateAttachments (markdownContent, storagePath, noteKey) {
   if (noteKey !== undefined && sander.existsSync(path.join(storagePath, 'images'))) {
     const attachments = getAttachmentsInMarkdownContent(markdownContent) || []
-    if (attachments !== []) {
+    if (attachments.length) {
       createAttachmentDestinationFolder(storagePath, noteKey)
     }
     for (const attachment of attachments) {

--- a/browser/main/lib/dataApi/attachmentManagement.js
+++ b/browser/main/lib/dataApi/attachmentManagement.js
@@ -82,7 +82,7 @@ function createAttachmentDestinationFolder (destinationStoragePath, noteKey) {
  * @param noteKey Key of the current note
  */
 function migrateAttachments (markdownContent, storagePath, noteKey) {
-  if (sander.existsSync(path.join(storagePath, 'images'))) {
+  if (noteKey !== undefined && sander.existsSync(path.join(storagePath, 'images'))) {
     const attachments = getAttachmentsInMarkdownContent(markdownContent) || []
     if (attachments !== []) {
       createAttachmentDestinationFolder(storagePath, noteKey)


### PR DESCRIPTION
Fix for issue https://github.com/BoostIo/Boostnote/issues/2088.
In specific situation, when all below conditions are met :
- one of the snippets notes tabs is a Markdown tab,
- the migrateAttachments code is called on a snippet note,
- historical attachments location '/images' exists in snippet storage folder

Following exception is being thrown :
> path.js:28 Uncaught TypeError: Path must be a string. Received undefined
    at assertPath (path.js:28:11)
    at Object.join (path.js:1251:7)
    at createAttachmentDestinationFolder (<anonymous>:84:25)
    at Object.migrateAttachments (<anonymous>:101:7)
    at MarkdownPreview.rewriteIframe (<anonymous>:512:28)
    at MarkdownPreview.proxiedMethod (<anonymous>:44:30)
    at MarkdownPreview.componentDidUpdate (<anonymous>:420:54)
    at MarkdownPreview.proxiedMethod (<anonymous>:44:30)

As a result, Markdown tab is not being rendered.
The exception is a result of an undefined noteKey variable (which is defined only for full Markdown notes, not for Markdown tabs of a Snippet Note).
The solution is to skip migration of attachments for notes without noteKey (which wouldn't be possible anyway, since noteKey is a necessary for creating folder for attachments).

Additionally, the condition `attachments !== []` has been changed to `attachments.length` , because the first one always returns true , as in simple js console example  :

<img width="106" alt="97dd6db5-742b-4aaa-a8eb-e2fbbf0fd30f" src="https://user-images.githubusercontent.com/1899533/43360482-43244750-92b6-11e8-97ef-e67070ff9b99.png">
 