### PR TITLE
fix visual bug with preview

### DIFF
--- a/browser/components/MarkdownEditor.styl
+++ b/browser/components/MarkdownEditor.styl
@@ -16,7 +16,6 @@
 .preview
   display block
   absolute top bottom left right
-  z-index 100
   background-color white
   height 100%
   width 100%


### PR DESCRIPTION
This change fixes hidden the note's infos or the tag autocomplete behind the note's preview.

It's fixing #2472