### PR TITLE
update codemirror to fix centered column as not emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "aws-sdk": "^2.48.0",
     "aws-sdk-mobile-analytics": "^0.9.2",
     "chart.js": "^2.7.2",
-    "codemirror": "^5.39.0",
+    "codemirror": "^5.40.2",
     "codemirror-mode-elixir": "^1.1.1",
     "electron-config": "^1.0.0",
     "electron-gh-releases": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,9 +1803,9 @@ codemirror@^5.18.2, codemirror@^5.20.2:
   version "5.38.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.38.0.tgz#26a9551446e51dbdde36aabe60f72469724fd332"
 
-codemirror@^5.39.0:
-  version "5.39.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.39.0.tgz#4654f7d2f7e525e04a62e72d9482348ccb37dce5"
+codemirror@^5.40.2:
+  version "5.40.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.40.2.tgz#f4a41fee2d84e679543591b3680af259d903330b"
 
 coffee-script@^1.10.0, coffee-script@^1.12.4:
   version "1.12.7"


### PR DESCRIPTION
This change updates `codemirror` to fix the centered column of a table so it won't be recognized as an emoji.

```
| Left-aligned | Center-aligned | Right-aligned |
| :---         |     :---:      |          ---: |
| git status   | git status     | git status    |
| git diff     | git diff       | git diff      |
```

[GFM reference](https://help.github.com/articles/organizing-information-with-tables/)