### PR TITLE
Images pasted from clipboard now work in Windows.

### DIFF
--- a/browser/main/lib/dataApi/attachmentManagement.js
+++ b/browser/main/lib/dataApi/attachmentManagement.js
@@ -249,6 +249,8 @@ function fixLocalURLS (renderedHTML, storagePath) {
  * @returns {String} Generated markdown code
  */
 function generateAttachmentMarkdown (fileName, path, showPreview) {
+  // Fix file path if windows changing backslashes for forward slashes
+  if (global.process.platform === 'win32') path = path.replace(/\\/g, '/')
   return `${showPreview ? '!' : ''}[${fileName}](${path})`
 }
 


### PR DESCRIPTION
## Description
Adjusts how image markdown tags are generated when pasting an image from clipboard on Windows.


## Issue fixed
Pasting images now works.

_Before_
![giphy.gif](https://media.giphy.com/media/5qFfs2Ad9e5JXeiChR/giphy.gif)

_After_

![giphy.gif](https://media.giphy.com/media/1AHCEVpREivcQdAJFa/giphy.gif)

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
