### PR TITLE
Statusbar height fix

### DIFF
--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -5,7 +5,7 @@ $danger-color = #c9302c
 $danger-lighten-color = lighten(#c9302c, 5%)
 
 // Layouts
-$statusBar-height = 22px
+$statusBar-height = 28px
 $sideNav-width = 200px
 $sideNav--folded-width = 44px
 $topBar-height = 60px


### PR DESCRIPTION
Was about to start another issue and noticed this. It really bugged me so I fixed it 😄This also stops the scrollbar from covering the status bar. If can't see the issue check the bottom right corner of the screenshots.

BEFORE:
<img width="1440" alt="screen shot 2018-09-01 at 12 53 28 pm" src="https://user-images.githubusercontent.com/14887287/44941731-9f360100-ade6-11e8-97a5-fd422808a55e.png">

AFTER:
<img width="1440" alt="screen shot 2018-09-01 at 12 56 24 pm" src="https://user-images.githubusercontent.com/14887287/44941732-a65d0f00-ade6-11e8-9275-81dac455b478.png">