### PR TITLE
Update electron framework to version 3.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "node dev-scripts/dev.js"
   },
   "config": {
-    "electron-version": "3.0.3"
+    "electron-version": "3.0.8"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "css-loader": "^0.19.0",
     "devtron": "^1.1.0",
     "dom-storage": "^2.0.2",
-    "electron": "3.0.3",
+    "electron": "3.0.8",
     "electron-packager": "^12.0.0",
     "eslint": "^3.13.1",
     "eslint-config-standard": "^6.2.1",


### PR DESCRIPTION
On Ubuntu 18.10 there is a issue with glibc versions below 2.28 see
[Prebuilt Electron binaries segfault at startup on Arch Linux with glibc 2.28 #13972](https://github.com/electron/electron/issues/13972)