### PR TITLE
show the scroll bar when the tag list is overflow

### DIFF
--- a/browser/main/Detail/TagSelect.styl
+++ b/browser/main/Detail/TagSelect.styl
@@ -4,7 +4,7 @@
   user-select none
   vertical-align middle
   width 96%
-  overflow-x scroll
+  overflow-x auto
   white-space nowrap
   margin-top 31px
   position absolute

--- a/browser/main/Detail/TagSelect.styl
+++ b/browser/main/Detail/TagSelect.styl
@@ -6,13 +6,15 @@
   width 96%
   overflow-x auto
   white-space nowrap
-  margin-top 31px
+  top 50px
   position absolute
+  &::-webkit-scrollbar
+    height 8px
 
 .tag
   display flex
   align-items center
-  margin 0px 2px
+  margin 0px 2px 2px
   padding 2px 4px
   background-color alpha($ui-tag-backgroundColor, 3%)
   border-radius 4px

--- a/browser/main/Detail/TagSelect.styl
+++ b/browser/main/Detail/TagSelect.styl
@@ -3,14 +3,11 @@
   align-items center
   user-select none
   vertical-align middle
-  width 100%
+  width 96%
   overflow-x scroll
   white-space nowrap
   margin-top 31px
   position absolute
-
-.root::-webkit-scrollbar
-  display none
 
 .tag
   display flex

--- a/browser/styles/Detail/TagSelect.styl
+++ b/browser/styles/Detail/TagSelect.styl
@@ -4,8 +4,10 @@
     border none
     background-color transparent
     outline none
-    padding 0 4px
+    padding 2px 4px
+    margin 0px 2px 2px
     font-size 13px
+    height 23px
 
   ul
     position fixed


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
When the number of tags exceed the width of the window, scroll bar is not showing.

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#2688 
<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible

## Screenshot:
![image](https://user-images.githubusercontent.com/43637878/50141866-8db82c80-02e3-11e9-9522-dff383f14305.png)

