### PR TITLE
Feature - Line highlighting within code block #2469

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -519,6 +519,11 @@ export default class CodeEditor extends React.Component {
 
   handleHighlight (editor, changeObject) {
     const lines = editor.options.linesHighlighted
+
+    if (lines == null) {
+      return
+    }
+
     if (!lines.includes(changeObject)) {
       lines.push(changeObject)
       editor.addLineClass(changeObject, 'text', 'CodeMirror-activeline-background')
@@ -564,11 +569,6 @@ export default class CodeEditor extends React.Component {
     const cursor = this.editor.getCursor()
     this.editor.setValue(value)
     this.editor.setCursor(cursor)
-  }
-
-  restartHighlighting () {
-    this.editor.options.linesHighlighted = this.props.linesHighlighted
-    this.initialHighlighting()
   }
 
   handleDropImage (dropEvent) {
@@ -709,12 +709,21 @@ export default class CodeEditor extends React.Component {
   }
 
   initialHighlighting () {
+    if (this.editor.options.linesHighlighted == null) {
+      return
+    }
+
     const count = this.editor.lineCount()
     for (let i = 0; i < count; i++) {
       if (this.editor.options.linesHighlighted.includes(i)) {
         this.editor.addLineClass(i, 'text', 'CodeMirror-activeline-background')
       }
     }
+  }
+
+  restartHighlighting () {
+    this.editor.options.linesHighlighted = this.props.linesHighlighted
+    this.initialHighlighting()
   }
 
   mapImageResponse (response, pastedTxt) {

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -520,10 +520,6 @@ export default class CodeEditor extends React.Component {
   handleHighlight (editor, changeObject) {
     const lines = editor.options.linesHighlighted
 
-    if (lines == null) {
-      return
-    }
-
     if (!lines.includes(changeObject)) {
       lines.push(changeObject)
       editor.addLineClass(changeObject, 'text', 'CodeMirror-activeline-background')

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -209,13 +209,13 @@ export default class CodeEditor extends React.Component {
         }
         return CodeMirror.Pass
       }
-    })   
+    })
 
     this.value = this.props.value
     this.editor = CodeMirror(this.refs.root, {
       rulers: buildCMRulers(rulers, enableRulers),
       value: this.props.value,
-      linesHighlighted:this.props.linesHighlighted,
+      linesHighlighted: this.props.linesHighlighted,
       lineNumbers: this.props.displayLineNumbers,
       lineWrapping: true,
       theme: this.props.theme,
@@ -242,7 +242,7 @@ export default class CodeEditor extends React.Component {
     this.editor.on('focus', this.focusHandler)
     this.editor.on('blur', this.blurHandler)
     this.editor.on('change', this.changeHandler)
-    this.editor.on("gutterClick",this.highlightHandler)
+    this.editor.on('gutterClick', this.highlightHandler)
     this.editor.on('paste', this.pasteHandler)
     this.editor.on('contextmenu', this.contextMenuHandler)
     eventEmitter.on('top:search', this.searchHandler)
@@ -320,10 +320,10 @@ export default class CodeEditor extends React.Component {
       clientWidth: this.refs.root.clientWidth
     })
 
-    this.initialHighlighting()    
+    this.initialHighlighting()
   }
 
-  expandSnippet (line, cursor, cm, snippets) {    
+  expandSnippet (line, cursor, cm, snippets) {
     const wordBeforeCursor = this.getWordBeforeCursor(
       line,
       cursor.line,
@@ -518,13 +518,13 @@ export default class CodeEditor extends React.Component {
   }
 
   handleHighlight (editor, changeObject) {
-    let lines =editor.options.linesHighlighted 
-    if(!lines.includes(changeObject)){
+    const lines = editor.options.linesHighlighted
+    if (!lines.includes(changeObject)) {
       lines.push(changeObject)
-      editor.addLineClass(changeObject,'text',"CodeMirror-activeline-background")
-    }else{
-      lines.splice(lines.indexOf(changeObject),1)
-      editor.removeLineClass(changeObject,'text',"CodeMirror-activeline-background")
+      editor.addLineClass(changeObject, 'text', 'CodeMirror-activeline-background')
+    } else {
+      lines.splice(lines.indexOf(changeObject), 1)
+      editor.removeLineClass(changeObject, 'text', 'CodeMirror-activeline-background')
     }
     if (this.props.onChange) {
       this.props.onChange(editor)
@@ -566,7 +566,7 @@ export default class CodeEditor extends React.Component {
     this.editor.setCursor(cursor)
   }
 
-  restartHighlighting(){
+  restartHighlighting () {
     this.editor.options.linesHighlighted = this.props.linesHighlighted
     this.initialHighlighting()
   }
@@ -708,11 +708,11 @@ export default class CodeEditor extends React.Component {
     })
   }
 
-  initialHighlighting(){
-    var count = this.editor.lineCount(), i
-    for (i = 0; i < count; i++) {
-      if(this.editor.options.linesHighlighted.includes(i)){
-        this.editor.addLineClass(i,'text',"CodeMirror-activeline-background")
+  initialHighlighting () {
+    const count = this.editor.lineCount()
+    for (let i = 0; i < count; i++) {
+      if (this.editor.options.linesHighlighted.includes(i)) {
+        this.editor.addLineClass(i, 'text', 'CodeMirror-activeline-background')
       }
     }
   }

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -518,11 +518,12 @@ export default class CodeEditor extends React.Component {
   }
 
   handleHighlight (editor, changeObject) {
-    if(!editor.options.linesHighlighted.includes(changeObject)){
-      editor.options.linesHighlighted.push(changeObject)
+    let lines =editor.options.linesHighlighted 
+    if(!lines.includes(changeObject)){
+      lines.push(changeObject)
       editor.addLineClass(changeObject,'text',"CodeMirror-activeline-background")
     }else{
-      editor.options.linesHighlighted.splice(editor.options.linesHighlighted.indexOf(changeObject),1)
+      lines.splice(lines.indexOf(changeObject),1)
       editor.removeLineClass(changeObject,'text',"CodeMirror-activeline-background")
     }
     if (this.props.onChange) {
@@ -567,7 +568,7 @@ export default class CodeEditor extends React.Component {
 
   restartHighlighting(){
     this.editor.options.linesHighlighted = this.props.linesHighlighted
-    this.initialHighlighting();
+    this.initialHighlighting()
   }
 
   handleDropImage (dropEvent) {
@@ -708,7 +709,7 @@ export default class CodeEditor extends React.Component {
   }
 
   initialHighlighting(){
-    var count = this.editor.lineCount(), i;
+    var count = this.editor.lineCount(), i
     for (i = 0; i < count; i++) {
       if(this.editor.options.linesHighlighted.includes(i)){
         this.editor.addLineClass(i,'text',"CodeMirror-activeline-background")

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -713,11 +713,16 @@ export default class CodeEditor extends React.Component {
       return
     }
 
-    const count = this.editor.lineCount()
-    for (let i = 0; i < count; i++) {
-      if (this.editor.options.linesHighlighted.includes(i)) {
-        this.editor.addLineClass(i, 'text', 'CodeMirror-activeline-background')
+    const totalHighlightedLines = this.editor.options.linesHighlighted.length
+    const totalAvailableLines = this.editor.lineCount()
+
+    for (let i = 0; i < totalHighlightedLines; i++) {
+      const lineNumber = this.editor.options.linesHighlighted[i]
+      if (lineNumber > totalAvailableLines) {
+        // make sure that we skip the invalid lines althrough this case should not be happened.
+        continue
       }
+      this.editor.addLineClass(lineNumber, 'text', 'CodeMirror-activeline-background')
     }
   }
 

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -232,7 +232,7 @@ class MarkdownEditor extends React.Component {
   }
 
   render () {
-    const {className, value, config, storageKey, noteKey} = this.props
+    const {className, value, config, storageKey, noteKey, linesHighlighted} = this.props
 
     let editorFontSize = parseInt(config.editor.fontSize, 10)
     if (!(editorFontSize > 0 && editorFontSize < 101)) editorFontSize = 14
@@ -275,7 +275,8 @@ class MarkdownEditor extends React.Component {
           noteKey={noteKey}
           fetchUrlTitle={config.editor.fetchUrlTitle}
           enableTableEditor={config.editor.enableTableEditor}
-          onChange={(e) => this.handleChange(e)}
+          linesHighlighted={linesHighlighted}
+          onChange={(e) => this.handleChange(e).bind(this)}
           onBlur={(e) => this.handleBlur(e)}
           spellCheck={config.editor.spellcheck}
         />

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -276,7 +276,7 @@ class MarkdownEditor extends React.Component {
           fetchUrlTitle={config.editor.fetchUrlTitle}
           enableTableEditor={config.editor.enableTableEditor}
           linesHighlighted={linesHighlighted}
-          onChange={(e) => this.handleChange.bind(this)(e)}
+          onChange={(e) => this.handleChange(e)}
           onBlur={(e) => this.handleBlur(e)}
           spellCheck={config.editor.spellcheck}
         />

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -276,7 +276,7 @@ class MarkdownEditor extends React.Component {
           fetchUrlTitle={config.editor.fetchUrlTitle}
           enableTableEditor={config.editor.enableTableEditor}
           linesHighlighted={linesHighlighted}
-          onChange={(e) => this.handleChange(e).bind(this)}
+          onChange={(e) => this.handleChange.bind(this)(e)}
           onBlur={(e) => this.handleBlur(e)}
           spellCheck={config.editor.spellcheck}
         />

--- a/browser/components/MarkdownSplitEditor.js
+++ b/browser/components/MarkdownSplitEditor.js
@@ -170,7 +170,7 @@ class MarkdownSplitEditor extends React.Component {
           storageKey={storageKey}
           noteKey={noteKey}
           linesHighlighted={linesHighlighted}
-          onChange={(e) => this.handleOnChange.bind(this)(e)}
+          onChange={(e) => this.handleOnChange(e)}
           onScroll={this.handleScroll.bind(this)}
           spellCheck={config.editor.spellcheck}
        />

--- a/browser/components/MarkdownSplitEditor.js
+++ b/browser/components/MarkdownSplitEditor.js
@@ -170,7 +170,7 @@ class MarkdownSplitEditor extends React.Component {
           storageKey={storageKey}
           noteKey={noteKey}
           linesHighlighted={linesHighlighted}
-          onChange={(e) => this.handleOnChange(e).bind(this)}
+          onChange={(e) => this.handleOnChange.bind(this)(e)}
           onScroll={this.handleScroll.bind(this)}
           spellCheck={config.editor.spellcheck}
        />

--- a/browser/components/MarkdownSplitEditor.js
+++ b/browser/components/MarkdownSplitEditor.js
@@ -24,9 +24,9 @@ class MarkdownSplitEditor extends React.Component {
     this.refs.code.setValue(value)
   }
 
-  handleOnChange () {
+  handleOnChange (e) {
     this.value = this.refs.code.value
-    this.props.onChange()
+    this.props.onChange(e)
   }
 
   handleScroll (e) {
@@ -136,7 +136,7 @@ class MarkdownSplitEditor extends React.Component {
   }
 
   render () {
-    const {config, value, storageKey, noteKey} = this.props
+    const {config, value, storageKey, noteKey, linesHighlighted} = this.props
     const storage = findStorage(storageKey)
     let editorFontSize = parseInt(config.editor.fontSize, 10)
     if (!(editorFontSize > 0 && editorFontSize < 101)) editorFontSize = 14
@@ -169,7 +169,8 @@ class MarkdownSplitEditor extends React.Component {
           enableTableEditor={config.editor.enableTableEditor}
           storageKey={storageKey}
           noteKey={noteKey}
-          onChange={this.handleOnChange.bind(this)}
+          linesHighlighted={linesHighlighted}
+          onChange={(e) => this.handleOnChange(e).bind(this)}
           onScroll={this.handleScroll.bind(this)}
           spellCheck={config.editor.spellcheck}
        />

--- a/browser/lib/newNote.js
+++ b/browser/lib/newNote.js
@@ -18,7 +18,8 @@ export function createMarkdownNote (storage, folder, dispatch, location, params,
       folder: folder,
       title: '',
       tags,
-      content: ''
+      content: '',
+      linesHighlighted: []
     })
     .then(note => {
       const noteHash = note.key

--- a/browser/lib/newNote.js
+++ b/browser/lib/newNote.js
@@ -57,7 +57,7 @@ export function createSnippetNote (storage, folder, dispatch, location, params, 
           name: '',
           mode: config.editor.snippetDefaultLanguage || 'text',
           content: '',
-          linesHighlighted:[],
+          linesHighlighted: []
         }
       ]
     })

--- a/browser/lib/newNote.js
+++ b/browser/lib/newNote.js
@@ -56,7 +56,8 @@ export function createSnippetNote (storage, folder, dispatch, location, params, 
         {
           name: '',
           mode: config.editor.snippetDefaultLanguage || 'text',
-          content: ''
+          content: '',
+          linesHighlighted:[],
         }
       ]
     })

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -47,11 +47,6 @@ class MarkdownNoteDetail extends React.Component {
       editorType: props.config.editor.type
     }
 
-    let lines = this.state.note.linesHighlighted
-    if (lines === undefined) {
-      lines = []
-    }
-
     this.dispatchTimer = null
 
     this.toggleLockButton = this.handleToggleLockButton.bind(this)
@@ -78,7 +73,7 @@ class MarkdownNoteDetail extends React.Component {
     if (!this.state.isMovingNote && (isNewNote || hasDeletedTags)) {
       if (this.saveQueue != null) this.saveNow()
       this.setState({
-        note: Object.assign({}, nextProps.note)
+        note: Object.assign({linesHighlighted: []}, nextProps.note)
       }, () => {
         this.refs.content.reload()
         if (this.refs.tags) this.refs.tags.reset()

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -39,12 +39,19 @@ class MarkdownNoteDetail extends React.Component {
       isMovingNote: false,
       note: Object.assign({
         title: '',
-        content: ''
+        content: '',
+        linesHighlighted: []
       }, props.note),
       isLockButtonShown: false,
       isLocked: false,
       editorType: props.config.editor.type
     }
+
+    let lines = this.state.note.linesHighlighted
+    if (lines === undefined) {
+      lines = []
+    }
+
     this.dispatchTimer = null
 
     this.toggleLockButton = this.handleToggleLockButton.bind(this)
@@ -361,6 +368,7 @@ class MarkdownNoteDetail extends React.Component {
         value={note.content}
         storageKey={note.storage}
         noteKey={note.key}
+        linesHighlighted={note.linesHighlighted}
         onChange={this.handleUpdateContent.bind(this)}
         ignorePreviewPointerEvents={ignorePreviewPointerEvents}
       />
@@ -371,6 +379,7 @@ class MarkdownNoteDetail extends React.Component {
         value={note.content}
         storageKey={note.storage}
         noteKey={note.key}
+        linesHighlighted={note.linesHighlighted}
         onChange={this.handleUpdateContent.bind(this)}
         ignorePreviewPointerEvents={ignorePreviewPointerEvents}
       />

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -410,7 +410,7 @@ class SnippetNoteDetail extends React.Component {
     return (e) => {
       const snippets = this.state.note.snippets.slice()
       snippets[index].content = this.refs['code-' + index].value
-      snippets[index].linesHighlighted=e.options.linesHighlighted
+      snippets[index].linesHighlighted = e.options.linesHighlighted
 
       this.setState(state => ({note: Object.assign(state.note, {snippets: snippets})}))
       this.setState(state => ({
@@ -605,7 +605,7 @@ class SnippetNoteDetail extends React.Component {
       name: '',
       mode: config.editor.snippetDefaultLanguage || 'text',
       content: '',
-      linesHighlighted:[]
+      linesHighlighted: []
     }])
     const snippetIndex = note.snippets.length - 1
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -48,15 +48,9 @@ class SnippetNoteDetail extends React.Component {
       note: Object.assign({
         description: ''
       }, props.note, {
-        snippets: props.note.snippets.map((snippet) => Object.assign({}, snippet))
+        snippets: props.note.snippets.map((snippet) => Object.assign({linesHighlighted: []}, snippet))
       })
     }
-
-    this.state.note.snippets.forEach(function (s) {
-      if (s.linesHighlighted === undefined) {
-        s.linesHighlighted = []
-      }
-    })
 
     this.scrollToNextTabThreshold = 0.7
     this.generateToc = () => this.handleGenerateToc()
@@ -82,8 +76,9 @@ class SnippetNoteDetail extends React.Component {
       const nextNote = Object.assign({
         description: ''
       }, nextProps.note, {
-        snippets: nextProps.note.snippets.map((snippet) => Object.assign({}, snippet))
+        snippets: nextProps.note.snippets.map((snippet) => Object.assign({linesHighlighted: []}, snippet))
       })
+
       this.setState({
         snippetIndex: 0,
         note: nextNote
@@ -694,10 +689,8 @@ class SnippetNoteDetail extends React.Component {
 
     const viewList = note.snippets.map((snippet, index) => {
       const isActive = this.state.snippetIndex === index
-
       let syntax = CodeMirror.findModeByName(convertModeName(snippet.mode))
       if (syntax == null) syntax = CodeMirror.findModeByName('Plain Text')
-
       return <div styleName='tabView'
         key={index}
         style={{zIndex: isActive ? 5 : 4}}

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -706,6 +706,7 @@ class SnippetNoteDetail extends React.Component {
           ? <MarkdownEditor styleName='tabView-content'
             value={snippet.content}
             config={config}
+            linesHighlighted={snippet.linesHighlighted}
             onChange={(e) => this.handleCodeChange(index)(e)}
             ref={'code-' + index}
             ignorePreviewPointerEvents={this.props.ignorePreviewPointerEvents}

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -52,6 +52,12 @@ class SnippetNoteDetail extends React.Component {
       })
     }
 
+    this.state.note.snippets.forEach(function (s) {
+      if (s.linesHighlighted === undefined) {
+        s.linesHighlighted = []
+      }
+    })
+
     this.scrollToNextTabThreshold = 0.7
     this.generateToc = () => this.handleGenerateToc()
   }

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -410,6 +410,8 @@ class SnippetNoteDetail extends React.Component {
     return (e) => {
       const snippets = this.state.note.snippets.slice()
       snippets[index].content = this.refs['code-' + index].value
+      snippets[index].linesHighlighted=e.options.linesHighlighted
+
       this.setState(state => ({note: Object.assign(state.note, {snippets: snippets})}))
       this.setState(state => ({
         note: state.note
@@ -602,7 +604,8 @@ class SnippetNoteDetail extends React.Component {
     note.snippets = note.snippets.concat([{
       name: '',
       mode: config.editor.snippetDefaultLanguage || 'text',
-      content: ''
+      content: '',
+      linesHighlighted:[]
     }])
     const snippetIndex = note.snippets.length - 1
 
@@ -705,6 +708,7 @@ class SnippetNoteDetail extends React.Component {
           : <CodeEditor styleName='tabView-content'
             mode={snippet.mode}
             value={snippet.content}
+            linesHighlighted={snippet.linesHighlighted}
             theme={config.editor.theme}
             fontFamily={config.editor.fontFamily}
             fontSize={editorFontSize}

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -96,12 +96,14 @@ class Main extends React.Component {
               {
                 name: 'example.html',
                 mode: 'html',
-                content: "<html>\n<body>\n<h1 id='hello'>Enjoy Boostnote!</h1>\n</body>\n</html>"
+                content: "<html>\n<body>\n<h1 id='hello'>Enjoy Boostnote!</h1>\n</body>\n</html>",
+                linesHighlighted:[]
               },
               {
                 name: 'example.js',
                 mode: 'javascript',
-                content: "var boostnote = document.getElementById('enjoy').innerHTML\n\nconsole.log(boostnote)"
+                content: "var boostnote = document.getElementById('enjoy').innerHTML\n\nconsole.log(boostnote)",
+                linesHighlighted:[]
               }
             ]
           })

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -97,13 +97,13 @@ class Main extends React.Component {
                 name: 'example.html',
                 mode: 'html',
                 content: "<html>\n<body>\n<h1 id='hello'>Enjoy Boostnote!</h1>\n</body>\n</html>",
-                linesHighlighted:[]
+                linesHighlighted: []
               },
               {
                 name: 'example.js',
                 mode: 'javascript',
                 content: "var boostnote = document.getElementById('enjoy').innerHTML\n\nconsole.log(boostnote)",
-                linesHighlighted:[]
+                linesHighlighted: []
               }
             ]
           })

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -707,7 +707,8 @@ class NoteList extends React.Component {
         type: firstNote.type,
         folder: folder.key,
         title: firstNote.title + ' ' + i18n.__('copy'),
-        content: firstNote.content
+        content: firstNote.content,
+        linesHighlighted: firstNote.linesHighlighted
       })
       .then((note) => {
         attachmentManagement.cloneAttachments(firstNote, note)

--- a/browser/main/lib/dataApi/createNote.js
+++ b/browser/main/lib/dataApi/createNote.js
@@ -24,7 +24,7 @@ function validateInput (input) {
           name: '',
           mode: 'text',
           content: '',
-          linesHighlighted:[],
+          linesHighlighted: []
         }]
       }
       break

--- a/browser/main/lib/dataApi/createNote.js
+++ b/browser/main/lib/dataApi/createNote.js
@@ -23,7 +23,8 @@ function validateInput (input) {
         input.snippets = [{
           name: '',
           mode: 'text',
-          content: ''
+          content: '',
+          linesHighlighted:[],
         }]
       }
       break

--- a/browser/main/lib/dataApi/createNote.js
+++ b/browser/main/lib/dataApi/createNote.js
@@ -16,6 +16,7 @@ function validateInput (input) {
   switch (input.type) {
     case 'MARKDOWN_NOTE':
       if (!_.isString(input.content)) input.content = ''
+      if (!_.isArray(input.linesHighlighted)) input.linesHighlighted = []
       break
     case 'SNIPPET_NOTE':
       if (!_.isString(input.description)) input.description = ''

--- a/browser/main/lib/dataApi/createSnippet.js
+++ b/browser/main/lib/dataApi/createSnippet.js
@@ -10,7 +10,7 @@ function createSnippet (snippetFile) {
       name: 'Unnamed snippet',
       prefix: [],
       content: '',
-      linesHighlighted: [],
+      linesHighlighted: []
     }
     fetchSnippet(null, snippetFile).then((snippets) => {
       snippets.push(newSnippet)

--- a/browser/main/lib/dataApi/createSnippet.js
+++ b/browser/main/lib/dataApi/createSnippet.js
@@ -9,7 +9,8 @@ function createSnippet (snippetFile) {
       id: crypto.randomBytes(16).toString('hex'),
       name: 'Unnamed snippet',
       prefix: [],
-      content: ''
+      content: '',
+      linesHighlighted: [],
     }
     fetchSnippet(null, snippetFile).then((snippets) => {
       snippets.push(newSnippet)

--- a/browser/main/lib/dataApi/migrateFromV5Storage.js
+++ b/browser/main/lib/dataApi/migrateFromV5Storage.js
@@ -88,7 +88,7 @@ function importAll (storage, data) {
               name: article.mode,
               mode: article.mode,
               content: article.content,
-              linesHighlighted: article.linesHighlighted,
+              linesHighlighted: article.linesHighlighted
             }]
           }
           notes.push(newNote)

--- a/browser/main/lib/dataApi/migrateFromV5Storage.js
+++ b/browser/main/lib/dataApi/migrateFromV5Storage.js
@@ -87,7 +87,8 @@ function importAll (storage, data) {
             snippets: [{
               name: article.mode,
               mode: article.mode,
-              content: article.content
+              content: article.content,
+              linesHighlighted: article.linesHighlighted,
             }]
           }
           notes.push(newNote)

--- a/browser/main/lib/dataApi/migrateFromV5Storage.js
+++ b/browser/main/lib/dataApi/migrateFromV5Storage.js
@@ -69,7 +69,8 @@ function importAll (storage, data) {
             isStarred: false,
             title: article.title,
             content: '# ' + article.title + '\n\n' + article.content,
-            key: noteKey
+            key: noteKey,
+            linesHighlighted: article.linesHighlighted
           }
           notes.push(newNote)
         } else {

--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -39,6 +39,9 @@ function validateInput (input) {
       if (input.content != null) {
         if (!_.isString(input.content)) validatedInput.content = ''
         else validatedInput.content = input.content
+
+        if (!_.isArray(input.linesHighlighted)) validatedInput.linesHighlighted = []
+        else validatedInput.linesHighlighted = input.linesHighlighted
       }
       return validatedInput
     case 'SNIPPET_NOTE':
@@ -103,7 +106,8 @@ function updateNote (storageKey, noteKey, input) {
           }
           : {
             type: 'MARKDOWN_NOTE',
-            content: ''
+            content: '',
+            linesHighlighted: []
           }
         noteData.title = ''
         if (storage.folders.length === 0) throw new Error('Failed to restore note: No folder exists.')

--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -118,8 +118,6 @@ function updateNote (storageKey, noteKey, input) {
 
       if (noteData.type === 'SNIPPET_NOTE') {
         noteData.title
-        if(noteData.linesHighlighted = null)
-          noteData.linesHighlighted = [];
       }
 
       Object.assign(noteData, input, {

--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -51,7 +51,8 @@ function validateInput (input) {
           validatedInput.snippets = [{
             name: '',
             mode: 'text',
-            content: ''
+            content: '',
+            linesHighlighted:[],
           }]
         } else {
           validatedInput.snippets = input.snippets
@@ -96,7 +97,8 @@ function updateNote (storageKey, noteKey, input) {
             snippets: [{
               name: '',
               mode: 'text',
-              content: ''
+              content: '',
+              linesHighlighted:[],
             }]
           }
           : {

--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -118,6 +118,8 @@ function updateNote (storageKey, noteKey, input) {
 
       if (noteData.type === 'SNIPPET_NOTE') {
         noteData.title
+        if(noteData.linesHighlighted = null)
+          noteData.linesHighlighted = [];
       }
 
       Object.assign(noteData, input, {

--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -52,7 +52,7 @@ function validateInput (input) {
             name: '',
             mode: 'text',
             content: '',
-            linesHighlighted:[],
+            linesHighlighted: []
           }]
         } else {
           validatedInput.snippets = input.snippets
@@ -98,7 +98,7 @@ function updateNote (storageKey, noteKey, input) {
               name: '',
               mode: 'text',
               content: '',
-              linesHighlighted:[],
+              linesHighlighted: []
             }]
           }
           : {

--- a/browser/main/lib/dataApi/updateSnippet.js
+++ b/browser/main/lib/dataApi/updateSnippet.js
@@ -12,8 +12,8 @@ function updateSnippet (snippet, snippetFile) {
         if (
           currentSnippet.name === snippet.name &&
           currentSnippet.prefix === snippet.prefix &&
-          currentSnippet.content === snippet.content && 
-          currentSnippet.linesHighlighted===snippet.linesHighlighted 
+          currentSnippet.content === snippet.content &&
+          currentSnippet.linesHighlighted === snippet.linesHighlighted
         ) {
           // if everything is the same then don't write to disk
           resolve(snippets)

--- a/browser/main/lib/dataApi/updateSnippet.js
+++ b/browser/main/lib/dataApi/updateSnippet.js
@@ -12,7 +12,8 @@ function updateSnippet (snippet, snippetFile) {
         if (
           currentSnippet.name === snippet.name &&
           currentSnippet.prefix === snippet.prefix &&
-          currentSnippet.content === snippet.content
+          currentSnippet.content === snippet.content && 
+          currentSnippet.linesHighlighted===snippet.linesHighlighted 
         ) {
           // if everything is the same then don't write to disk
           resolve(snippets)
@@ -20,6 +21,7 @@ function updateSnippet (snippet, snippetFile) {
           currentSnippet.name = snippet.name
           currentSnippet.prefix = snippet.prefix
           currentSnippet.content = snippet.content
+          currentSnippet.linesHighlighted = (snippet.linesHighlighted)
           fs.writeFile(snippetFile || consts.SNIPPET_FILE, JSON.stringify(snippets, null, 4), (err) => {
             if (err) reject(err)
             resolve(snippets)

--- a/tests/dataApi/createNote-test.js
+++ b/tests/dataApi/createNote-test.js
@@ -25,13 +25,16 @@ test.serial('Create a note', (t) => {
   const storageKey = t.context.storage.cache.key
   const folderKey = t.context.storage.json.folders[0].key
 
+  const randLinesHighlightedArray = new Array(10).fill().map(() => Math.round(Math.random() * 10))
+
   const input1 = {
     type: 'SNIPPET_NOTE',
     description: faker.lorem.lines(),
     snippets: [{
       name: faker.system.fileName(),
       mode: 'text',
-      content: faker.lorem.lines()
+      content: faker.lorem.lines(),
+      linesHighlighted: randLinesHighlightedArray
     }],
     tags: faker.lorem.words().split(' '),
     folder: folderKey
@@ -42,7 +45,8 @@ test.serial('Create a note', (t) => {
     type: 'MARKDOWN_NOTE',
     content: faker.lorem.lines(),
     tags: faker.lorem.words().split(' '),
-    folder: folderKey
+    folder: folderKey,
+    linesHighlighted: randLinesHighlightedArray
   }
   input2.title = input2.content.split('\n').shift()
 
@@ -59,6 +63,7 @@ test.serial('Create a note', (t) => {
 
       t.is(storageKey, data1.storage)
       const jsonData1 = CSON.readFileSync(path.join(storagePath, 'notes', data1.key + '.cson'))
+
       t.is(input1.title, data1.title)
       t.is(input1.title, jsonData1.title)
       t.is(input1.description, data1.description)
@@ -71,6 +76,8 @@ test.serial('Create a note', (t) => {
       t.is(input1.snippets[0].content, jsonData1.snippets[0].content)
       t.is(input1.snippets[0].name, data1.snippets[0].name)
       t.is(input1.snippets[0].name, jsonData1.snippets[0].name)
+      t.deepEqual(input1.snippets[0].linesHighlighted, data1.snippets[0].linesHighlighted)
+      t.deepEqual(input1.snippets[0].linesHighlighted, jsonData1.snippets[0].linesHighlighted)
 
       t.is(storageKey, data2.storage)
       const jsonData2 = CSON.readFileSync(path.join(storagePath, 'notes', data2.key + '.cson'))
@@ -80,6 +87,8 @@ test.serial('Create a note', (t) => {
       t.is(input2.content, jsonData2.content)
       t.is(input2.tags.length, data2.tags.length)
       t.is(input2.tags.length, jsonData2.tags.length)
+      t.deepEqual(input2.linesHighlighted, data2.linesHighlighted)
+      t.deepEqual(input2.linesHighlighted, jsonData2.linesHighlighted)
     })
 })
 

--- a/tests/dataApi/createSnippet-test.js
+++ b/tests/dataApi/createSnippet-test.js
@@ -26,6 +26,7 @@ test.serial('Create a snippet', (t) => {
       t.is(snippet.name, data.name)
       t.deepEqual(snippet.prefix, data.prefix)
       t.is(snippet.content, data.content)
+      t.deepEqual(snippet.linesHighlighted, data.linesHighlighted)
     })
 })
 

--- a/tests/dataApi/updateNote-test.js
+++ b/tests/dataApi/updateNote-test.js
@@ -26,13 +26,17 @@ test.serial('Update a note', (t) => {
   const storageKey = t.context.storage.cache.key
   const folderKey = t.context.storage.json.folders[0].key
 
+  const randLinesHighlightedArray = new Array(10).fill().map(() => Math.round(Math.random() * 10))
+  const randLinesHighlightedArray2 = new Array(15).fill().map(() => Math.round(Math.random() * 15))
+
   const input1 = {
     type: 'SNIPPET_NOTE',
     description: faker.lorem.lines(),
     snippets: [{
       name: faker.system.fileName(),
       mode: 'text',
-      content: faker.lorem.lines()
+      content: faker.lorem.lines(),
+      linesHighlighted: randLinesHighlightedArray
     }],
     tags: faker.lorem.words().split(' '),
     folder: folderKey
@@ -43,7 +47,8 @@ test.serial('Update a note', (t) => {
     type: 'MARKDOWN_NOTE',
     content: faker.lorem.lines(),
     tags: faker.lorem.words().split(' '),
-    folder: folderKey
+    folder: folderKey,
+    linesHighlighted: randLinesHighlightedArray
   }
   input2.title = input2.content.split('\n').shift()
 
@@ -53,7 +58,8 @@ test.serial('Update a note', (t) => {
     snippets: [{
       name: faker.system.fileName(),
       mode: 'text',
-      content: faker.lorem.lines()
+      content: faker.lorem.lines(),
+      linesHighlighted: randLinesHighlightedArray2
     }],
     tags: faker.lorem.words().split(' ')
   }
@@ -62,7 +68,8 @@ test.serial('Update a note', (t) => {
   const input4 = {
     type: 'MARKDOWN_NOTE',
     content: faker.lorem.lines(),
-    tags: faker.lorem.words().split(' ')
+    tags: faker.lorem.words().split(' '),
+    linesHighlighted: randLinesHighlightedArray2
   }
   input4.title = input4.content.split('\n').shift()
 
@@ -99,6 +106,8 @@ test.serial('Update a note', (t) => {
       t.is(input3.snippets[0].content, jsonData1.snippets[0].content)
       t.is(input3.snippets[0].name, data1.snippets[0].name)
       t.is(input3.snippets[0].name, jsonData1.snippets[0].name)
+      t.deepEqual(input3.snippets[0].linesHighlighted, data1.snippets[0].linesHighlighted)
+      t.deepEqual(input3.snippets[0].linesHighlighted, jsonData1.snippets[0].linesHighlighted)
 
       const jsonData2 = CSON.readFileSync(path.join(storagePath, 'notes', data2.key + '.cson'))
       t.is(input4.title, data2.title)
@@ -107,6 +116,8 @@ test.serial('Update a note', (t) => {
       t.is(input4.content, jsonData2.content)
       t.is(input4.tags.length, data2.tags.length)
       t.is(input4.tags.length, jsonData2.tags.length)
+      t.deepEqual(input4.linesHighlighted, data2.linesHighlighted)
+      t.deepEqual(input4.linesHighlighted, jsonData2.linesHighlighted)
     })
 })
 


### PR DESCRIPTION
## Description
This PR solves the #2469 issue, it allows the user to highlight lines of code within a snippet of code by clicking on the line number. This highlight is not temporary, it persists when exiting Boostnote. Used CodeMirror built-in functionality to do this.

To use this feature you just need to click the line number of the respective line you want to highlight.

### Before
![screenshot from 2018-12-05 13-19-51](https://user-images.githubusercontent.com/19807634/49516218-03a6a780-f891-11e8-9812-4af4b3433a03.png)
### After
![screenshot from 2018-12-05 13-20-18](https://user-images.githubusercontent.com/19807634/49516224-06090180-f891-11e8-8b77-6b896b629a32.png)

## Issue fixed
Issue #2469 Line highlighting within code block

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: : Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :radio_button: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
