### PR TITLE
Empty PR for issue #2635

### DIFF
--- a/lib/main-app.js
+++ b/lib/main-app.js
@@ -97,7 +97,7 @@ app.on('ready', function () {
     checkUpdate()
   }, 1000 * 60 * 60 * 24)
 
-  // Check update after 10 secs to prevent file locking of Windows
+  // Check update after 10 secs to prevent file locking of Windows.
   setTimeout(() => {
     checkUpdate()
 


### PR DESCRIPTION
This PR only exists for fulfilling/playing around with issuehunt
Issue #2635 was fixed with the following instructions, also posted here for future reference. 
User has confirmed that this fixed their issue.

---

This issue is caused by you having installed node through AUR and is an issue with the package manager. Your node install is in /usr/bin which requires elevated privileges on  Arch/Manjaro. Many installers, such as n, install to this location as on most OSes it is not an issue. You need to have your Node install in ~/

Here is how to resolve it.

_remove node_
```
npm --global remove  npm
```

_install nvm and use it to install npm_
```
yay -S nvm
echo 'source /usr/share/nvm/init-nvm.sh' >> ~/.bashrc
exec $SHELL
nvm ls-remote
nvm install 9
```
confirm installation
```
node -v #should be 9+
npm -v #should be 5+
```
install yarn globally and Boostnote
```
npm install -g yarn
echo 'export PATH=$PATH:~/.yarn/bin' >> ~/.bashrc
yay -S boostnote
```
This solution has been tested on a Manjaro 18 virtual machine.

There will not be anything that can be done to correct this issue from this end as it is an issue with the package manager.