### PR TITLE
fix paste image

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -749,7 +749,13 @@ export default class CodeEditor extends React.Component {
       this.handlePasteText(editor, pastedTxt)
     } else if (fetchUrlTitle && isURL(pastedTxt) && !isInLinkTag(editor)) {
       this.handlePasteUrl(editor, pastedTxt)
-    } else if (enableSmartPaste || forceSmartPaste) {
+    } else if (attachmentManagement.isAttachmentLink(pastedTxt)) {
+      attachmentManagement
+        .handleAttachmentLinkPaste(storageKey, noteKey, pastedTxt)
+        .then(modifiedText => {
+          this.editor.replaceSelection(modifiedText)
+        })
+    } else {
       const image = clipboard.readImage()
       if (!image.isEmpty()) {
         attachmentManagement.handlePastNativeImage(
@@ -758,22 +764,16 @@ export default class CodeEditor extends React.Component {
           noteKey,
           image
         )
-      } else {
+      } else if (enableSmartPaste || forceSmartPaste) {
         const pastedHtml = clipboard.readHTML()
         if (pastedHtml.length > 0) {
           this.handlePasteHtml(editor, pastedHtml)
         } else {
           this.handlePasteText(editor, pastedTxt)
         }
+      } else {
+        this.handlePasteText(editor, pastedTxt)
       }
-    } else if (attachmentManagement.isAttachmentLink(pastedTxt)) {
-      attachmentManagement
-        .handleAttachmentLinkPaste(storageKey, noteKey, pastedTxt)
-        .then(modifiedText => {
-          this.editor.replaceSelection(modifiedText)
-        })
-    } else {
-      this.handlePasteText(editor, pastedTxt)
     }
   }
 

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -151,7 +151,7 @@ class HotkeyTab extends React.Component {
             </div>
           </div>
           <div styleName='group-section'>
-            <div styleName='group-section-label'>{i18n.__('Paste Smartly')}</div>
+            <div styleName='group-section-label'>{i18n.__('Paste HTML')}</div>
             <div styleName='group-section-control'>
               <input styleName='group-section-control-input'
                 onChange={(e) => this.handleHotkeyChange(e)}

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -561,7 +561,7 @@ class UiTab extends React.Component {
                 ref='enableSmartPaste'
                 type='checkbox'
               />&nbsp;
-              {i18n.__('Enable smart paste')}
+              {i18n.__('Enable HTML paste')}
             </label>
           </div>
 


### PR DESCRIPTION
## Description

This change fixes the editor so `Ctrl+V` or `Cmd+V` can paste an image.

## Issue fixed

- #2716
- #2719
- #2736

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
