### PR TITLE
fix issue #1995

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -559,6 +559,12 @@ export default class MarkdownPreview extends React.Component {
           .concat(defaultCodeBlockFontFamily)
       : defaultCodeBlockFontFamily
 
+    const win = global.process.platform === 'win32'
+    if (win) {
+      codeBlockFontFamily = codeBlockFontFamily.filter(item => item !== 'Consolas')
+      codeBlockFontFamily.unshift('Consolas')
+    }
+
     return {
       fontFamily,
       fontSize,


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
I fixed that code block can not render space correctly.
This bug occurred because a monospaced font was not used on Windows.
[Segoe UI](https://docs.microsoft.com/ja-jp/typography/font-list/segoe-ui) default setting on Windows is not a monospaced font.
> Fixed pitch | False

The reason for moving the definition position of [Consolas](https://docs.microsoft.com/en-us/typography/font-list/consolas) is that it is a monospaced font.
> Consolas is aimed for use in programming environments and other circumstances where a monospaced font is specified. 
> Fixed pitch | True

### Why fixed only Windows?
[Consolas](https://docs.microsoft.com/en-us/typography/font-list/consolas) is included only on Windows or Office Mac.
And I saw [the comment](https://github.com/BoostIo/Boostnote/issues/1995#issuecomment-394380082) that it did not occur on OS X.

### Before
![before](https://user-images.githubusercontent.com/11808736/50403257-79db6180-07e0-11e9-8ce9-0f5023fbe2a8.PNG)

### After
![after](https://user-images.githubusercontent.com/11808736/50403260-82339c80-07e0-11e9-84e5-c3089f395c85.PNG)

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#1995

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
