### PR TITLE
fixing Mermaid diagram's height

### DIFF
--- a/browser/components/render/MermaidRender.js
+++ b/browser/components/render/MermaidRender.js
@@ -28,6 +28,7 @@ function render (element, content, theme) {
     })
     mermaidAPI.render(getId(), content, (svgGraph) => {
       element.innerHTML = svgGraph
+      element.style.height = element.attributes.getNamedItem('data-height').value + 'vh'
     })
   } catch (e) {
     console.error(e)

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -44,7 +44,7 @@ class Markdown {
           return `<pre class="chart">${str}</pre>`
         }
         if (langType === 'mermaid') {
-          return `<pre class="mermaid">${str}</pre>`
+          return `<pre class="mermaid" data-height="${fileName}">${str}</pre>`
         }
         return '<pre class="code CodeMirror">' +
           '<span class="filename">' + fileName + '</span>' +

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -384,3 +384,7 @@ modalmonokai()
   background-color $ui-monokai-backgroundColor
   overflow hidden
   border-radius $modal-border-radius
+
+pre.mermaid svg {
+  max-width 100% !important
+}


### PR DESCRIPTION
This change allows to specify the desired height of the diagram (in percentage in `vh`).
It should be able to fix #2335.

For example:
~~~
```mermaid:50
graph TB
	c1-->c2
	c2-->c3
	c3-->c4
	c4-->c5
	c5-->c6
```
~~~
