### PR TITLE
Allow abbreviation for Option in hotkeys

### DIFF
--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -195,6 +195,7 @@ function rewriteHotkey (config) {
   const keys = [...Object.keys(config.hotkey)]
   keys.forEach(key => {
     config.hotkey[key] = config.hotkey[key].replace(/Cmd/g, 'Command')
+    config.hotkey[key] = config.hotkey[key].replace(/Opt/g, 'Alt')
   })
   return config
 }


### PR DESCRIPTION
This commit allows a user to use 'Opt' as an abbreviation
for Option when setting a hotkey.