### PR TITLE
Bug - The output HTML has no codeblock color #2675

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -38,7 +38,7 @@ class Markdown {
       const allowedTags = ['iframe', 'input', 'b',
         'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7', 'h8', 'br', 'b', 'i', 'strong', 'em', 'a', 'pre', 'code', 'img', 'tt',
         'div', 'ins', 'del', 'sup', 'sub', 'p', 'ol', 'ul', 'table', 'thead', 'tbody', 'tfoot', 'blockquote',
-        'dl', 'dt', 'dd', 'kbd', 'q', 'samp', 'var', 'hr', 'ruby', 'rt', 'rp', 'li', 'tr', 'td', 'th', 's', 'strike', 'summary', 'details'
+        'dl', 'dt', 'dd', 'kbd', 'q', 'samp', 'var', 'hr', 'ruby', 'rt', 'rp', 'li', 'tr', 'td', 'th', 's', 'strike', 'summary', 'style', 'details'
       ]
       const allowedAttributes = [
         'abbr', 'accept', 'accept-charset',
@@ -55,15 +55,10 @@ class Markdown {
         'nowrap', 'open', 'prompt', 'readonly', 'rel', 'rev',
         'rows', 'rowspan', 'rules', 'scope',
         'selected', 'shape', 'size', 'span',
-        'start', 'summary', 'tabindex', 'target',
+        'start', 'summary', 'style', 'tabindex', 'target',
         'title', 'type', 'usemap', 'valign', 'value',
         'vspace', 'width', 'itemprop'
       ]
-
-      if (updatedOptions.sanitize === 'ALLOW_STYLES') {
-        allowedTags.push('style')
-        allowedAttributes.push('style')
-      }
 
       // Sanitize use rinput before other plugins
       this.md.use(sanitize, {


### PR DESCRIPTION

## Description
This PR solves the #2675 issue. Upon looking at the code I noticed that the default configuration (sanitize = 'STRICT'), did not allow style tags in the HTML parsing module used. The best solution would be to change the default configuration, present in ConfigManager.js, to sanitize='ALLOW_STYLES'. Meanwhile, in the first run of the program a default configuration is stored in a different directory at your home folder (~./config). For most users, this default configuration already has the 'STRICT' tag. In the startup this saved configuration is assigned with the one present in ConfigManager, so the newly defined tag won't be used. Finally, for this solution to take effect it would require for all previous users to delete the .config folder and run the program. 
The solution I implemented, that requires no deletions of folders, was simply to allow style tags in the STRICT sanitize method (that renders the ALLOW_STYLES sanitize useless).

Output:
![screenshot from 2018-12-07 14-22-13](https://user-images.githubusercontent.com/32707738/49653484-ffaf8c80-fa2c-11e8-9e1e-8f9d2698e251.png)


## Issue fixed
The output HTML has no codeblock color #2675


## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :radio_button: Breaking change (Change that can cause existing functionality to change)
- :white_circle: : Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
