### PR TITLE
Fix #2782- Feature request- ToC autoupdating functionality on header change.

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -26,6 +26,7 @@ import TurndownService from 'turndown'
 import {
   gfm
 } from 'turndown-plugin-gfm'
+import markdownTocGenerator from '../lib/markdown-toc-generator'
 
 CodeMirror.modeURL = '../node_modules/codemirror/mode/%N/%N.js'
 
@@ -738,7 +739,13 @@ export default class CodeEditor extends React.Component {
   handleChange (editor, changeObject) {
     spellcheck.handleChange(editor, changeObject)
 
-    this.updateHighlight(editor, changeObject)
+    // if the editor has a ToC, and the modified line is a header, update the ToC
+    const lineChanged = editor.getLine(changeObject.to.line) // contents of the line that was modified
+    if (lineChanged[0] === '#') { // Line changed was a markdown header
+      if (markdownTocGenerator.tocExistsInEditor(editor) === true) { // If there is already a ToC section, update it
+        markdownTocGenerator.generateInEditor(editor)
+      }
+    }
 
     this.value = editor.getValue()
     if (this.props.onChange) {
@@ -747,14 +754,14 @@ export default class CodeEditor extends React.Component {
   }
 
   incrementLines (start, linesAdded, linesRemoved, editor) {
-    let highlightedLines = editor.options.linesHighlighted
+    const highlightedLines = editor.options.linesHighlighted
 
     const totalHighlightedLines = highlightedLines.length
 
-    let offset = linesAdded - linesRemoved
+    const offset = linesAdded - linesRemoved
 
     // Store new items to be added as we're changing the lines
-    let newLines = []
+    const newLines = []
 
     let i = totalHighlightedLines
 

--- a/browser/lib/markdown-toc-generator.js
+++ b/browser/lib/markdown-toc-generator.js
@@ -25,6 +25,11 @@ function linkify (token) {
   return token
 }
 
+export function tocExistsInEditor (editor) {
+  const tocRegex = new RegExp(`${TOC_MARKER_START}[\\s\\S]*?${TOC_MARKER_END}`)
+  return tocRegex.test(editor.getValue())
+}
+
 const TOC_MARKER_START = '<!-- toc -->'
 const TOC_MARKER_END = '<!-- tocstop -->'
 
@@ -94,5 +99,6 @@ function wrapTocWithEol (toc, editor) {
 
 export default {
   generate,
-  generateInEditor
+  generateInEditor,
+  tocExistsInEditor
 }


### PR DESCRIPTION
## Description
If there is a Table of Contents and a header is changed, the ToC now autoupdates.
![demo](https://i.imgur.com/R9tWfrt.gif)

## Issue fixed
feature request #2782 

## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :radio_button:  Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button:  My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button:  I have attached a screenshot/video to visualize my change if possible
