### PR TITLE
now filters for non-existant files before trying to move them

### DIFF
--- a/browser/main/lib/dataApi/exportNote.js
+++ b/browser/main/lib/dataApi/exportNote.js
@@ -19,6 +19,7 @@ const attachmentManagement = require('./attachmentManagement')
  * @param {function} outputFormatter
  * @return {Promise.<*[]>}
  */
+
 function exportNote (nodeKey, storageKey, noteContent, targetPath, outputFormatter) {
   const storagePath = path.isAbsolute(storageKey) ? storageKey : findStorage(storageKey).path
   const exportTasks = []
@@ -29,7 +30,8 @@ function exportNote (nodeKey, storageKey, noteContent, targetPath, outputFormatt
   const attachmentsAbsolutePaths = attachmentManagement.getAbsolutePathsOfAttachmentsInContent(
     noteContent,
     storagePath
-  )
+  ).filter(path => fs.existsSync(path))
+
   attachmentsAbsolutePaths.forEach(attachment => {
     exportTasks.push({
       src: attachment,


### PR DESCRIPTION
## Description
No longer attempts to copy files that do not exist, no longer raises an exception or creates a 0 bit file in target attachments folder.

It will still repath the markdown in the exported file, maybe change?

Pre export:
![image](https://user-images.githubusercontent.com/21070668/51065857-06956600-15bc-11e9-9264-fb57517e0842.png)

Post export:
![image](https://user-images.githubusercontent.com/21070668/51065899-2e84c980-15bc-11e9-8f26-73da9bd62180.png)


## Issue fixed
fix #2793 


## Type of changes

- :radio_button:  Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button:  Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button:  My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
