### PR TITLE
Fix feature 'saveTagsAlphabetically'

### DIFF
--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -45,8 +45,14 @@ class TagSelect extends React.Component {
     value = _.isArray(value)
       ? value.slice()
       : []
-    value.push(newTag)
-    value = _.uniq(value)
+
+    if (!_.includes(value, newTag)) {
+      value.push(newTag)
+    }
+
+    if (this.props.saveTagsAlphabetically) {
+      value = _.sortBy(value)
+    }
 
     this.setState({
       newTag: ''


### PR DESCRIPTION
## Description

`saveTagsAlphabetically` feature has been added in 8b4a9dd, but this feature removed by 4e80e1d. Both commits are in same PR #2314.
If this feature was valid, tags of a note would be saved in alphabetical order. However, in the latest version, the tags are saved in order of creation as below.

![savetagsalphabetically_off](https://user-images.githubusercontent.com/31370233/50041055-d24c8980-0091-11e9-9050-d3ede938b2eb.gif)

Now, I fix this feature and the tags are saved in alphabetical order as below.

![savetagsalphabetically_onf](https://user-images.githubusercontent.com/31370233/50041232-01182f00-0095-11e9-8336-60e059e0a0f0.gif)


## Issue fixed

- #2699 


## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
