### PR TITLE
Fix Cmd+Left to go to end of line on Mac

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -177,6 +177,9 @@ export default class CodeEditor extends React.Component {
           }
         }
       },
+      'Cmd-Left': function (cm) {
+        cm.execCommand('goLineLeft')
+      },
       'Cmd-T': function (cm) {
         // Do nothing
       },


### PR DESCRIPTION
https://github.com/BoostIO/Boostnote/pull/2466