### PR TITLE
Handle encoded uri path on `copyFile`

### DIFF
--- a/browser/main/lib/dataApi/copyFile.js
+++ b/browser/main/lib/dataApi/copyFile.js
@@ -16,7 +16,7 @@ function copyFile (srcPath, dstPath) {
     const dstFolder = path.dirname(dstPath)
     if (!fs.existsSync(dstFolder)) fs.mkdirSync(dstFolder)
 
-    const input = fs.createReadStream(srcPath)
+    const input = fs.createReadStream(decodeURI(srcPath))
     const output = fs.createWriteStream(dstPath)
 
     output.on('error', reject)

--- a/tests/dataApi/copyFile-test.js
+++ b/tests/dataApi/copyFile-test.js
@@ -1,0 +1,35 @@
+const test = require('ava')
+const copyFile = require('browser/main/lib/dataApi/copyFile')
+
+const path = require('path')
+const fs = require('fs')
+
+const testFile = 'test.txt'
+const srcFolder = path.join(__dirname, '🤔')
+const srcPath = path.join(srcFolder, testFile)
+const dstFolder = path.join(__dirname, '😇')
+const dstPath = path.join(dstFolder, testFile)
+
+test.before((t) => {
+  if (!fs.existsSync(srcFolder)) fs.mkdirSync(srcFolder)
+
+  fs.writeFileSync(srcPath, 'test')
+})
+
+test('`copyFile` should handle encoded URI on src path', (t) => {
+  return copyFile(encodeURI(srcPath), dstPath)
+    .then(() => {
+      t.true(true)
+    })
+    .catch(() => {
+      t.true(false)
+    })
+})
+
+test.after((t) => {
+  fs.unlinkSync(srcPath)
+  fs.unlinkSync(dstPath)
+  fs.rmdirSync(srcFolder)
+  fs.rmdirSync(dstFolder)
+})
+


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
Currently, Boostnote seems managing file path with encodeURI. 
so if your path contains unicode character, it turns encoded URI. 
`ex) 'User/안녕/dev', ->'User%2F%EC%95%88%EB%85%95%2Fdev`

I cannot figure out which process handle path encoding,
but it affected `copyFile` only. so I attached `decodeURI` here.

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#2578


<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :radio_button: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
