### PR TITLE
Remove emacs keymap Ctrl-V binding to allow pasting

### DIFF
--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -168,6 +168,8 @@ class Main extends React.Component {
       }
     })
 
+    delete CodeMirror.keyMap.emacs["Ctrl-V"]
+
     eventEmitter.on('editor:fullscreen', this.toggleFullScreen)
   }
 

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -168,7 +168,7 @@ class Main extends React.Component {
       }
     })
 
-    delete CodeMirror.keyMap.emacs["Ctrl-V"]
+    delete CodeMirror.keyMap.emacs['Ctrl-V']
 
     eventEmitter.on('editor:fullscreen', this.toggleFullScreen)
   }


### PR DESCRIPTION
Fixes #1406 

Hey friends, this fix is borrowed from a CodeMirror issue: https://github.com/codemirror/CodeMirror/issues/5321#issuecomment-375232302

It's a one-liner that should be run only once. I wasn't sure where to put this code so I tried a main entry that is executed once: the mounting of the main window.

**If you think of a better place to put this please let me know so I can fix**. I'm not familiar too much with boostnote code.