### PR TITLE
Fixed delete note not navigating to the next note

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -652,14 +652,18 @@ class NoteList extends React.Component {
         })
       )
       .then((data) => {
-        data.forEach((item) => {
-          dispatch({
-            type: 'DELETE_NOTE',
-            storageKey: item.storageKey,
-            noteKey: item.noteKey
+        const dispatchHandler = () => {
+          data.forEach((item) => {
+            dispatch({
+              type: 'DELETE_NOTE',
+              storageKey: item.storageKey,
+              noteKey: item.noteKey
+            })
           })
-        })
+        }
+        ee.once('list:next', dispatchHandler)
       })
+      .then(() => ee.emit('list:next'))
       .catch((err) => {
         console.error('Cannot Delete note: ' + err)
       })
@@ -683,6 +687,7 @@ class NoteList extends React.Component {
         })
         AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
       })
+      .then(() => ee.emit('list:next'))
       .catch((err) => {
         console.error('Notes could not go to trash: ' + err)
       })


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
This PR fixed the unwanted behavior when users delete a note. Instead of showing the create note message, the next note in the list will be displayed.
**Before**
![boostnote_before](https://user-images.githubusercontent.com/12984316/49064466-9b7f1280-f24d-11e8-96bd-7b0cdddd2e6f.gif)

**After**
![boostnote_after](https://user-images.githubusercontent.com/12984316/49064486-a8036b00-f24d-11e8-906b-99e6ba21503b.gif)


## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
https://github.com/BoostIO/Boostnote/issues/2615, https://github.com/BoostIO/Boostnote/issues/2343
<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
