### PR TITLE
Replace current fullscreen button of SnippetNote to FullscreenButton module

### DIFF
--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -20,6 +20,7 @@ import _ from 'lodash'
 import {findNoteTitle} from 'browser/lib/findNoteTitle'
 import convertModeName from 'browser/lib/convertModeName'
 import AwsMobileAnalyticsConfig from 'browser/main/lib/AwsMobileAnalyticsConfig'
+import FullscreenButton from './FullscreenButton'
 import TrashButton from './TrashButton'
 import RestoreButton from './RestoreButton'
 import PermanentDeleteButton from './PermanentDeleteButton'
@@ -796,11 +797,7 @@ class SnippetNoteDetail extends React.Component {
           isActive={note.isStarred}
         />
 
-        <button styleName='control-fullScreenButton' title={i18n.__('Fullscreen')}
-          onMouseDown={(e) => this.handleFullScreenButton(e)}>
-          <img styleName='iconInfo' src='../resources/icon/icon-full.svg' />
-          <span styleName='tooltip'>{i18n.__('Fullscreen')}</span>
-        </button>
+        <FullscreenButton onClick={(e) => this.handleFullScreenButton(e)} />
 
         <TrashButton onClick={(e) => this.handleTrashButtonClick(e)} />
 


### PR DESCRIPTION
## Description

For #2769.

Replace current fullscreen button of SnippetNote to [FullscreenButton](https://github.com/BoostIO/Boostnote/blob/master/browser/main/Detail/FullscreenButton.js) in reference to [MarkdownNoteDetail](https://github.com/BoostIO/Boostnote/blob/master/browser/main/Detail/MarkdownNoteDetail.js#L466).

**Before**
<img width="434" alt="2019-01-01 22 08 01" src="https://user-images.githubusercontent.com/31370233/50573650-803e8e80-0e1b-11e9-991c-1a24abbd1ea3.png">


**After**
<img width="456" alt="2019-01-01 23 15 42" src="https://user-images.githubusercontent.com/31370233/50573652-87659c80-0e1b-11e9-9b89-4710d7fb469a.png">


## Issue fixed

#2769 


## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible