### PR TITLE
Automatic table of contents generation for Markdown

### DIFF
--- a/browser/lib/markdown-toc-generator.js
+++ b/browser/lib/markdown-toc-generator.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Markdown table of contents generator
+ */
+
+import toc from 'markdown-toc'
+import diacritics from 'diacritics-map'
+import stripColor from 'strip-color'
+
+/**
+ * @caseSensitiveSlugify Custom slugify function
+ * Same implementation that the original used by markdown-toc (node_modules/markdown-toc/lib/utils.js),
+ * but keeps original case to properly handle https://github.com/BoostIO/Boostnote/issues/2067
+ */
+function caseSensitiveSlugify (str) {
+  function replaceDiacritics (str) {
+    return str.replace(/[À-ž]/g, function (ch) {
+      return diacritics[ch] || ch
+    })
+  }
+  function getTitle (str) {
+    if (/^\[[^\]]+\]\(/.test(str)) {
+      var m = /^\[([^\]]+)\]/.exec(str)
+      if (m) return m[1]
+    }
+    return str
+  }
+  str = getTitle(str)
+  str = stripColor(str)
+  // str = str.toLowerCase() //let's be case sensitive
+
+  // `.split()` is often (but not always) faster than `.replace()`
+  str = str.split(' ').join('-')
+  str = str.split(/\t/).join('--')
+  str = str.split(/<\/?[^>]+>/).join('')
+  str = str.split(/[|$&`~=\\\/@+*!?({[\]})<>=.,;:'"^]/).join('')
+  str = str.split(/[。？！，、；：“”【】（）〔〕［］﹃﹄“ ”‘’﹁﹂—…－～《》〈〉「」]/).join('')
+  str = replaceDiacritics(str)
+  return str
+}
+
+export function generate (currentValue, updateCallback) {
+  const TOC_MARKER = '<!-- toc -->'
+  if (!currentValue.includes(TOC_MARKER)) {
+    currentValue = TOC_MARKER + currentValue
+  }
+  updateCallback(toc.insert(currentValue, {slugify: caseSensitiveSlugify}))
+}
+
+export default {
+  generate
+}
+

--- a/browser/lib/markdown-toc-generator.js
+++ b/browser/lib/markdown-toc-generator.js
@@ -6,6 +6,8 @@ import toc from 'markdown-toc'
 import diacritics from 'diacritics-map'
 import stripColor from 'strip-color'
 
+const EOL = require('os').EOL
+
 /**
  * @caseSensitiveSlugify Custom slugify function
  * Same implementation that the original used by markdown-toc (node_modules/markdown-toc/lib/utils.js),
@@ -17,6 +19,7 @@ function caseSensitiveSlugify (str) {
       return diacritics[ch] || ch
     })
   }
+
   function getTitle (str) {
     if (/^\[[^\]]+\]\(/.test(str)) {
       var m = /^\[([^\]]+)\]/.exec(str)
@@ -24,6 +27,7 @@ function caseSensitiveSlugify (str) {
     }
     return str
   }
+
   str = getTitle(str)
   str = stripColor(str)
   // str = str.toLowerCase() //let's be case sensitive
@@ -38,15 +42,59 @@ function caseSensitiveSlugify (str) {
   return str
 }
 
-export function generate (currentValue, updateCallback) {
-  const TOC_MARKER = '<!-- toc -->'
-  if (!currentValue.includes(TOC_MARKER)) {
-    currentValue = TOC_MARKER + currentValue
+const TOC_MARKER_START = '<!-- toc -->'
+const TOC_MARKER_END = '<!-- tocstop -->'
+
+/**
+ * Takes care of proper updating given editor with TOC.
+ * If TOC doesn't exit in the editor, it's inserted at current caret position.
+ * Otherwise,TOC is updated in place.
+ * @param editor CodeMirror editor to be updated with TOC
+ */
+export function generateInEditor (editor) {
+  const tocRegex = new RegExp(`${TOC_MARKER_START}[\\s\\S]*?${TOC_MARKER_END}`)
+
+  function tocExistsInEditor () {
+    return tocRegex.test(editor.getValue())
   }
-  updateCallback(toc.insert(currentValue, {slugify: caseSensitiveSlugify}))
+
+  function updateExistingToc () {
+    const toc = generate(editor.getValue())
+    const search = editor.getSearchCursor(tocRegex)
+    while (search.findNext()) {
+      search.replace(toc)
+    }
+  }
+
+  function addTocAtCursorPosition () {
+    const toc = generate(editor.getRange(editor.getCursor(), {line: Infinity}))
+    editor.replaceRange(wrapTocWithEol(toc, editor), editor.getCursor())
+  }
+
+  if (tocExistsInEditor()) {
+    updateExistingToc()
+  } else {
+    addTocAtCursorPosition()
+  }
+}
+
+/**
+ * Generates MD TOC based on MD document passed as string.
+ * @param markdownText MD document
+ * @returns generatedTOC String containing generated TOC
+ */
+export function generate (markdownText) {
+  const generatedToc = toc(markdownText, {slugify: caseSensitiveSlugify})
+  return TOC_MARKER_START + EOL + EOL + generatedToc.content + EOL + EOL + TOC_MARKER_END
+}
+
+function wrapTocWithEol (toc, editor) {
+  const leftWrap = editor.getCursor().ch === 0 ? '' : EOL
+  const rightWrap = editor.getLine(editor.getCursor().line).length === editor.getCursor().ch ? '' : EOL
+  return leftWrap + toc + rightWrap
 }
 
 export default {
-  generate
+  generate,
+  generateInEditor
 }
-

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -29,6 +29,7 @@ import { formatDate } from 'browser/lib/date-formatter'
 import { getTodoPercentageOfCompleted } from 'browser/lib/getTodoStatus'
 import striptags from 'striptags'
 import { confirmDeleteNote } from 'browser/lib/confirmDeleteNote'
+import markdownToc from 'browser/lib/markdown-toc-generator'
 
 class MarkdownNoteDetail extends React.Component {
   constructor (props) {
@@ -47,6 +48,7 @@ class MarkdownNoteDetail extends React.Component {
     this.dispatchTimer = null
 
     this.toggleLockButton = this.handleToggleLockButton.bind(this)
+    this.generateToc = () => this.handleGenerateToc()
   }
 
   focus () {
@@ -59,6 +61,7 @@ class MarkdownNoteDetail extends React.Component {
       const reversedType = this.state.editorType === 'SPLIT' ? 'EDITOR_PREVIEW' : 'SPLIT'
       this.handleSwitchMode(reversedType)
     })
+    ee.on('code:generate-toc', this.generateToc)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -75,6 +78,7 @@ class MarkdownNoteDetail extends React.Component {
 
   componentWillUnmount () {
     ee.off('topbar:togglelockbutton', this.toggleLockButton)
+    ee.off('code:generate-toc', this.generateToc)
     if (this.saveQueue != null) this.saveNow()
   }
 
@@ -260,6 +264,11 @@ class MarkdownNoteDetail extends React.Component {
     } else {
       this.setState({isLockButtonShown: false})
     }
+  }
+
+  handleGenerateToc () {
+    markdownToc.generate(this.refs.content.value,
+      (modifiedValue) => { this.refs.content.refs.code.setValue(modifiedValue) })
   }
 
   handleFocus (e) {

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -268,7 +268,7 @@ class MarkdownNoteDetail extends React.Component {
 
   handleGenerateToc () {
     markdownToc.generate(this.refs.content.value,
-      (modifiedValue) => { this.refs.content.refs.code.setValue(modifiedValue) })
+      (modifiedValue) => this.refs.content.refs.code.setValue(modifiedValue))
   }
 
   handleFocus (e) {

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -267,8 +267,8 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   handleGenerateToc () {
-    markdownToc.generate(this.refs.content.value,
-      (modifiedValue) => this.refs.content.refs.code.setValue(modifiedValue))
+    const editor = this.refs.content.refs.code.editor
+    markdownToc.generateInEditor(editor)
   }
 
   handleFocus (e) {

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -100,9 +100,8 @@ class SnippetNoteDetail extends React.Component {
   handleGenerateToc () {
     const currentMode = this.state.note.snippets[this.state.snippetIndex].mode
     if (currentMode.includes('Markdown')) {
-      const currentValue = this.refs['code-' + this.state.snippetIndex].value
       const currentEditor = this.refs['code-' + this.state.snippetIndex].refs.code.editor
-      markdownToc.generate(currentValue, (modifiedValue) => currentEditor.setValue(modifiedValue))
+      markdownToc.generateInEditor(currentEditor)
     }
   }
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -98,10 +98,10 @@ class SnippetNoteDetail extends React.Component {
   }
 
   handleGenerateToc () {
-    let currentMode = this.state.note.snippets[this.state.snippetIndex].mode
+    const currentMode = this.state.note.snippets[this.state.snippetIndex].mode
     if (currentMode.includes('Markdown')) {
-      let currentValue = this.refs['code-' + this.state.snippetIndex].value
-      let currentEditor = this.refs['code-' + this.state.snippetIndex].refs.code.editor
+      const currentValue = this.refs['code-' + this.state.snippetIndex].value
+      const currentEditor = this.refs['code-' + this.state.snippetIndex].refs.code.editor
       markdownToc.generate(currentValue, (modifiedValue) => { currentEditor.setValue(modifiedValue) })
     }
   }

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -98,9 +98,10 @@ class SnippetNoteDetail extends React.Component {
   }
 
   handleGenerateToc () {
-    const currentMode = this.state.note.snippets[this.state.snippetIndex].mode
+    const { note, snippetIndex } = this.state
+    const currentMode = note.snippets[snippetIndex].mode
     if (currentMode.includes('Markdown')) {
-      const currentEditor = this.refs['code-' + this.state.snippetIndex].refs.code.editor
+      const currentEditor = this.refs[`code-${snippetIndex}`].refs.code.editor
       markdownToc.generateInEditor(currentEditor)
     }
   }

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -29,6 +29,7 @@ import InfoPanelTrashed from './InfoPanelTrashed'
 import { formatDate } from 'browser/lib/date-formatter'
 import i18n from 'browser/lib/i18n'
 import { confirmDeleteNote } from 'browser/lib/confirmDeleteNote'
+import markdownToc from 'browser/lib/markdown-toc-generator'
 
 const electron = require('electron')
 const { remote } = electron
@@ -52,6 +53,7 @@ class SnippetNoteDetail extends React.Component {
     }
 
     this.scrollToNextTabThreshold = 0.7
+    this.generateToc = () => this.handleGenerateToc()
   }
 
   componentDidMount () {
@@ -65,6 +67,7 @@ class SnippetNoteDetail extends React.Component {
         enableLeftArrow: allTabs.offsetLeft !== 0
       })
     }
+    ee.on('code:generate-toc', this.generateToc)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -91,6 +94,16 @@ class SnippetNoteDetail extends React.Component {
 
   componentWillUnmount () {
     if (this.saveQueue != null) this.saveNow()
+    ee.off('code:generate-toc', this.generateToc)
+  }
+
+  handleGenerateToc () {
+    let currentMode = this.state.note.snippets[this.state.snippetIndex].mode
+    if (currentMode.includes('Markdown')) {
+      let currentValue = this.refs['code-' + this.state.snippetIndex].value
+      let currentEditor = this.refs['code-' + this.state.snippetIndex].refs.code.editor
+      markdownToc.generate(currentValue, (modifiedValue) => { currentEditor.setValue(modifiedValue) })
+    }
   }
 
   handleChange (e) {
@@ -441,7 +454,7 @@ class SnippetNoteDetail extends React.Component {
           const isSuper = global.process.platform === 'darwin'
             ? e.metaKey
             : e.ctrlKey
-          if (isSuper && !e.shiftKey) {
+          if (isSuper && !e.shiftKey && !e.altKey) {
             e.preventDefault()
             this.addSnippet()
           }

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -102,7 +102,7 @@ class SnippetNoteDetail extends React.Component {
     if (currentMode.includes('Markdown')) {
       const currentValue = this.refs['code-' + this.state.snippetIndex].value
       const currentEditor = this.refs['code-' + this.state.snippetIndex].refs.code.editor
-      markdownToc.generate(currentValue, (modifiedValue) => { currentEditor.setValue(modifiedValue) })
+      markdownToc.generate(currentValue, (modifiedValue) => currentEditor.setValue(modifiedValue))
     }
   }
 

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -228,6 +228,16 @@ const edit = {
       click () {
         mainWindow.webContents.send('editor:add-tag')
       }
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Generate/Update Markdown TOC',
+      accelerator: 'CommandOrControl+Alt+T',
+      click () {
+        mainWindow.webContents.send('code:generate-toc')
+      }
     }
   ]
 }

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -146,6 +146,16 @@ const file = {
       type: 'separator'
     },
     {
+      label: 'Generate/Update Markdown TOC',
+      accelerator: 'Shift+Ctrl+T',
+      click () {
+        mainWindow.webContents.send('code:generate-toc')
+      }
+    },
+    {
+      type: 'separator'
+    },
+    {
       label: 'Print',
       accelerator: 'CommandOrControl+P',
       click () {
@@ -227,16 +237,6 @@ const edit = {
       accelerator: 'CommandOrControl+Shift+T',
       click () {
         mainWindow.webContents.send('editor:add-tag')
-      }
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: 'Generate/Update Markdown TOC',
-      accelerator: 'CommandOrControl+Alt+T',
-      click () {
-        mainWindow.webContents.send('code:generate-toc')
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "markdown-it-named-headers": "^0.0.4",
     "markdown-it-plantuml": "^1.1.0",
     "markdown-it-smartarrows": "^1.0.1",
+    "markdown-toc": "^1.2.0",
     "mdurl": "^1.0.1",
     "mermaid": "^8.0.0-rc.8",
     "moment": "^2.10.3",

--- a/tests/helpers/setup-browser-env.js
+++ b/tests/helpers/setup-browser-env.js
@@ -1,5 +1,23 @@
 import browserEnv from 'browser-env'
-browserEnv(['window', 'document'])
+browserEnv(['window', 'document', 'navigator'])
+
+// for CodeMirror mockup
+document.body.createTextRange = function () {
+  return {
+    setEnd: function () {},
+    setStart: function () {},
+    getBoundingClientRect: function () {
+      return {right: 0}
+    },
+    getClientRects: function () {
+      return {
+        length: 0,
+        left: 0,
+        right: 0
+      }
+    }
+  }
+}
 
 window.localStorage = {
   // polyfill

--- a/tests/lib/markdown-toc-generator-test.js
+++ b/tests/lib/markdown-toc-generator-test.js
@@ -1,0 +1,444 @@
+/**
+ * @fileoverview Unit test for browser/lib/markdown-toc-generator
+ */
+const test = require('ava')
+const markdownToc = require('browser/lib/markdown-toc-generator')
+const EOL = require('os').EOL
+
+test(t => {
+  /**
+   * @testCases Contains array of test cases in format :
+   *  [
+   *     test title
+   *     input markdown,
+   *     expected output markdown with toc
+   *  ]
+   *
+   */
+  const testCases = [
+    [
+      '***************************** empty note',
+      `  
+    `,
+      ` 
+<!-- toc -->
+
+
+
+<!-- tocstop -->
+    `
+    ],
+    [
+      '***************************** single level',
+      `
+# one
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+
+<!-- tocstop -->
+
+# one
+    `
+    ],
+    [
+      '***************************** two levels',
+      `
+# one
+# two    
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+- [two](#two)
+
+<!-- tocstop -->
+
+# one
+# two    
+    `
+    ],
+    [
+      '***************************** 3 levels with children',
+      `
+# one
+## one one
+# two
+## two two
+# three
+## three three
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+- [two](#two)
+  * [two two](#two-two)
+- [three](#three)
+  * [three three](#three-three)
+
+<!-- tocstop -->
+
+# one
+## one one
+# two
+## two two
+# three
+## three three
+    `
+    ],
+    [
+      '***************************** 3 levels, 3rd with 6 sub-levels',
+      `
+# one
+## one one
+# two
+## two two
+# three
+## three three
+### three three three
+#### three three three three
+##### three three three three three
+###### three three three three three three
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+- [two](#two)
+  * [two two](#two-two)
+- [three](#three)
+  * [three three](#three-three)
+    + [three three three](#three-three-three)
+      - [three three three three](#three-three-three-three)
+        * [three three three three three](#three-three-three-three-three)
+          + [three three three three three three](#three-three-three-three-three-three)
+
+<!-- tocstop -->
+
+# one
+## one one
+# two
+## two two
+# three
+## three three
+### three three three
+#### three three three three
+##### three three three three three
+###### three three three three three three
+    `
+    ],
+    [
+      '***************************** multilevel with texts in between',
+      `
+# one
+this is a level one text
+this is a level one text
+## one one
+# two
+  this is a level two text
+  this is a level two text
+## two two
+  this is a level two two text
+  this is a level two two text
+# three
+  this is a level three three text
+  this is a level three three text
+## three three
+  this is a text
+  this is a text
+### three three three
+  this is a text
+  this is a text
+### three three three 2
+  this is a text
+  this is a text
+#### three three three three
+  this is a text
+  this is a text
+#### three three three three 2
+  this is a text
+  this is a text
+##### three three three three three
+  this is a text
+  this is a text
+##### three three three three three 2
+  this is a text
+  this is a text
+###### three three three three three three
+  this is a text
+  this is a text
+  this is a text      
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+- [two](#two)
+  * [two two](#two-two)
+- [three](#three)
+  * [three three](#three-three)
+    + [three three three](#three-three-three)
+    + [three three three 2](#three-three-three-2)
+      - [three three three three](#three-three-three-three)
+      - [three three three three 2](#three-three-three-three-2)
+        * [three three three three three](#three-three-three-three-three)
+        * [three three three three three 2](#three-three-three-three-three-2)
+          + [three three three three three three](#three-three-three-three-three-three)
+
+<!-- tocstop -->
+
+# one
+this is a level one text
+this is a level one text
+## one one
+# two
+  this is a level two text
+  this is a level two text
+## two two
+  this is a level two two text
+  this is a level two two text
+# three
+  this is a level three three text
+  this is a level three three text
+## three three
+  this is a text
+  this is a text
+### three three three
+  this is a text
+  this is a text
+### three three three 2
+  this is a text
+  this is a text
+#### three three three three
+  this is a text
+  this is a text
+#### three three three three 2
+  this is a text
+  this is a text
+##### three three three three three
+  this is a text
+  this is a text
+##### three three three three three 2
+  this is a text
+  this is a text
+###### three three three three three three
+  this is a text
+  this is a text
+  this is a text
+    `
+    ],
+    [
+      '***************************** already generated toc',
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+- [two](#two)
+  * [two two](#two-two)
+- [three](#three)
+  * [three three](#three-three)
+    + [three three three](#three-three-three)
+      - [three three three three](#three-three-three-three)
+        * [three three three three three](#three-three-three-three-three)
+          + [three three three three three three](#three-three-three-three-three-three)
+
+<!-- tocstop -->
+
+# one
+## one one
+# two
+## two two
+# three
+## three three
+### three three three
+#### three three three three
+##### three three three three three
+###### three three three three three three      
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+- [two](#two)
+  * [two two](#two-two)
+- [three](#three)
+  * [three three](#three-three)
+    + [three three three](#three-three-three)
+      - [three three three three](#three-three-three-three)
+        * [three three three three three](#three-three-three-three-three)
+          + [three three three three three three](#three-three-three-three-three-three)
+
+<!-- tocstop -->
+
+# one
+## one one
+# two
+## two two
+# three
+## three three
+### three three three
+#### three three three three
+##### three three three three three
+###### three three three three three three            
+    `
+    ],
+    [
+      '***************************** note with just an opening TOC marker',
+      `
+<!-- toc -->
+
+
+# one
+## one one
+      
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+
+<!-- tocstop -->
+
+# one
+## one one
+    `
+    ],
+    [
+      '***************************** note with just a closing TOC marker',
+      `
+<!-- tocstop -->
+
+# one
+## one one     
+    `,
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+
+<!-- tocstop -->
+
+# one
+## one one
+      
+    `
+    ],
+
+    [
+      '***************************** outdated TOC',
+      `
+<!-- toc -->
+
+- [one](#one)
+  * [one one](#one-one)
+
+<!-- tocstop -->
+
+# one modified
+## one one
+      
+    `,
+      `
+<!-- toc -->
+
+- [one modified](#one-modified)
+  * [one one](#one-one)
+
+<!-- tocstop -->
+
+# one modified
+## one one      
+    `
+    ],
+    [
+      '***************************** properly generated case sensitive TOC',
+      `
+# onE 
+## oNe one
+    `,
+      `
+<!-- toc -->
+
+- [onE](#onE)
+  * [oNe one](#oNe-one)
+
+<!-- tocstop -->
+
+# onE 
+## oNe one      
+    `
+    ],
+    [
+      '***************************** position of TOC is stable (do not use elements above toc marker)',
+      `
+# title
+
+this is a text
+
+<!-- toc -->
+
+- [onE](#onE)
+  * [oNe one](#oNe-one)
+
+<!-- tocstop -->
+
+# onE 
+## oNe one      
+    `,
+      `
+# title
+
+this is a text
+
+<!-- toc -->
+
+- [onE](#onE)
+  * [oNe one](#oNe-one)
+
+<!-- tocstop -->
+
+# onE 
+## oNe one      
+    `
+    ],
+    [
+      '***************************** properly handle generation of not completed TOC',
+      `
+# hoge
+
+##     
+    `,
+      `
+<!-- toc -->
+
+- [hoge](#hoge)
+
+<!-- tocstop -->
+
+# hoge
+
+##      
+    `
+    ]
+  ]
+
+  testCases.forEach(testCase => {
+    const title = testCase[0]
+    const inputMd = testCase[1].trim()
+    const expectedOutput = testCase[2].trim()
+    let generatedOutput
+    markdownToc.generate(inputMd, (o) => { generatedOutput = o.trim() })
+    t.is(generatedOutput, expectedOutput, `Test ${title} , generated : ${EOL}${generatedOutput}, expected : ${EOL}${expectedOutput}`)
+  })
+})

--- a/webpack-skeleton.js
+++ b/webpack-skeleton.js
@@ -37,6 +37,7 @@ var config = {
     'markdown-it-kbd',
     'markdown-it-plantuml',
     'markdown-it-admonition',
+    'markdown-toc',
     'devtron',
     '@rokt33r/season',
     {


### PR DESCRIPTION
This PR aims to solve #1436.

- Adds table of contents for any currently displayed Markdown note or Markdown snippet, at current cursor position.
- Consequent generations update existing TOC.
- Generated TOC is case sensitive to handle #2067

**Shortcut** : _SHIFT+CTRL+T_
**Menu** : _File / Generate/Update Markdown TOC_