### PR TITLE
Removed depreciated code by updating method used to detect second instance.

### DIFF
--- a/lib/main-app.js
+++ b/lib/main-app.js
@@ -8,7 +8,8 @@ var ipcServer = null
 
 var mainWindow = null
 
-var shouldQuit = app.makeSingleInstance(function (commandLine, workingDirectory) {
+const gotInstanceLock = app.requestSingleInstanceLock();
+app.on('second-instance', (event, commandLine, workingDirectory) => {
   if (mainWindow) {
     if (process.platform === 'win32') {
       mainWindow.minimize()
@@ -16,12 +17,9 @@ var shouldQuit = app.makeSingleInstance(function (commandLine, workingDirectory)
     }
     mainWindow.focus()
   }
-  return true
+  app.quit()
 })
 
-if (shouldQuit) {
-  app.quit()
-}
 
 var isUpdateReady = false
 

--- a/lib/main-app.js
+++ b/lib/main-app.js
@@ -8,7 +8,7 @@ var ipcServer = null
 
 var mainWindow = null
 
-app.requestSingleInstanceLock()
+const gotInstanceLock = app.requestSingleInstanceLock()
 app.on('second-instance', (event, commandLine, workingDirectory) => {
   if (mainWindow) {
     if (process.platform === 'win32') {
@@ -17,8 +17,12 @@ app.on('second-instance', (event, commandLine, workingDirectory) => {
     }
     mainWindow.focus()
   }
-  app.quit()
+  return true
 })
+
+if (!gotInstanceLock) {
+  app.quit()
+}
 
 var isUpdateReady = false
 

--- a/lib/main-app.js
+++ b/lib/main-app.js
@@ -8,7 +8,7 @@ var ipcServer = null
 
 var mainWindow = null
 
-const gotInstanceLock = app.requestSingleInstanceLock();
+app.requestSingleInstanceLock()
 app.on('second-instance', (event, commandLine, workingDirectory) => {
   if (mainWindow) {
     if (process.platform === 'win32') {
@@ -19,7 +19,6 @@ app.on('second-instance', (event, commandLine, workingDirectory) => {
   }
   app.quit()
 })
-
 
 var isUpdateReady = false
 


### PR DESCRIPTION
Updated method used to detect second instance as per https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md

Removes depreciated code, removing the warning when building Boostnote or starting it from the command line. 

Before
![image](https://user-images.githubusercontent.com/21070668/51077892-5c701980-1661-11e9-8e7d-b58291de9e7f.png)

After

![image](https://user-images.githubusercontent.com/21070668/51077901-86c1d700-1661-11e9-879d-3019f863b45b.png)

## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
