### PR TITLE
Fix the shift selection and ctrl selection in note list

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -86,7 +86,7 @@ class NoteList extends React.Component {
     this.state = {
       ctrlKeyDown: false,
       shiftKeyDown: false,
-      firstShiftSelectedNoteIndex: -1,
+      prevShiftNoteIndex: -1,
       selectedNoteKeys: []
     }
 
@@ -409,9 +409,8 @@ class NoteList extends React.Component {
   handleNoteClick (e, uniqueKey) {
     const { router } = this.context
     const { location } = this.props
-    let { selectedNoteKeys } = this.state
+    let { selectedNoteKeys, prevShiftNoteIndex } = this.state
     const { ctrlKeyDown, shiftKeyDown } = this.state
-    let firstShiftSelectedNoteIndex = -1
     const hasSelectedNoteKey = selectedNoteKeys.length > 0
 
     if (ctrlKeyDown && selectedNoteKeys.includes(uniqueKey)) {
@@ -424,28 +423,40 @@ class NoteList extends React.Component {
     if (!ctrlKeyDown && !shiftKeyDown) {
       selectedNoteKeys = []
     }
+
+    if (!shiftKeyDown) {
+      prevShiftNoteIndex = -1
+    }
+
     selectedNoteKeys.push(uniqueKey)
 
     if (shiftKeyDown && hasSelectedNoteKey) {
-      const firstSelectedNoteIndex = selectedNoteKeys[0] > this.state.firstShiftSelectedNoteIndex
-        ? selectedNoteKeys[0] : this.state.firstShiftSelectedNoteIndex
-      const lastSelectedNoteIndex = this.getNoteIndexByKey(uniqueKey)
-      const startIndex = firstSelectedNoteIndex < lastSelectedNoteIndex
-        ? firstSelectedNoteIndex : lastSelectedNoteIndex
-      const endIndex = firstSelectedNoteIndex > lastSelectedNoteIndex
-        ? firstSelectedNoteIndex : lastSelectedNoteIndex
+      let firstShiftNoteIndex = this.getNoteIndexByKey(selectedNoteKeys[0])
+      // Shift selection can either start from first note in the exisiting selectedNoteKeys
+      // or previous first shift note index
+      firstShiftNoteIndex = firstShiftNoteIndex > prevShiftNoteIndex
+        ? firstShiftNoteIndex : prevShiftNoteIndex
+
+      const lastShiftNoteIndex = this.getNoteIndexByKey(uniqueKey)
+
+      const startIndex = firstShiftNoteIndex < lastShiftNoteIndex
+        ? firstShiftNoteIndex : lastShiftNoteIndex
+      const endIndex = firstShiftNoteIndex > lastShiftNoteIndex
+        ? firstShiftNoteIndex : lastShiftNoteIndex
 
       selectedNoteKeys = []
       for (let i = startIndex; i <= endIndex; i++) {
         selectedNoteKeys.push(this.notes[i].key)
       }
 
-      firstShiftSelectedNoteIndex = firstSelectedNoteIndex
+      if (prevShiftNoteIndex < 0) {
+        prevShiftNoteIndex = firstShiftNoteIndex
+      }
     }
 
     this.setState({
       selectedNoteKeys,
-      firstShiftSelectedNoteIndex
+      prevShiftNoteIndex
     })
 
     router.push({


### PR DESCRIPTION
## Description
There are two behaviors being changed:
1. When user click on the notes 
     a. Shift - It will select the notes among the first and the last note
     b. Ctrl - it will only select the selected note
2. When user uses the arrow keys
    a. Shift - it will extends the selection from the last selected note
    b. Ctrl - Nothing will happens

## Issue fixed
#1975 

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible