### PR TITLE
Monokai theme fixes

### DIFF
--- a/browser/components/NoteItem.styl
+++ b/browser/components/NoteItem.styl
@@ -368,13 +368,13 @@ body[data-theme="monokai"]
     .item-title
     .item-title-icon
     .item-bottom-time
-      color $ui-monokai-text-color
+      color $ui-monokai-active-color
     .item-bottom-tagList-item
       background-color alpha(white, 10%)
       color $ui-monokai-text-color
     &:hover
       // background-color alpha($ui-monokai-button--active-backgroundColor, 60%)
-      color #c0392b
+      color #f92672
       .item-bottom-tagList-item
         background-color alpha(#fff, 20%)
 

--- a/browser/components/NoteItemSimple.styl
+++ b/browser/components/NoteItemSimple.styl
@@ -240,7 +240,7 @@ body[data-theme="monokai"]
       .item-simple-title-icon
       .item-simple-bottom-time
         transition 0.15s
-        color $ui-solarized-dark-text-color
+        color $ui-monokai-text-color
       .item-simple-bottom-tagList-item
         transition 0.15s
         background-color alpha(#fff, 20%)

--- a/browser/components/TodoListPercentage.styl
+++ b/browser/components/TodoListPercentage.styl
@@ -39,7 +39,7 @@ body[data-theme="dark"]
 
   .percentageText
     color $ui-dark-text-color
-    
+
 body[data-theme="solarized-dark"]
   .percentageBar
     background-color #002b36
@@ -52,10 +52,10 @@ body[data-theme="solarized-dark"]
 
 body[data-theme="monokai"]
   .percentageBar
-    background-color #f92672
+    background-color: $ui-monokai-borderColor
 
   .progressBar
-    background-color: #373831
+    background-color $ui-monokai-active-color
 
   .percentageText
-    color #fdf6e3
+    color $ui-monokai-text-color

--- a/browser/main/Detail/TagSelect.styl
+++ b/browser/main/Detail/TagSelect.styl
@@ -74,4 +74,4 @@ body[data-theme="monokai"]
     background-color transparent
 
   .tag-label
-    color $ui-monokai-borderColor
+    color $ui-monokai-text-color

--- a/browser/main/Detail/TagSelect.styl
+++ b/browser/main/Detail/TagSelect.styl
@@ -67,11 +67,11 @@ body[data-theme="solarized-dark"]
 
 body[data-theme="monokai"]
   .tag
-    background-color $ui-monokai-button-backgroundColor
+    background-color $ui-monokai-tag-backgroundColor
 
   .tag-removeButton
     border-color $ui-button--focus-borderColor
     background-color transparent
 
   .tag-label
-    color $ui-monokai-text-color
+    color $ui-monokai-borderColor

--- a/browser/main/Detail/ToggleModeButton.styl
+++ b/browser/main/Detail/ToggleModeButton.styl
@@ -61,5 +61,5 @@ body[data-theme="monokai"]
   .control-toggleModeButton
       background-color #373831
     .active
-      background-color #1EC38B
+      background-color #f92672
       box-shadow 2px 0px 7px #222222

--- a/browser/main/Detail/ToggleModeButton.styl
+++ b/browser/main/Detail/ToggleModeButton.styl
@@ -59,7 +59,7 @@ body[data-theme="solarized-dark"]
 
 body[data-theme="monokai"]
   .control-toggleModeButton
-      background-color #272822
+      background-color #373831
     .active
       background-color #1EC38B
       box-shadow 2px 0px 7px #222222

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -369,7 +369,7 @@ $ui-monokai-active-color = #f92672
 
 $ui-monokai-borderColor = #373831
 
-$ui-monokai-tag-backgroundColor = #f92672
+$ui-monokai-tag-backgroundColor = #A6E22E
 
 $ui-monokai-button-backgroundColor = #373831
 $ui-monokai-button--active-color = white

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -369,7 +369,7 @@ $ui-monokai-active-color = #f92672
 
 $ui-monokai-borderColor = #373831
 
-$ui-monokai-tag-backgroundColor = #A6E22E
+$ui-monokai-tag-backgroundColor = #373831
 
 $ui-monokai-button-backgroundColor = #373831
 $ui-monokai-button--active-color = white


### PR DESCRIPTION
Updated the Monokai theme to fix a few styling bugs and updated the styling of the NoteItem, NoteItemSimple, toggleModeButton and the TodoListPercentage to follow the logic of the new Dracula theme.

![new_monokai](https://user-images.githubusercontent.com/14887287/46219993-25dbf080-c349-11e8-99f4-b41bac2af35c.gif)
