### PR TITLE
fixing bug #2321 

### DIFF
--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -198,12 +198,12 @@ class SideNav extends React.Component {
     const tags = pathSegments[pathSegments.length - 1]
     return (tags === 'alltags')
       ? []
-      : tags.split(' ')
+      : tags.split(' ').map(tag => decodeURIComponent(tag))
   }
 
   handleClickTagListItem (name) {
     const { router } = this.context
-    router.push(`/tags/${name}`)
+    router.push(`/tags/${encodeURIComponent(name)}`)
   }
 
   handleSortTagsByChange (e) {
@@ -230,7 +230,7 @@ class SideNav extends React.Component {
     } else {
       listOfTags.push(tag)
     }
-    router.push(`/tags/${listOfTags.join(' ')}`)
+    router.push(`/tags/${listOfTags.map(tag => encodeURIComponent(tag)).join(' ')}`)
   }
 
   emptyTrash (entries) {


### PR DESCRIPTION
This change is fixing the bug #2321 due to the unescaped characters `#` or `?` in the route.