### PR TITLE
Zoom Controls

### DIFF
--- a/browser/main/StatusBar/index.js
+++ b/browser/main/StatusBar/index.js
@@ -5,6 +5,7 @@ import styles from './StatusBar.styl'
 import ZoomManager from 'browser/main/lib/ZoomManager'
 import i18n from 'browser/lib/i18n'
 import context from 'browser/lib/context'
+import EventEmitter from 'browser/main/lib/eventEmitter'
 
 const electron = require('electron')
 const { remote, ipcRenderer } = electron
@@ -13,6 +14,26 @@ const { dialog } = remote
 const zoomOptions = [0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
 
 class StatusBar extends React.Component {
+
+  constructor (props) {
+    super(props)
+    this.handleZoomInMenuItem = this.handleZoomInMenuItem.bind(this)
+    this.handleZoomOutMenuItem = this.handleZoomOutMenuItem.bind(this)
+    this.handleZoomResetMenuItem = this.handleZoomResetMenuItem.bind(this)
+  }
+
+  componentDidMount () {
+    EventEmitter.on('status:zoomin', this.handleZoomInMenuItem)
+    EventEmitter.on('status:zoomout', this.handleZoomOutMenuItem)
+    EventEmitter.on('status:zoomreset', this.handleZoomResetMenuItem)
+  }
+
+  componentWillUnmount () {
+    EventEmitter.off('status:zoomin', this.handleZoomInMenuItem)
+    EventEmitter.off('status:zoomout', this.handleZoomOutMenuItem)
+    EventEmitter.off('status:zoomreset', this.handleZoomResetMenuItem)
+  }
+
   updateApp () {
     const index = dialog.showMessageBox(remote.getCurrentWindow(), {
       type: 'warning',
@@ -46,6 +67,20 @@ class StatusBar extends React.Component {
       type: 'SET_ZOOM',
       zoom: zoomFactor
     })
+  }
+
+  handleZoomInMenuItem () {
+    const zoomFactor = ZoomManager.getZoom() + 0.1
+    this.handleZoomMenuItemClick(zoomFactor)
+  }
+
+  handleZoomOutMenuItem () {
+    const zoomFactor = ZoomManager.getZoom() - 0.1
+    this.handleZoomMenuItemClick(zoomFactor)
+  }
+
+  handleZoomResetMenuItem () {
+    this.handleZoomMenuItemClick(1.0)
   }
 
   render () {

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -325,7 +325,7 @@ const view = {
     },
     {
       label: 'Zoom Out',
-      accelerator: macOS ? 'CmdOrCtrl+-' : 'Control+-',
+      accelerator: macOS ? 'CommandOrControl+-' : 'Control+-',
       click () {
         mainWindow.webContents.send('status:zoomout')
       }

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -310,11 +310,25 @@ const view = {
       type: 'separator'
     },
     {
-      role: 'zoomin',
-      accelerator: macOS ? 'CommandOrControl+Plus' : 'Control+='
+      label: 'Actual Size',
+      accelerator: macOS ? 'CommandOrControl+0' : 'Control+0',
+      click () {
+        mainWindow.webContents.send('status:zoomreset')
+      }
     },
     {
-      role: 'zoomout'
+      label: 'Zoom In',
+      accelerator: macOS ? 'CommandOrControl+=' : 'Control+=',
+      click () {
+        mainWindow.webContents.send('status:zoomin')
+      }
+    },
+    {
+      label: 'Zoom Out',
+      accelerator: macOS ? 'CmdOrCtrl+-' : 'Control+-',
+      click () {
+        mainWindow.webContents.send('status:zoomout')
+      }
     }
   ]
 }


### PR DESCRIPTION
## Description
### Zoom Controls
- Updated the zoom logic for the zoom in/out menu items so that if you zoom it reflects in the status bar and the config. 
- Also added an actual size / zoom reset menu item for convenience.

The shortcuts follow the standard controls I have seen in popular apps like google chrome or spotify.

You may notice that I have bound the zoom in to `CommandOrControl+=` instead of the standard `CommandOrControl+Plus`, this is due to an electron bug. I have posted a comment here. Feel free to check it out https://github.com/electron/electron/issues/6731. The accelerator does the same thing so it has no effect on user experience.

I've tested everything on macOS and it seems to be fine 👍
I need others to test on windows and linux please 🙏 

![zoom controls](https://user-images.githubusercontent.com/14887287/48312328-e6462c80-e5b5-11e8-8208-cad1d5dd2445.gif)

## Issue fixed
https://github.com/BoostIO/Boostnote/issues/2554
https://github.com/BoostIO/Boostnote/issues/2089

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :radio_button: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible