### PR TITLE
fix: Fixed storageList typo (storgaeList).

### DIFF
--- a/browser/components/StorageList.js
+++ b/browser/components/StorageList.js
@@ -7,18 +7,18 @@ import styles from './StorageList.styl'
 import CSSModules from 'browser/lib/CSSModules'
 
 /**
-* @param {Array} storgaeList
+* @param {Array} storageList
 */
 
 const StorageList = ({storageList, isFolded}) => (
   <div styleName={isFolded ? 'storageList-folded' : 'storageList'}>
     {storageList.length > 0 ? storageList : (
-      <div styleName='storgaeList-empty'>No storage mount.</div>
+      <div styleName='storageList-empty'>No storage mount.</div>
     )}
   </div>
 )
 
 StorageList.propTypes = {
-  storgaeList: PropTypes.arrayOf(PropTypes.element).isRequired
+  storageList: PropTypes.arrayOf(PropTypes.element).isRequired
 }
 export default CSSModules(StorageList, styles)


### PR DESCRIPTION
There was a typo with both the prop name (in the propTypes check) and the styleName for storageList-empty.  This prevented the "No storage mount." div from ever being displayed (see the before and after screenshots attached).

Before:
![before](https://user-images.githubusercontent.com/1617070/47609239-efe56700-d9ef-11e8-8b84-fcc67b42f55b.png)

After:
![after](https://user-images.githubusercontent.com/1617070/47609238-efe56700-d9ef-11e8-8d00-d67f5ea74287.png)

