### PR TITLE
Change Toggle Editor Mode hotkey on OS X

### DIFF
--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -24,7 +24,7 @@ export const DEFAULT_CONFIG = {
   amaEnabled: true,
   hotkey: {
     toggleMain: OSX ? 'Command + Alt + L' : 'Super + Alt + E',
-    toggleMode: OSX ? 'Command + M' : 'Ctrl + M'
+    toggleMode: OSX ? 'Command + Option + M' : 'Ctrl + M'
   },
   ui: {
     language: 'en',


### PR DESCRIPTION
By default the Toggle Editor Mode hotkey was set to Command + M,
which is a great and mnemonic hotkey. Unfortunately that hotkey
is also the hotkey to minimize an application.

This commit changes the default Toggle Editor Mode hotkey to
Command + Option + M on OS X, which will not minimize the window
and maintains the mnemonic pattern.