### PR TITLE
Two asterisks enhancement

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -211,6 +211,7 @@ export default class CodeEditor extends React.Component {
     })
 
     this.value = this.props.value
+    this.mirrorActive = this.props.value
     this.editor = CodeMirror(this.refs.root, {
       rulers: buildCMRulers(rulers, enableRulers),
       value: this.props.value,
@@ -775,7 +776,8 @@ CodeEditor.propTypes = {
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   readOnly: PropTypes.bool,
-  spellCheck: PropTypes.bool
+  spellCheck: PropTypes.bool,
+  mirrorActive: PropTypes.bool
 }
 
 CodeEditor.defaultProps = {

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -211,7 +211,15 @@ export default class CodeEditor extends React.Component {
     })
 
     this.value = this.props.value
-    this.mirrorActive = this.props.value
+    console.log(this.props.enableCodeMirror)
+    var enable = true
+    if (this.props.enableCodeMirror === 'true') {
+      enable = true
+    } else {
+      enable = false
+    }
+    console.log('editor: ')
+    console.log(enable)
     this.editor = CodeMirror(this.refs.root, {
       rulers: buildCMRulers(rulers, enableRulers),
       value: this.props.value,
@@ -231,11 +239,10 @@ export default class CodeEditor extends React.Component {
         pairs: '()[]{}\'\'""$$**``',
         triples: '```"""\'\'\'',
         explode: '[]{}``$$',
-        override: true
+        override: enable
       },
       extraKeys: this.defaultKeyMap
     })
-
     this.setMode(this.props.mode)
 
     this.editor.on('focus', this.focusHandler)
@@ -777,7 +784,7 @@ CodeEditor.propTypes = {
   onChange: PropTypes.func,
   readOnly: PropTypes.bool,
   spellCheck: PropTypes.bool,
-  mirrorActive: PropTypes.bool
+  enableCodeMirror: PropTypes.bool
 }
 
 CodeEditor.defaultProps = {

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -278,6 +278,7 @@ class MarkdownEditor extends React.Component {
           onChange={(e) => this.handleChange(e)}
           onBlur={(e) => this.handleBlur(e)}
           spellCheck={config.editor.spellcheck}
+          enableCodeMirror={config.editor.enableCodeMirror}
         />
         <MarkdownPreview styleName={this.state.status === 'PREVIEW'
             ? 'preview'

--- a/browser/components/MarkdownSplitEditor.js
+++ b/browser/components/MarkdownSplitEditor.js
@@ -172,6 +172,7 @@ class MarkdownSplitEditor extends React.Component {
           onChange={this.handleOnChange.bind(this)}
           onScroll={this.handleScroll.bind(this)}
           spellCheck={config.editor.spellcheck}
+          enableCodeMirror={config.editor.enableCodeMirror}
        />
         <div styleName='slider' style={{left: this.state.codeEditorWidthInPercent + '%'}} onMouseDown={e => this.handleMouseDown(e)} >
           <div styleName='slider-hitbox' />

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -52,7 +52,8 @@ export const DEFAULT_CONFIG = {
     enableTableEditor: false,
     enableFrontMatterTitle: true,
     frontMatterTitleField: 'title',
-    spellcheck: false
+    spellcheck: false,
+    enableCodeMirror: true
   },
   preview: {
     fontSize: '14',

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -55,6 +55,7 @@ class UiTab extends React.Component {
   handleUIChange (e) {
     const { codemirrorTheme } = this.state
     let checkHighLight = document.getElementById('checkHighLight')
+    console.log(this.refs.enableCodeMirror.value)
 
     if (checkHighLight === null) {
       checkHighLight = document.createElement('link')
@@ -96,7 +97,8 @@ class UiTab extends React.Component {
         enableTableEditor: this.refs.enableTableEditor.checked,
         enableFrontMatterTitle: this.refs.enableFrontMatterTitle.checked,
         frontMatterTitleField: this.refs.frontMatterTitleField.value,
-        spellcheck: this.refs.spellcheck.checked
+        spellcheck: this.refs.spellcheck.checked,
+        enableCodeMirror: this.refs.enableCodeMirror.value
       },
       preview: {
         fontSize: this.refs.previewFontSize.value,
@@ -434,7 +436,27 @@ class UiTab extends React.Component {
               />
             </div>
           </div>
-
+          <div styleName='group-section'>
+            <div styleName='group-section-label'>
+              {i18n.__('Double Characters [Needs Refresh] ')}
+            </div>
+            <div styleName='group-section-control'>
+              <div>
+                <select value={config.editor.enableCodeMirror}
+                  ref='enableCodeMirror'
+                  type='checkbox'
+                  onChange={(e) => this.handleUIChange(e)}
+                >
+                  <option value='true'>
+                    {i18n.__('Enable')}
+                  </option>
+                  <option value='false'>
+                    {i18n.__('Disable')}
+                  </option>
+                </select>
+              </div>
+            </div>
+          </div>
           <div styleName='group-section'>
             <div styleName='group-section-label'>
               {i18n.__('Switch to Preview')}


### PR DESCRIPTION
## Description
Fixes problem with doubling asterisks on markdown editor. Since some user may want to still have this feature, we have implemented an option on Boostnote' settings to enable/disable it.

## Issue fixed
#2218 

## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :radio_button: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
