### PR TITLE
Fix #2218. Prevent insertion of duplicate characters for * and $

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -227,7 +227,7 @@ export default class CodeEditor extends React.Component {
       foldGutter: true,
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
       autoCloseBrackets: {
-        pairs: '()[]{}\'\'""$$**``',
+        pairs: '()[]{}\'\'""``',
         triples: '```"""\'\'\'',
         explode: '[]{}``$$',
         override: true

--- a/browser/main/modals/PreferencesModal/SnippetEditor.js
+++ b/browser/main/modals/PreferencesModal/SnippetEditor.js
@@ -28,7 +28,7 @@ class SnippetEditor extends React.Component {
       foldGutter: true,
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
       autoCloseBrackets: {
-        pairs: '()[]{}\'\'""$$**``',
+        pairs: '()[]{}\'\'""``',
         triples: '```"""\'\'\'',
         explode: '[]{}``$$',
         override: true


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
Prevent insertion of duplicate characters for * and $. So when the user types *, just * appears instead of **. Likewise for $. 

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#2218

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- ☑️ Bug fix (Change that fixed an issue)
-  ☑️ Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

-  ☑️ My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
