### PR TITLE
fix segmentation fault with glibc 2.28

### DIFF
--- a/dev-scripts/dev.js
+++ b/dev-scripts/dev.js
@@ -49,7 +49,7 @@ function startServer () {
 }
 
 function startElectron () {
-  spawn(electron, ['--hot', './index.js'])
+  spawn(electron, ['--hot', './index.js'], { stdio: 'inherit' })
     .on('close', () => {
       server.close()
     })

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -7,13 +7,19 @@ const config = new Config()
 const _ = require('lodash')
 
 var showMenu = process.platform !== 'win32'
-const windowSize = config.get('windowsize') || { x: null, y: null, width: 1080, height: 720 }
+const windowSize = config.get('windowsize') || {
+  x: null,
+  y: null,
+  width: 1080,
+  height: 720
+}
 
 const mainWindow = new BrowserWindow({
   x: windowSize.x,
   y: windowSize.y,
   width: windowSize.width,
   height: windowSize.height,
+  useContentSize: true,
   minWidth: 500,
   minHeight: 320,
   autoHideMenuBar: showMenu,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "node dev-scripts/dev.js"
   },
   "config": {
-    "electron-version": "2.0.9"
+    "electron-version": "3.0.3"
   },
   "repository": {
     "type": "git",
@@ -56,7 +56,7 @@
     "codemirror": "^5.39.0",
     "codemirror-mode-elixir": "^1.1.1",
     "electron-config": "^1.0.0",
-    "electron-gh-releases": "^2.0.2",
+    "electron-gh-releases": "^2.0.4",
     "escape-string-regexp": "^1.0.5",
     "file-uri-to-path": "^1.0.0",
     "file-url": "^2.0.2",
@@ -121,7 +121,7 @@
     "css-loader": "^0.19.0",
     "devtron": "^1.1.0",
     "dom-storage": "^2.0.2",
-    "electron": "2.0.9",
+    "electron": "3.0.3",
     "electron-packager": "^12.0.0",
     "eslint": "^3.13.1",
     "eslint-config-standard": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "node dev-scripts/dev.js"
   },
   "config": {
-    "electron-version": "2.0.7"
+    "electron-version": "2.0.9"
   },
   "repository": {
     "type": "git",
@@ -121,7 +121,7 @@
     "css-loader": "^0.19.0",
     "devtron": "^1.1.0",
     "dom-storage": "^2.0.2",
-    "electron": "2.0.7",
+    "electron": "2.0.9",
     "electron-packager": "^12.0.0",
     "eslint": "^3.13.1",
     "eslint-config-standard": "^6.2.1",


### PR DESCRIPTION
This is fix :bug: 
ERRROR : [1] 7816 segmentation fault (core dumped) in Ubuntu 18.10 and i think all linux distro with glibc 2.28

[Issue](https://github.com/BoostIO/Boostnote/issues/2483)