### PR TITLE
Display timestamp on all notes

### DIFF
--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -74,24 +74,22 @@ const NoteItem = ({
           ? note.title
           : <span styleName='item-title-empty'>{i18n.__('Empty note')}</span>}
       </div>
-      {['ALL', 'STORAGE'].includes(viewType) &&
-        <div styleName='item-middle'>
-          <div styleName='item-middle-time'>{dateDisplay}</div>
-          <div styleName='item-middle-app-meta'>
-            <div
-              title={
-                viewType === 'ALL'
-                  ? storageName
-                  : viewType === 'STORAGE' ? folderName : null
-              }
-              styleName='item-middle-app-meta-label'
-            >
-              {viewType === 'ALL' && storageName}
-              {viewType === 'STORAGE' && folderName}
-            </div>
+      <div styleName='item-middle'>
+        <div styleName='item-middle-time'>{dateDisplay}</div>
+        <div styleName='item-middle-app-meta'>
+          <div
+            title={
+              viewType === 'ALL'
+                ? storageName
+                : viewType === 'STORAGE' ? folderName : null
+            }
+            styleName='item-middle-app-meta-label'
+          >
+            {viewType === 'ALL' && storageName}
+            {viewType === 'STORAGE' && folderName}
           </div>
-        </div>}
-
+        </div>
+      </div>
       <div styleName='item-bottom'>
         <div styleName='item-bottom-tagList'>
           {note.tags.length > 0


### PR DESCRIPTION
Notes inside My Storage did not display timestamp of last edit,
this commit makes the timestamp consistent across all notes in
all locations.

Before:
<img width="280" alt="screen shot 2018-09-29 at 6 28 16 pm" src="https://user-images.githubusercontent.com/33494799/46251327-7d479280-c415-11e8-84c7-05e60364b9b3.png">

After:
<img width="273" alt="screen shot 2018-09-29 at 6 29 32 pm" src="https://user-images.githubusercontent.com/33494799/46251339-a9631380-c415-11e8-8be0-9ce2316c9b83.png">

