### PR TITLE
Fix TypeError thrown on the Snippets page

### DIFF
--- a/browser/main/modals/PreferencesModal/SnippetTab.js
+++ b/browser/main/modals/PreferencesModal/SnippetTab.js
@@ -27,12 +27,14 @@ class SnippetTab extends React.Component {
 
   handleSnippetSelect (snippet) {
     const { currentSnippet } = this.state
-    if (currentSnippet === null || currentSnippet.id !== snippet.id) {
-      dataApi.fetchSnippet(snippet.id).then(changedSnippet => {
-        // notify the snippet editor to load the content of the new snippet
-        this.snippetEditor.onSnippetChanged(changedSnippet)
-        this.setState({currentSnippet: changedSnippet})
-      })
+    if (snippet !== null) {
+      if (currentSnippet === null || currentSnippet.id !== snippet.id) {
+        dataApi.fetchSnippet(snippet.id).then(changedSnippet => {
+          // notify the snippet editor to load the content of the new snippet
+          this.snippetEditor.onSnippetChanged(changedSnippet)
+          this.setState({currentSnippet: changedSnippet})
+        })
+      }
     }
   }
 


### PR DESCRIPTION
This commit protects from a TypeError that is consistently
thrown on the Snippets page.

<img width="492" alt="screen shot 2018-09-29 at 11 16 33 pm" src="https://user-images.githubusercontent.com/11466782/46253315-08d51980-c43e-11e8-808b-bd9fa95223c8.png">
