### PR TITLE
typo on pt-BR.json

### DIFF
--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -33,7 +33,7 @@
 	"White": "Branco",
 	"Solarized Dark": "Escuro Solarizado",
 	"Dark": "Escuro",
-	"Show a confirmation dialog when deleting notes": "Mostrar um diálogo de confirmação ao escluir notas",
+	"Show a confirmation dialog when deleting notes": "Mostrar um diálogo de confirmação ao excluir notas",
 	"Editor Theme": "Tema do Editor",
 	"Editor Font Size": "Tamanho da Fonte do Editor",
 	"Editor Font Family": "Família da Fonte do Editor",


### PR DESCRIPTION
## Description
There was a misspelling on the word "escluir", the correct one is "excluir", as you can see on [google translate](https://translate.google.com/?source=osdd#view=home&op=translate&sl=pt&tl=en&text=excluir)

## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :radio_button: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
