### PR TITLE
Issue 1994 fix

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -97,6 +97,10 @@ body {
 code {
   font-family: '${codeBlockFontFamily.join("','")}';
   background-color: rgba(0,0,0,0.04);
+  color: rgba(255,0,0,1);
+}
+code[class]{
+  color:unset;
 }
 .lineNumber {
   ${lineNumber && 'display: block !important;'}


### PR DESCRIPTION
## Description

In a previous version, the single-line code block appeared with a dark font color, which made it difficult to be noticed. With this changes, the font color was changed to red without it interfering with the multi-line code block theme which is defined in the preferences menu.

![issue_1994](https://user-images.githubusercontent.com/28384943/50219434-18059c80-0387-11e9-92f8-d83cb3c6cb88.png)

## Issue fixed

The applied changes were made only in the CSS code, adding new selectors, to distinguish between the single-line and the multi-line code blocks.

## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :radio_button: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
