### PR TITLE
Fix the auto-updating numbered list to the middle of a list

### DIFF
--- a/extra_scripts/boost/boostNewLineIndentContinueMarkdownList.js
+++ b/extra_scripts/boost/boostNewLineIndentContinueMarkdownList.js
@@ -44,9 +44,46 @@
           ? match[2].replace('x', ' ')
           : (parseInt(match[3], 10) + 1) + match[4]
         replacements[i] = '\n' + indent + bullet + after
+
+        if (bullet) incrementRemainingMarkdownListNumbers(cm, pos)
       }
     }
-
     cm.replaceSelections(replacements)
+  }
+  // Auto-updating Markdown list numbers when a new item is added to the
+  // middle of a list
+  function incrementRemainingMarkdownListNumbers(cm, pos) {
+    var startLine = pos.line, lookAhead = 0, skipCount = 0
+    var startItem = listRE.exec(cm.getLine(startLine)), startIndent = startItem[1]
+
+    do {
+      lookAhead += 1
+      var nextLineNumber = startLine + lookAhead
+      var nextLine = cm.getLine(nextLineNumber), nextItem = listRE.exec(nextLine)
+
+      if (nextItem) {
+        var nextIndent = nextItem[1]
+        var newNumber = (parseInt(startItem[3], 10) + lookAhead - skipCount)
+        var nextNumber = (parseInt(nextItem[3], 10)), itemNumber = nextNumber
+
+        if (startIndent === nextIndent && !isNaN(nextNumber)) {
+          if (newNumber === nextNumber) itemNumber = nextNumber + 1
+          if (newNumber > nextNumber) itemNumber = newNumber + 1
+          cm.replaceRange(
+            nextLine.replace(listRE, nextIndent + itemNumber + nextItem[4] + nextItem[5]),
+          {
+            line: nextLineNumber, ch: 0
+          }, {
+            line: nextLineNumber, ch: nextLine.length
+          })
+        } else {
+          if (startIndent.length > nextIndent.length) return
+          // This doesn't run if the next line immediatley indents, as it is
+          // not clear of the users intention (new indented item or same level)
+          if ((startIndent.length < nextIndent.length) && (lookAhead === 1)) return
+          skipCount += 1
+        }
+      }
+    } while (nextItem)
   }
 })


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
Fix the problem where the user update the numbered to the middle of the list, the following number(s) did not updated.

Screenshot:
![numberlist](https://user-images.githubusercontent.com/43637878/48304158-bebc7900-e54f-11e8-985c-f34eb0d9eca8.gif)

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#2170 

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible