### PR TITLE
Fixed windows debug path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
         "${workspaceFolder}/index.js"
       ],
       "windows": {
-        "runtimeExecutable": "${workspaceFolder}/node_modeules/.bin/electron.cmd"
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
       }
     },
     {


### PR DESCRIPTION
## Description
 Fixed typo that prevented debugging on windows operating systems.

## Issue fixed
 [#2726](https://github.com/BoostIO/Boostnote/issues/2726)

## Type of changes
- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :radio_button: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:
- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
