### PR TITLE
fix GUI style element for default theme

### DIFF
--- a/browser/main/StatusBar/StatusBar.styl
+++ b/browser/main/StatusBar/StatusBar.styl
@@ -47,6 +47,14 @@
 .update-icon
   color $brand-color
 
+body[data-theme="default"]
+  .zoom
+    color $ui-text-color
+
+body[data-theme="white"]
+  .zoom
+    color $ui-text-color
+
 body[data-theme="dark"]
   .root
     border-color $ui-dark-borderColor


### PR DESCRIPTION
fix white text not visible on white background for default theme and white theme.

@ZeroX-DG this is same as #2583. I am sorry for the confusion.