### PR TITLE
Clone notes to the same folder

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -659,7 +659,7 @@ class NoteList extends React.Component {
     dataApi
       .createNote(storage.key, {
         type: firstNote.type,
-        folder: folder.key,
+        folder: selectedNotes[0].folder,
         title: firstNote.title + ' ' + i18n.__('copy'),
         content: firstNote.content
       })

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -659,7 +659,7 @@ class NoteList extends React.Component {
     dataApi
       .createNote(storage.key, {
         type: firstNote.type,
-        folder: selectedNotes[0].folder,
+        folder: firstNote.folder,
         title: firstNote.title + ' ' + i18n.__('copy'),
         content: firstNote.content
       })

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -648,7 +648,6 @@ class NoteList extends React.Component {
   cloneNote () {
     const { selectedNoteKeys } = this.state
     const { dispatch, location } = this.props
-    const { storage, folder } = this.resolveTargetFolder()
     const notes = this.notes.map((note) => Object.assign({}, note))
     const selectedNotes = findNotesByKeys(notes, selectedNoteKeys)
     const firstNote = selectedNotes[0]
@@ -657,7 +656,7 @@ class NoteList extends React.Component {
     AwsMobileAnalyticsConfig.recordDynamicCustomEvent(eventName)
     AwsMobileAnalyticsConfig.recordDynamicCustomEvent('ADD_ALLNOTE')
     dataApi
-      .createNote(storage.key, {
+      .createNote(firstNote.storage, {
         type: firstNote.type,
         folder: firstNote.folder,
         title: firstNote.title + ' ' + i18n.__('copy'),


### PR DESCRIPTION
Currently notes are cloned to the default folder if the clone
note link is clicked from "All Notes" or "Starred." They are only
cloned to the same folder as the original note if the clone note
link is clicked inside of that folder.

This commit changes this behavior such that a clone is always in
the same folder as the note it was cloned from.