### PR TITLE
fix color for even rows in table

### DIFF
--- a/extra_scripts/codemirror/mode/bfm/bfm.css
+++ b/extra_scripts/codemirror/mode/bfm/bfm.css
@@ -34,7 +34,6 @@
 .cm-s-rubyblue.CodeMirror .cm-table-row-even { background-color: rgb(41, 58, 73); }
 .cm-s-seti.CodeMirror .cm-table-row-even { background-color: rgb(40, 42, 43); }
 .cm-s-shadowfox.CodeMirror .cm-table-row-even { background-color: rgb(56, 56, 59); }
-.cm-s-solarized.CodeMirror .cm-table-row-even { background-color: rgb(242, 242, 242); }
 .cm-s-the-matrix.CodeMirror .cm-table-row-even { background-color: rgb(0, 26, 0); }
 .cm-s-tomorrow-night-bright.CodeMirror .cm-table-row-even { background-color: rgb(23, 23, 23); }
 .cm-s-tomorrow-night-eighties.CodeMirror .cm-table-row-even { background-color: rgb(20, 20, 20); }
@@ -42,3 +41,5 @@
 .cm-s-vibrant-ink.CodeMirror .cm-table-row-even { background-color: rgb(26, 26, 26); }
 .cm-s-xq-dark.CodeMirror .cm-table-row-even { background-color: rgb(34, 25, 53); }
 .cm-s-yeti.CodeMirror .cm-table-row-even { background-color: rgb(235, 232, 230); }
+.cm-s-solarized.cm-s-dark .cm-table-row-even { background-color: rgb(13, 54, 64); }
+.cm-s-solarized.cm-s-light .cm-table-row-even { background-color: rgb(245, 240, 222); }

--- a/extra_scripts/codemirror/mode/bfm/bfm.js
+++ b/extra_scripts/codemirror/mode/bfm/bfm.js
@@ -54,6 +54,9 @@
 
         stream.skipToEnd()
         return null
+      },
+      blankLine(state) {
+        state.inTable = false
       }
     }
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -289,19 +289,18 @@ module.exports = function (grunt) {
     const Color = require('color')
     const parseCSS = require('css').parse
 
-    function generateRule(selector, bgColor, fgColor) {
+    function generateRule (selector, bgColor, fgColor) {
       if (bgColor.isLight()) {
-          bgColor = bgColor.mix(fgColor, 0.05)
-        } else {
-          bgColor = bgColor.mix(fgColor, 0.1)
-        }
+        bgColor = bgColor.mix(fgColor, 0.05)
+      } else {
+        bgColor = bgColor.mix(fgColor, 0.1)
+      }
 
-        if (selector && selector.length > 0) {
-          return `${selector} .cm-table-row-even { background-color: ${bgColor.rgb().string()}; }`
-        }
-        else {
-          return `.cm-table-row-even { background-color: ${bgColor.rgb().string()}; }`
-        }
+      if (selector && selector.length > 0) {
+        return `${selector} .cm-table-row-even { background-color: ${bgColor.rgb().string()}; }`
+      } else {
+        return `.cm-table-row-even { background-color: ${bgColor.rgb().string()}; }`
+      }
     }
 
     const root = path.join(__dirname, 'node_modules/codemirror/theme/')
@@ -319,7 +318,7 @@ module.exports = function (grunt) {
             bgColor = Color(declaration.value.split(' ')[0])
           } else if (declaration.property === 'color') {
             const value = /^(.*?)(?:\s*!important)?$/.exec(declaration.value)[1]
-            let match = /^rgba\((.*?),\s*1\)$/.exec(value)
+            const match = /^rgba\((.*?),\s*1\)$/.exec(value)
             if (match) {
               fgColor = Color(`rgb(${match[1]})`)
             } else {
@@ -328,18 +327,9 @@ module.exports = function (grunt) {
           }
         })
 
-        /* if (bgColor.isLight()) {
-          bgColor = bgColor.mix(fgColor, 0.05)
-        } else {
-          bgColor = bgColor.mix(fgColor, 0.1)
-        }
-
-        return `${rules[0].selectors[0]} .cm-table-row-even { background-color: ${bgColor.rgb().string()}; }` */
         return generateRule(rules[0].selectors[0], bgColor, fgColor)
       }
     }).filter(value => !!value)
-
-    //const defaultBgColor = Color('white').mix(Color('black'), 0.05)
 
     // default
     colors.unshift(generateRule(null, Color('white'), Color('black')))
@@ -347,18 +337,7 @@ module.exports = function (grunt) {
     colors.push(generateRule('.cm-s-solarized.cm-s-dark', Color('#002b36'), Color('#839496')))
     // solarized light
     colors.push(generateRule('.cm-s-solarized.cm-s-light', Color('#fdf6e3'), Color('#657b83')))
-    /* .cm-s-solarized.cm-s-dark {
-  color: #839496;
-  background-color: #002b36;
-  text-shadow: #002b36 0 1px;
-}
-.cm-s-solarized.cm-s-light {
-  background-color: #fdf6e3;
-  color: #657b83;
-  text-shadow: #eee8d5 0 1px;
-} */
 
-    /* fs.writeFileSync(path.join(__dirname, 'extra_scripts/codemirror/mode/bfm/bfm.css'), [`.cm-table-row-even { background-color: ${defaultBgColor.rgb().string()}; }`, ...colors].join('\n'), 'utf8') */
     fs.writeFileSync(path.join(__dirname, 'extra_scripts/codemirror/mode/bfm/bfm.css'), colors.join('\n'), 'utf8')
   })
 


### PR DESCRIPTION
## Description

This change fixes several bugs:
- reset row index on blank line
- separate even rows' colors for Solarized Dark and Solarized Light themes

Before:
![screenshot](https://user-images.githubusercontent.com/587742/47217681-627b9480-d3a9-11e8-8f24-f337b7b13e1f.png)

After:
![screenshot](https://user-images.githubusercontent.com/587742/47217689-6f988380-d3a9-11e8-9589-5e1925cd4d70.png)


## Issue fixed

#2505

## Type of changes

[x] Bug fix (Change that fixed an issue)
[ ] Breaking change (Change that can cause existing functionality to change)
[ ] Improvement (Change that improves the code. Maybe performance or development improvement)
[ ] Feature (Change that adds new functionality)
[ ] Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

[x] My code follows the project code style
[ ] I have written test for my code and it has been tested
[x] All existing tests have been passed
[x] I have attached a screenshot/video to visualize my change if possible