### PR TITLE
fix pasting into fenced code block

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -615,7 +615,6 @@ export default class CodeEditor extends React.Component {
           } else {
             return true
           }
-          return true
         } else {
           return false
         }


### PR DESCRIPTION
## Description

This change fixes the pasting in code block.
It avoid the pasted code to be parsed as HTML and so avoid any `\` or new lines to be added to the code.

## Issue fixed

- #2628

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
