### PR TITLE
change storage header from Storages to Storage Locations

### DIFF
--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -56,7 +56,7 @@ class Main extends React.Component {
   init () {
     dataApi
       .addStorage({
-        name: 'My Storage',
+        name: 'My Storage Location',
         path: path.join(remote.app.getPath('home'), 'Boostnote')
       })
       .then(data => {

--- a/browser/main/modals/PreferencesModal/StoragesTab.js
+++ b/browser/main/modals/PreferencesModal/StoragesTab.js
@@ -70,7 +70,7 @@ class StoragesTab extends React.Component {
     })
     return (
       <div styleName='list'>
-        <div styleName='header'>{i18n.__('Storages')}</div>
+        <div styleName='header'>{i18n.__('Storage Locations')}</div>
         {storageList.length > 0
           ? storageList
           : <div styleName='list-empty'>{i18n.__('No storage found.')}</div>

--- a/locales/da.json
+++ b/locales/da.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Print",
 	"Your preferences for Boostnote": "Your preferences for Boostnote",
-	"Storages": "Storages",
+	"Storage Locations": "Storage Locations",
 	"Add Storage Location": "Add Storage Location",
 	"Add Folder": "Add Folder",
 	"Open Storage folder": "Open Storage folder",

--- a/locales/de.json
+++ b/locales/de.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Drucken",
 	"Your preferences for Boostnote": "Boostnote Einstellungen",
-	"Storages": "Speicherverwaltung",
+	"Storage Locations": "Speicherverwaltung",
 	"Add Storage Location": "Speicherort hinzufügen",
 	"Add Folder": "Ordner hinzufügen",
 	"Open Storage folder": "Speicherort öffnen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,7 +23,7 @@
 	"Your preferences for Boostnote": "Your preferences for Boostnote",
 	"Help": "Help",
 	"Hide Help": "Hide Help",
-	"Storages": "Storages",
+	"Storage Locations": "Storage Locations",
 	"Add Storage Location": "Add Storage Location",
 	"Add Folder": "Add Folder",
 	"Select Folder": "Select Folder",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Imprimir",
 	"Your preferences for Boostnote": "Tus preferencias para Boostnote",
-	"Storages": "Almacenamientos",
+	"Storage Locations": "Almacenamientos",
 	"Add Storage Location": "Añadir ubicación de almacenamiento",
 	"Add Folder": "Añadir carpeta",
 	"Open Storage folder": "Abrir carpeta de almacenamiento",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -20,7 +20,7 @@
     ".html": ".html",
     "Print": "پرینت",
     "Your preferences for Boostnote": "تنظیمات شما برای boostnote",
-    "Storages": "ذخیره سازی",
+    "Storage Locations": "ذخیره سازی",
     "Add Storage Location": "افزودن محل ذخیره سازی",
     "Add Folder": "ساخت پوشه",
     "Open Storage folder": "بازکردن پوشه ذخیره سازی",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Imprimer",
 	"Your preferences for Boostnote": "Vos préférences pour Boostnote",
-	"Storages": "Stockages",
+	"Storage Locations": "Stockages",
 	"Add Storage Location": "Ajouter un espace de stockage",
 	"Add Folder": "Ajouter un dossier",
 	"Open Storage folder": "Ouvrir un dossier de stockage",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -23,7 +23,7 @@
 	"Your preferences for Boostnote": "Boostnote beállításaid",
 	"Help": "Súgó",
 	"Hide Help": "Súgó Elrejtése",
-	"Storages": "Tárolók",
+	"Storage Locations": "Tárolók",
 	"Add Storage Location": "Tároló Hozzáadása",
 	"Add Folder": "Könyvtár Hozzáadása",
 	"Select Folder": "Könyvtár Kiválasztása",

--- a/locales/it.json
+++ b/locales/it.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Stampa",
 	"Your preferences for Boostnote": "Le tue preferenze per Boostnote",
-	"Storages": "Posizioni",
+	"Storage Locations": "Posizioni",
 	"Add Storage Location": "Aggiungi posizione",
 	"Add Folder": "Aggiungi cartella",
 	"Open Storage folder": "Apri cartella di memoria",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -23,7 +23,7 @@
 	"Your preferences for Boostnote": "Boostnoteの個人設定",
 	"Help": "ヘルプ",
 	"Hide Help": "ヘルプを隠す",
-	"Storages": "ストレージ",
+	"Storage Locations": "ストレージ",
 	"Add Storage Location": "ストレージロケーションを追加",
 	"Add Folder": "フォルダを追加",
 	"Select Folder": "フォルダを選択",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "인쇄",
 	"Your preferences for Boostnote": "Boostnote 설정",
-	"Storages": "저장소",
+	"Storage Locations": "저장소",
 	"Add Storage Location": "저장소 위치 추가",
 	"Add Folder": "폴더 추가",
 	"Open Storage folder": "저장소 위치 열기",

--- a/locales/no.json
+++ b/locales/no.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Print",
 	"Your preferences for Boostnote": "Your preferences for Boostnote",
-	"Storages": "Storages",
+	"Storage Locations": "Storage Locations",
 	"Add Storage Location": "Add Storage Location",
 	"Add Folder": "Add Folder",
 	"Open Storage folder": "Open Storage folder",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -22,7 +22,7 @@
   "Print": "Drukuj",
   "Help": "Pomoc",
 	"Your preferences for Boostnote": "Twoje ustawienia dla Boostnote",
-	"Storages": "Storages",
+	"Storage Locations": "Storage Locations",
 	"Add Storage Location": "Dodaj miejsce zapisu",
 	"Add Folder": "Dodaj Folder",
 	"Open Storage folder": "Otwórz folder zapisu",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Imprimir",
 	"Your preferences for Boostnote": "Suas preferências para o Boostnote",
-	"Storages": "Armazenamentos",
+	"Storage Locations": "Armazenamentos",
 	"Add Storage Location": "Adicionar Local de Armazenamento",
 	"Add Folder": "Adicionar Pasta",
 	"Open Storage folder": "Abrir Local de Armazenamento",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Print",
 	"Your preferences for Boostnote": "Your preferences for Boostnote",
-	"Storages": "Storages",
+	"Storage Locations": "Storage Locations",
 	"Add Storage Location": "Add Storage Location",
 	"Add Folder": "Add Folder",
 	"Open Storage folder": "Open Storage folder",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Print",
 	"Your preferences for Boostnote": "Настройки Boostnote",
-	"Storages": "Хранилища",
+	"Storage Locations": "Хранилища",
 	"Add Storage Location": "Добавить хранилище",
 	"Add Folder": "Добавить папку",
 	"Open Storage folder": "Открыть хранилище",

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Print",
 	"Your preferences for Boostnote": "Your preferences for Boostnote",
-	"Storages": "Storages",
+	"Storage Locations": "Storage Locations",
 	"Add Storage Location": "Add Storage Location",
 	"Add Folder": "Add Folder",
 	"Open Storage folder": "Open Storage folder",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "Yazdır",
 	"Your preferences for Boostnote": "Boostnote tercihleriniz",
-	"Storages": "Saklama Alanları",
+	"Storage Locations": "Saklama Alanları",
 	"Add Storage Location": "Saklama Yeri Ekle",
 	"Add Folder": "Dosya Ekle",
 	"Open Storage folder": "Saklama Alanı Dosyasını Aç",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "打印",
 	"Your preferences for Boostnote": "个性设置",
-	"Storages": "本地存储",
+	"Storage Locations": "本地存储",
 	"Add Storage Location": "添加一个本地存储位置",
 	"Add Folder": "新建文件夹",
 	"Open Storage folder": "打开本地存储文件夹",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -20,7 +20,7 @@
 	".html": ".html",
 	"Print": "列印",
 	"Your preferences for Boostnote": "Boostnote 偏好設定",
-	"Storages": "儲存空間",
+	"Storage Locations": "儲存空間",
 	"Add Storage Location": "新增儲存位置",
 	"Add Folder": "新增資料夾",
 	"Open Storage folder": "開啟儲存資料夾",


### PR DESCRIPTION
Change the header "Storages" to "Storage Locations" in English.

<img width="1207" alt="screen shot 2018-09-18 at 10 17 45 am" src="https://user-images.githubusercontent.com/11466782/45697756-1af4b500-bb2c-11e8-8e30-cc39bc558b06.png">

<img width="1093" alt="screen shot 2018-09-18 at 10 19 52 am 1" src="https://user-images.githubusercontent.com/11466782/45697887-6a3ae580-bb2c-11e8-8639-4cc552d6eb93.png">

This is more consistent with the "Add Storage Location" button and makes more sense in English. Happy to hear feedback!
