### PR TITLE
Tasks checkboxes: display date of task completion

### DIFF
--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -142,6 +142,7 @@ class MarkdownEditor extends React.Component {
     const idMatch = /checkbox-([0-9]+)/
     const checkedMatch = /\[x\]/i
     const uncheckedMatch = /\[ \]/
+    const doneMatch = /\*@done(.*)\)\*/
     if (idMatch.test(e.target.getAttribute('id'))) {
       const lineIndex = parseInt(e.target.getAttribute('id').match(idMatch)[1], 10) - 1
       const lines = this.refs.code.value
@@ -151,9 +152,12 @@ class MarkdownEditor extends React.Component {
 
       if (targetLine.match(checkedMatch)) {
         lines[lineIndex] = targetLine.replace(checkedMatch, '[ ]')
+        lines[lineIndex] = lines[lineIndex].replace(doneMatch, '')
       }
       if (targetLine.match(uncheckedMatch)) {
+        const currentDate = new Date()
         lines[lineIndex] = targetLine.replace(uncheckedMatch, '[x]')
+        lines[lineIndex] += ' *@done (' + currentDate.toLocaleString() + ')*'
       }
       this.refs.code.setValue(lines.join('\n'))
     }

--- a/browser/components/markdown.styl
+++ b/browser/components/markdown.styl
@@ -180,6 +180,9 @@ ul
     display list-item
     &.taskListItem
       list-style none
+      em
+        font-style italic
+        color lightgrey
     p
       margin 0
   &>li>ul, &>li>ol


### PR DESCRIPTION
Issue: https://github.com/BoostIO/Boostnote/issues/2286

When using plaintask, I liked having the time of completion of a task automatically written when I completed it...  

Here is a capture of the feature:
<img width="434" alt="capture d ecran 2018-08-11 a 11 39 04" src="https://user-images.githubusercontent.com/1784781/43990366-7d9622e6-9d5b-11e8-9e65-dab5cce4bb9a.png">

The "@done" text with the date will diseappear if you uncheck the task. The date is written in the local format.
