### PR TITLE
Rewrite the crowdfunding copy

### DIFF
--- a/browser/main/modals/PreferencesModal/Crowdfunding.js
+++ b/browser/main/modals/PreferencesModal/Crowdfunding.js
@@ -31,7 +31,7 @@ class Crowdfunding extends React.Component {
         <p>{i18n.__('To support our growing userbase, and satisfy community expectations,')}</p>
         <p>{i18n.__('we would like to invest more time and resources in this project.')}</p>
         <br />
-        <p>{i18n.__(`If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!`)}</p>
+        <p>{i18n.__('If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!')}</p>
         <br />
         <p>{i18n.__('Thanks,')}</p>
         <p>{i18n.__('The Boostnote Team')}</p>

--- a/locales/da.json
+++ b/locales/da.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote is used in about 200 different countries and regions by an awesome community of developers.",
 	"To support our growing userbase, and satisfy community expectations,": "To support our growing userbase, and satisfy community expectations,",
 	"we would like to invest more time and resources in this project.": "we would like to invest more time and resources in this project.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!",
 	"Thanks,": "Thanks,",
 	"The Boostnote Team": "The Boostnote Team",
 	"Support via OpenCollective": "Support via OpenCollective",

--- a/locales/de.json
+++ b/locales/de.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote wird in über 200 verschiedenen Ländern von einer großartigen Community von Entwicklern verwendet.",
 	"To support our growing userbase, and satisfy community expectations,": "Um die Erwartungen der Community weiterhin erfüllen zu können und die Verbreitung von Boostnote weiter voranzutreiben,",
 	"we would like to invest more time and resources in this project.": "würden wir gern mehr Zeit und Resourcen in dieses Projekt investieren.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Wenn dir dieses Projekt gefällt und du sein Potential erkennst, kannst du uns gern mit OpenCollective unterstützen!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Wenn dir dieses Projekt gefällt und du sein Potential erkennst, kannst du uns gern mit OpenCollective unterstützen!",
 	"Thanks,": "Vielen Dank,",
 	"The Boostnote Team": "Dein Boostnote Team",
 	"Support via OpenCollective": "Unterstützen mit OpenCollective",

--- a/locales/en.json
+++ b/locales/en.json
@@ -95,7 +95,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote is used in about 200 different countries and regions by an awesome community of developers.",
 	"To support our growing userbase, and satisfy community expectations,": "To support our growing userbase, and satisfy community expectations,",
 	"we would like to invest more time and resources in this project.": "we would like to invest more time and resources in this project.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!",
 	"Thanks,": "Thanks,",
 	"The Boostnote Team": "The Boostnote Team",
 	"Support via OpenCollective": "Support via OpenCollective",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote es utilizado en alrededor de 200 países y regiones diferentes por una increíble comunidad de desarrolladores.",
 	"To support our growing userbase, and satisfy community expectations,": "Para continuar apoyando este crecimiento y satisfacer las expectativas de la comunidad,",
 	"we would like to invest more time and resources in this project.": "nos gustaría invertir más tiempo y recursos en este proyecto.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Si te gusta este proyecto y ves su potencial, ¡puedes ayudar apoyándonos en OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Si te gusta este proyecto y ves su potencial, ¡puedes ayudar apoyándonos en OpenCollective!",
 	"Thanks,": "Gracias,",
 	"The Boostnote Team": "Equipo de Boostnote",
 	"Support via OpenCollective": "Contribuir vía OpenCollective",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -88,7 +88,7 @@
     "Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "در ۲۰۰ کشور مختلف دنیا مورد توسط جمعی از برنامه نویسان بی نظیر مورد استفاده قرار میگیرد.  Boostnote",
     "To support our growing userbase, and satisfy community expectations,": "برای حمایت از این رشد ، و برآورده شدن انتظارات کامینیتی,",
     "we would like to invest more time and resources in this project.": "ما می خواهیم زمان و منابع بیشتری را در این پروژه سرمایه گذاری کنیم.",
-    "If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "اگر این پروژه را دوست دارید و پتانسیلی در آن می‌بینید، میتوانید مارا در اوپن‌ کالکتیو حمایت کنید.",
+    "If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "اگر این پروژه را دوست دارید و پتانسیلی در آن می‌بینید، میتوانید مارا در اوپن‌ کالکتیو حمایت کنید.",
     "Thanks,": "با تشکر,",
     "The Boostnote Team": "Boostnote نگهدارندگان",
     "Support via OpenCollective": "حمایت کنید OpenCollective از طریق",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -87,7 +87,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote est utilisé dans plus de 200 pays et régions par une impressionnante communauté de développeurs.",
 	"To support our growing userbase, and satisfy community expectations,": "Afin de continuer à grandir, et de satisfaire les attentes de la communauté,",
 	"we would like to invest more time and resources in this project.": "nous aimerions investir d'avantage de temps et de ressources dans ce proje.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Si vous aimez ce projet et que vous en voyez tout le potentiel, vous pouvez aider par un support sur OpenCollective !",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Si vous aimez ce projet et que vous en voyez tout le potentiel, vous pouvez aider par un support sur OpenCollective !",
 	"Thanks,": "Merci,",
 	"The Boostnote Team": "Les mainteneurs de Boostnote",
 	"Support via OpenCollective": "Support via OpenCollective",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -95,7 +95,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "A Boostnote-ot több, mint 200 ország és régió fantasztikus fejlesztői használják.",
 	"To support our growing userbase, and satisfy community expectations,": "Hogy folytathassuk ezt a fejlődést és kielégíthessük a felhasználói elvárásokat,",
 	"we would like to invest more time and resources in this project.": "több időt és erőforrást szeretnénk a projektbe fektetni.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Ha tetszik a projekt és hasznosnak találod, te is segíthetsz ebben az OpenCollective-en keresztül küldött támogatásoddal.",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Ha tetszik a projekt és hasznosnak találod, te is segíthetsz ebben az OpenCollective-en keresztül küldött támogatásoddal.",
 	"Thanks,": "Köszönjük!",
 	"The Boostnote Team": "A Boostnote csapata",
 	"Support via OpenCollective": "Támogatás Küldése",

--- a/locales/it.json
+++ b/locales/it.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote è usato in circa 200 Paesi da una fantastica community di sviluppatori.",
 	"To support our growing userbase, and satisfy community expectations,": "Per continuare a supportarne la crescita, e per soddisfare le aspettative della comunità,",
 	"we would like to invest more time and resources in this project.": "ci piacerebbe investire più tempo e risorse in questo progetto.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Se ti piace questo progetto e ci vedi del potenziale, puoi aiutarci dandodci supporto su OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Se ti piace questo progetto e ci vedi del potenziale, puoi aiutarci dandodci supporto su OpenCollective!",
 	"Thanks,": "Grazie,",
 	"The Boostnote Team": "I mantainers di Boostnote",
 	"Support via OpenCollective": "Supporta su OpenCollective",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -95,7 +95,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote はおよそ 200 の国と地域において、開発者コミュニティを中心に利用されています。",
 	"To support our growing userbase, and satisfy community expectations,": "この成長を持続し、またコミュニティからの要望に答えるため、",
 	"we would like to invest more time and resources in this project.": "私達はこのプロジェクトにより多くの時間とリソースを投資したいと考えています。",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "もしあなたがこのプロジェクトとそのポテンシャルを気に入っていただけたのであれば、OpenCollective を通じて支援いただくことができます！",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "もしあなたがこのプロジェクトとそのポテンシャルを気に入っていただけたのであれば、OpenCollective を通じて支援いただくことができます！",
 	"Thanks,": "ありがとうございます。",
 	"The Boostnote Team": "Boostnote メンテナンスチーム",
 	"Support via OpenCollective": "OpenCollective を通じて支援します",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote는 200여개의 국가에서 뛰어난 개발자들에게 사용되어지고 있습니다.",
 	"To support our growing userbase, and satisfy community expectations,": "성장을 계속하기 위해 그리고 커뮤니티의 기대를 만족시키기 위해서,",
 	"we would like to invest more time and resources in this project.": "저희도 시간과 자원을 더 쏟아붓고 싶습니다.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "만약 이 프로젝트가 마음에 들고 가능성이 보이신다면, 저희를 OpenCollective에서 도와주세요!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "만약 이 프로젝트가 마음에 들고 가능성이 보이신다면, 저희를 OpenCollective에서 도와주세요!",
 	"Thanks,": "감사합니다,",
 	"The Boostnote Team": "Boostnote 메인테이너",
 	"Support via OpenCollective": "OpenCollective로 지원하기",

--- a/locales/no.json
+++ b/locales/no.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote is used in about 200 different countries and regions by an awesome community of developers.",
 	"To support our growing userbase, and satisfy community expectations,": "To support our growing userbase, and satisfy community expectations,",
 	"we would like to invest more time and resources in this project.": "we would like to invest more time and resources in this project.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!",
 	"Thanks,": "Thanks,",
 	"The Boostnote Team": "The Boostnote Team",
 	"Support via OpenCollective": "Support via OpenCollective",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -94,7 +94,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote jest używany w około 200 krajach i regionach przez wspaniałą społeczność programistów.",
 	"To support our growing userbase, and satisfy community expectations,": "Chcielibyśmy poświęcić więcej czasu na rozwój naszego projektu",
 	"we would like to invest more time and resources in this project.": "aby popularność i satysfakcja naszej społeczności ciągle wzrastała.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Jeśli podoba Ci się naszy projekt i lubisz go używać, możesz wspomóc nasz przez OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Jeśli podoba Ci się naszy projekt i lubisz go używać, możesz wspomóc nasz przez OpenCollective!",
 	"Thanks,": "Dzięki,",
 	"The Boostnote Team": "Kontrybutorzy Boostnote",
 	"Support via OpenCollective": "Wspomóż przez OpenCollective",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "O Boostnote é usado em cerca de 200 países e regiões diferentes por uma incrível comunidade de desenvolvedores.",
 	"To support our growing userbase, and satisfy community expectations,": "Para continuar apoiando o crescimento e satisfazer as expectativas da comunidade,",
 	"we would like to invest more time and resources in this project.": "gostaríamos de investir mais tempo e recursos neste projeto.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Se você gosta deste projeto e vê o seu potencial, você pode nos ajudar apoiando-nos no OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Se você gosta deste projeto e vê o seu potencial, você pode nos ajudar apoiando-nos no OpenCollective!",
 	"Thanks,": "Obrigado,",
 	"The Boostnote Team": "Mantenedores do Boostnote",
 	"Support via OpenCollective": "Suporte via OpenCollective",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -88,7 +88,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote is used in about 200 different countries and regions by an awesome community of developers.",
 	"To support our growing userbase, and satisfy community expectations,": "To support our growing userbase, and satisfy community expectations,",
 	"we would like to invest more time and resources in this project.": "we would like to invest more time and resources in this project.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!",
 	"Thanks,": "Thanks,",
 	"The Boostnote Team": "The Boostnote Team",
 	"Support via OpenCollective": "Support via OpenCollective",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -87,7 +87,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote используется в 200 странах и регионов дружным сообществом разработчиков.",
 	"To support our growing userbase, and satisfy community expectations,": "Чтобы продукт развивался и удовлетворял ожиданиям пользователей,",
 	"we would like to invest more time and resources in this project.": "мы хотим выделять больше времени и ресурсов проекту.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Если вам нравится Boostnote и его сообщество, вы можете профинансировать проект на OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Если вам нравится Boostnote и его сообщество, вы можете профинансировать проект на OpenCollective!",
 	"Thanks,": "Спасибо,",
 	"The Boostnote Team": "разработчики Boostnote",
 	"Support via OpenCollective": "Старница проекта на OpenCollective",

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -87,7 +87,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote is used in about 200 different countries and regions by an awesome community of developers.",
 	"To support our growing userbase, and satisfy community expectations,": "To support our growing userbase, and satisfy community expectations,",
 	"we would like to invest more time and resources in this project.": "we would like to invest more time and resources in this project.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!",
 	"Thanks,": "Thanks,",
 	"The Boostnote Team": "The Boostnote Team",
 	"Support via OpenCollective": "Support via OpenCollective",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -87,7 +87,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "Boostnote, 200 farklı ülke ve bölgede, harika bir geliştirici topluluğu tarafından kullanılmaktadır.",
 	"To support our growing userbase, and satisfy community expectations,": "Bu büyümeyi desteklemeye devam etmek ve topluluk beklentilerini karşılamak için,",
 	"we would like to invest more time and resources in this project.": "bu projeye daha fazla zaman ve kaynak yatırmak istiyoruz.",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "Bu projeyi beğeniyor ve potansiyel görüyorsanız, OpenCollective üzerinden bizi destekleyerek katkıda bulunabilirsiniz!",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "Bu projeyi beğeniyor ve potansiyel görüyorsanız, OpenCollective üzerinden bizi destekleyerek katkıda bulunabilirsiniz!",
 	"Thanks,": "Teşekkürler,",
 	"The Boostnote Team": "Boostnote'un bakımını yapanlar",
 	"Support via OpenCollective": "OpenCollective aracılığıyla destekle",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -89,7 +89,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "大约有200个不同的国家和地区的优秀开发者们都在使用 Boostnote！",
 	"To support our growing userbase, and satisfy community expectations,": "为了继续支持这种发展，和满足社区的期待，",
 	"we would like to invest more time and resources in this project.": "我们非常愿意投入更多的时间和资源到这个项目中。",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "如果你喜欢这款软件并且看好它的潜力, 请在 OpenCollective 上支持我们！",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "如果你喜欢这款软件并且看好它的潜力, 请在 OpenCollective 上支持我们！",
 	"Thanks,": "十分感谢！",
 	"The Boostnote Team": "Boostnote 的维护人员",
 	"Support via OpenCollective": "在 OpenCollective 上支持我们",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -87,7 +87,7 @@
 	"Boostnote is used in about 200 different countries and regions by an awesome community of developers.": "大約有 200 個不同的國家和地區的優秀開發者們都在使用 Boostnote！",
 	"To support our growing userbase, and satisfy community expectations,": "為了繼續支持這種發展，和滿足社群的期待，",
 	"we would like to invest more time and resources in this project.": "我們非常願意投入更多的時間和資源到這個專案中。",
-	"If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!": "如果你喜歡這款軟體並且看好它的潛力, 請在 OpenCollective 上支持我們！",
+	"If you use Boostnote and see its potential, help us out by supporting the project on OpenCollective!": "如果你喜歡這款軟體並且看好它的潛力, 請在 OpenCollective 上支持我們！",
 	"Thanks,": "十分感謝！",
 	"The Boostnote Team": "Boostnote 的維護人員",
 	"Support via OpenCollective": "在 OpenCollective 上支持我們",


### PR DESCRIPTION
Some of the grammar needed to be revisted, and there were a
few opportunities to communicate a more genuine message.

The page now reads:

> Dear Boostnote users,
> 
> Thank you for using Boostnote!
> Boostnote is used in about 200 different countries and regions by an awesome community of developers.
> 
> To support our growing userbase, and satisfy community expectations,
> we would like to invest more time and resources in this project.
> 
> If you use Boostnote and see it's potential, help us out by supporting the project on OpenCollective!
> 
> Thanks,
> The Boostnote Team