### PR TITLE
disable hyperlink for attachments

### DIFF
--- a/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
+++ b/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
@@ -52,7 +52,8 @@
 
       if (className.indexOf('cm-url') !== -1) {
         const match = /^\((.*)\)|\[(.*)\]|(.*)$/.exec(el.textContent)
-        return match[1] || match[2] || match[3]
+        const url = match[1] || match[2] || match[3]
+        return /^:storage\//.test(url) ? null : url
       }
 
       return null

--- a/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
+++ b/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
@@ -53,6 +53,8 @@
       if (className.indexOf('cm-url') !== -1) {
         const match = /^\((.*)\)|\[(.*)\]|(.*)$/.exec(el.textContent)
         const url = match[1] || match[2] || match[3]
+
+        // `:storage` is the value of the variable `STORAGE_FOLDER_PLACEHOLDER` defined in `browser/main/lib/dataApi/attachmentManagement`
         return /^:storage(?:\/|%5C)/.test(url) ? null : url
       }
 

--- a/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
+++ b/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
@@ -53,7 +53,7 @@
       if (className.indexOf('cm-url') !== -1) {
         const match = /^\((.*)\)|\[(.*)\]|(.*)$/.exec(el.textContent)
         const url = match[1] || match[2] || match[3]
-        return /^:storage\//.test(url) ? null : url
+        return /^:storage(?:\/|%5C)/.test(url) ? null : url
       }
 
       return null


### PR DESCRIPTION
This change disables the following popover on attached images:
![screenshot](https://user-images.githubusercontent.com/587742/46613827-7fe07100-cb14-11e8-8e79-f1a55c0fc4b8.jpg)
