### PR TITLE
Add option to "Auto close asterisks(*) and dollars($)"

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -25,6 +25,14 @@ CodeMirror.modeURL = '../node_modules/codemirror/mode/%N/%N.js'
 const buildCMRulers = (rulers, enableRulers) =>
   (enableRulers ? rulers.map(ruler => ({ column: ruler })) : [])
 
+const buildAutoCloseBrackets = (autoCloseAsterisks) =>
+  ({
+      pairs: '()[]{}\'\'""``' + (autoCloseAsterisks ? '$$**' : ''),
+      triples: '```"""\'\'\'',
+      explode: '[]{}``$$',
+      override: true
+  })
+
 export default class CodeEditor extends React.Component {
   constructor (props) {
     super(props)
@@ -226,12 +234,7 @@ export default class CodeEditor extends React.Component {
       dragDrop: false,
       foldGutter: true,
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-      autoCloseBrackets: {
-        pairs: '()[]{}\'\'""$$**``',
-        triples: '```"""\'\'\'',
-        explode: '[]{}``$$',
-        override: true
-      },
+      autoCloseBrackets: buildAutoCloseBrackets(this.props.autoCloseAsterisks),
       extraKeys: this.defaultKeyMap
     })
 
@@ -489,6 +492,10 @@ export default class CodeEditor extends React.Component {
       } else {
         this.editor.addPanel(this.createSpellCheckPanel(), {position: 'bottom'})
       }
+    }
+
+    if (prevProps.autoCloseAsterisks !== this.props.autoCloseAsterisks) {
+      this.editor.setOption('autoCloseBrackets', buildAutoCloseBrackets(this.props.autoCloseAsterisks))
     }
 
     if (needRefresh) {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -278,6 +278,7 @@ class MarkdownEditor extends React.Component {
           onChange={(e) => this.handleChange(e)}
           onBlur={(e) => this.handleBlur(e)}
           spellCheck={config.editor.spellcheck}
+          autoCloseAsterisks={config.editor.autoCloseAsterisks}
         />
         <MarkdownPreview styleName={this.state.status === 'PREVIEW'
             ? 'preview'

--- a/browser/components/MarkdownSplitEditor.js
+++ b/browser/components/MarkdownSplitEditor.js
@@ -172,6 +172,7 @@ class MarkdownSplitEditor extends React.Component {
           onChange={this.handleOnChange.bind(this)}
           onScroll={this.handleScroll.bind(this)}
           spellCheck={config.editor.spellcheck}
+          autoCloseAsterisks={config.editor.autoCloseAsterisks}
        />
         <div styleName='slider' style={{left: this.state.codeEditorWidthInPercent + '%'}} onMouseDown={e => this.handleMouseDown(e)} >
           <div styleName='slider-hitbox' />

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -722,6 +722,7 @@ class SnippetNoteDetail extends React.Component {
             scrollPastEnd={config.editor.scrollPastEnd}
             fetchUrlTitle={config.editor.fetchUrlTitle}
             enableTableEditor={config.editor.enableTableEditor}
+            autoCloseAsterisks={config.editor.autoCloseAsterisks}
             onChange={(e) => this.handleCodeChange(index)(e)}
             ref={'code-' + index}
           />

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -52,7 +52,8 @@ export const DEFAULT_CONFIG = {
     enableTableEditor: false,
     enableFrontMatterTitle: true,
     frontMatterTitleField: 'title',
-    spellcheck: false
+    spellcheck: false,
+    autoCloseAsterisks: true
   },
   preview: {
     fontSize: '14',

--- a/browser/main/modals/PreferencesModal/SnippetEditor.js
+++ b/browser/main/modals/PreferencesModal/SnippetEditor.js
@@ -8,12 +8,20 @@ import dataApi from 'browser/main/lib/dataApi'
 const defaultEditorFontFamily = ['Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', 'monospace']
 const buildCMRulers = (rulers, enableRulers) =>
   enableRulers ? rulers.map(ruler => ({ column: ruler })) : []
+const buildAutoCloseBrackets = (autoCloseAsterisks) =>
+  ({
+      pairs: '()[]{}\'\'""``' + (autoCloseAsterisks ? '$$**' : ''),
+      triples: '```"""\'\'\'',
+      explode: '[]{}``$$',
+      override: true
+  })
 
 class SnippetEditor extends React.Component {
 
   componentDidMount () {
     this.props.onRef(this)
     const { rulers, enableRulers } = this.props
+    console.log(this.props);
     this.cm = CodeMirror(this.refs.root, {
       rulers: buildCMRulers(rulers, enableRulers),
       lineNumbers: this.props.displayLineNumbers,
@@ -27,12 +35,7 @@ class SnippetEditor extends React.Component {
       dragDrop: false,
       foldGutter: true,
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-      autoCloseBrackets: {
-        pairs: '()[]{}\'\'""$$**``',
-        triples: '```"""\'\'\'',
-        explode: '[]{}``$$',
-        override: true
-      },
+      autoCloseBrackets: buildAutoCloseBrackets(this.props.autoCloseAsterisks),
       mode: 'null'
     })
     this.cm.setSize('100%', '100%')

--- a/browser/main/modals/PreferencesModal/SnippetTab.js
+++ b/browser/main/modals/PreferencesModal/SnippetTab.js
@@ -137,6 +137,7 @@ class SnippetTab extends React.Component {
               rulers={config.editor.rulers}
               displayLineNumbers={config.editor.displayLineNumbers}
               scrollPastEnd={config.editor.scrollPastEnd}
+              autoCloseAsterisks={config.editor.autoCloseAsterisks}
               onRef={ref => { this.snippetEditor = ref }} />
           </div>
         </div>

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -96,7 +96,8 @@ class UiTab extends React.Component {
         enableTableEditor: this.refs.enableTableEditor.checked,
         enableFrontMatterTitle: this.refs.enableFrontMatterTitle.checked,
         frontMatterTitleField: this.refs.frontMatterTitleField.value,
-        spellcheck: this.refs.spellcheck.checked
+        spellcheck: this.refs.spellcheck.checked,
+        autoCloseAsterisks: this.refs.autoCloseAsterisks.checked
       },
       preview: {
         fontSize: this.refs.previewFontSize.value,
@@ -560,6 +561,16 @@ class UiTab extends React.Component {
                 type='checkbox'
               />&nbsp;
               {i18n.__('Enable spellcheck - Experimental feature!! :)')}
+            </label>
+          </div>
+          <div styleName='group-checkBoxSection'>
+            <label>
+              <input onChange={(e) => this.handleUIChange(e)}
+                checked={this.state.config.editor.autoCloseAsterisks}
+                ref='autoCloseAsterisks'
+                type='checkbox'
+              />&nbsp;
+              {i18n.__('Auto close asterisks(*) and dollars($)')}
             </label>
           </div>
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -184,5 +184,6 @@
 	"Enable live count of notes": "Enable live count of notes",
 	"Enable smart table editor": "Enable smart table editor",
 	"Snippet Default Language": "Snippet Default Language",
-  "New notes are tagged with the filtering tags": "New notes are tagged with the filtering tags"
+  "New notes are tagged with the filtering tags": "New notes are tagged with the filtering tags",
+	"Auto close asterisks(*) and dollars($)": "Auto close asterisks(*) and dollars($)"
 }


### PR DESCRIPTION
issue: https://github.com/BoostIO/Boostnote/issues/2218
<img width="687" alt="screen shot 2018-12-09 at 10 10 45 pm" src="https://user-images.githubusercontent.com/104346/49697128-5967b080-fbff-11e8-89ae-46935c2ca3bd.png">
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
1.  Add new configuration to enable/disable auto close on '*' and '$'
2. Update CodeEditor to read from the new configuration

## Issue fixed
https://github.com/BoostIO/Boostnote/issues/2218

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :radio_button: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
