### PR TITLE
fix small visual bug in tag autocomplete

### DIFF
--- a/browser/styles/Detail/TagSelect.styl
+++ b/browser/styles/Detail/TagSelect.styl
@@ -14,18 +14,18 @@
     list-style none
     padding 0
     margin 0
-    
+
     border-radius 4px
-    margin .2em 0 0
+    margin .5rem 0 0
     background-color $ui-noteList-backgroundColor
     border 1px solid rgba(0,0,0,.3)
     box-shadow .05em .2em .6em rgba(0,0,0,.2)
     text-shadow none
-    
+
     &:empty,
     &[hidden]
       display none
-    
+
     &:before
       content ""
       position absolute
@@ -39,12 +39,12 @@
       border-bottom 0
       -webkit-transform rotate(45deg)
       transform rotate(45deg)
-      
+
     li
       position relative
       padding 6px 18px 6px 10px
       cursor pointer
-    
+
     li[aria-selected="true"]
       background-color alpha($ui-button--active-backgroundColor, 40%)
       color $ui-text-color
@@ -53,15 +53,15 @@ body[data-theme="dark"]
   .TagSelect
     .react-autosuggest__input
       color $ui-dark-text-color
-    
+
     ul
       border-color $ui-dark-borderColor
       background-color $ui-dark-noteList-backgroundColor
       color $ui-dark-text-color
-      
+
       &:before
         background-color $ui-dark-noteList-backgroundColor
-      
+
       li[aria-selected="true"]
         background-color $ui-dark-button--active-backgroundColor
         color $ui-dark-text-color
@@ -70,15 +70,15 @@ body[data-theme="monokai"]
   .TagSelect
     .react-autosuggest__input
       color $ui-monokai-text-color
-    
+
     ul
       border-color $ui-monokai-borderColor
       background-color $ui-monokai-noteList-backgroundColor
       color $ui-monokai-text-color
-      
+
       &:before
         background-color $ui-dark-noteList-backgroundColor
-      
+
       li[aria-selected="true"]
         background-color $ui-monokai-button-backgroundColor
         color $ui-monokai-text-color
@@ -87,15 +87,15 @@ body[data-theme="solarized-dark"]
   .TagSelect
     .react-autosuggest__input
       color $ui-solarized-dark-text-color
-    
+
     ul
       border-color $ui-solarized-dark-borderColor
       background-color $ui-solarized-dark-noteList-backgroundColor
       color $ui-solarized-dark-text-color
-      
+
       &:before
         background-color $ui-solarized-dark-noteList-backgroundColor
-      
+
       li[aria-selected="true"]
         background-color $ui-dark-button--active-backgroundColor
         color $ui-solarized-dark-text-color
@@ -104,6 +104,6 @@ body[data-theme="white"]
   .TagSelect
     ul
       background-color $ui-white-noteList-backgroundColor
-      
+
       li[aria-selected="true"]
         background-color $ui-button--active-backgroundColor


### PR DESCRIPTION
This change fixes a small visual bug in the tag's autocomplete.

Before:
![screenshot](https://user-images.githubusercontent.com/587742/46362888-be3be300-c671-11e8-87b1-e22daaadf9f8.jpg)

After:
![screenshot](https://user-images.githubusercontent.com/587742/46362931-dc094800-c671-11e8-9d68-841141db9b86.jpg)

