### PR TITLE
Increase arrow size on sidebar

### DIFF
--- a/browser/components/NavToggleButton.js
+++ b/browser/components/NavToggleButton.js
@@ -16,8 +16,8 @@ const NavToggleButton = ({isFolded, handleToggleButtonClick}) => (
     onClick={(e) => handleToggleButtonClick(e)}
   >
     {isFolded
-     ? <i className='fa fa-angle-double-right' />
-     : <i className='fa fa-angle-double-left' />
+     ? <i className='fa fa-angle-double-right fa-2x' />
+     : <i className='fa fa-angle-double-left fa-2x' />
     }
   </button>
 )


### PR DESCRIPTION
The arrow in the sidebar is extremely easy to miss. Increasing
the size of the arrows makes them much more obvious.