### PR TITLE
Removal of USB drive will no longer cause irreparable damage.

### DIFF
--- a/browser/main/lib/dataApi/init.js
+++ b/browser/main/lib/dataApi/init.js
@@ -4,6 +4,7 @@ const resolveStorageData = require('./resolveStorageData')
 const resolveStorageNotes = require('./resolveStorageNotes')
 const consts = require('browser/lib/consts')
 const path = require('path')
+const fs = require('fs')
 const CSON = require('@rokt33r/season')
 /**
  * @return {Object} all storages and notes
@@ -19,11 +20,14 @@ const CSON = require('@rokt33r/season')
  * 2. legacy
  * 3. empty directory
  */
+
 function init () {
   const fetchStorages = function () {
     let rawStorages
     try {
       rawStorages = JSON.parse(window.localStorage.getItem('storages'))
+      // Remove storages who's location is inaccesible.
+      rawStorages = rawStorages.filter(storage => fs.existsSync(storage.path))
       if (!_.isArray(rawStorages)) throw new Error('Cached data is not valid.')
     } catch (e) {
       console.warn('Failed to parse cached data from localStorage', e)

--- a/browser/main/lib/dataApi/init.js
+++ b/browser/main/lib/dataApi/init.js
@@ -40,6 +40,7 @@ function init () {
 
   const fetchNotes = function (storages) {
     const findNotesFromEachStorage = storages
+    .filter(storage => fs.existsSync(storage.path))
       .map((storage) => {
         return resolveStorageNotes(storage)
           .then((notes) => {
@@ -54,7 +55,7 @@ function init () {
                 })
               }
             })
-            if (unknownCount > 0) {
+            if (unknownCount > 0 && fs.existsSync(storage.path)) {
               CSON.writeFileSync(path.join(storage.path, 'boostnote.json'), _.pick(storage, ['folders', 'version']))
             }
             return notes

--- a/browser/main/lib/dataApi/init.js
+++ b/browser/main/lib/dataApi/init.js
@@ -55,8 +55,12 @@ function init () {
                 })
               }
             })
-            if (unknownCount > 0 && fs.existsSync(storage.path)) {
-              CSON.writeFileSync(path.join(storage.path, 'boostnote.json'), _.pick(storage, ['folders', 'version']))
+            if (unknownCount > 0) {
+              try {
+                CSON.writeFileSync(path.join(storage.path, 'boostnote.json'), _.pick(storage, ['folders', 'version']))
+              } catch (e) {
+                console.log('Error writting boostnote.json: ' + e + ' from init.js')
+              }
             }
             return notes
           })


### PR DESCRIPTION
## Description
Filters storages on init to filter out locations that not longer exist. Previously it would attempt to make a folder on whatever paths were there which would raise an exception if the drive was not connected. 

User will need to restart Boostnote with the drive reinserted to access storage, but it will show up automatically on restart.

Cause was attempting to access a folder that does not exist, and also attempting to write a boostnote.json inside if there was not one already. This behaviour is fine on a local disk but not a missing external drive. 


## Issue fixed

fix #2799
Fix #2711 


## Type of changes

- ✔️ Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- ✔️  Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- ✔️  My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- ✔️  All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
