### PR TITLE
Move boostnote to main display if on a connected display

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -5,6 +5,7 @@ const path = require('path')
 const Config = require('electron-config')
 const config = new Config()
 const _ = require('lodash')
+const screen = electron.screen
 
 const windowSize = config.get('windowsize') || {
   x: null,
@@ -80,6 +81,21 @@ function storeWindowSize () {
 app.on('activate', function () {
   if (mainWindow == null) return null
   mainWindow.show()
+})
+
+// Event triggers when display is disconnected. If window is on the disconnected display, move it to main display
+screen.on('display-removed', function (e) {
+  const bounds = mainWindow.getBounds()
+  const whichScreen = electron.screen.getDisplayNearestPoint({x: bounds.x, y: bounds.y})
+  const id = whichScreen.id
+  const displays = electron.screen.getAllDisplays()
+  if (displays.findIndex(display => display.id === id) === -1) { // window was on the removed display
+    mainWindow.x = 0
+    mainWindow.y = 0
+    mainWindow.width = 500
+    mainWindow.height = 320
+  }
+  console.log('Boostnote moved to main display due to being on removed display. See main-window.js')
 })
 
 module.exports = mainWindow


### PR DESCRIPTION

## Description
If a display is disconnected, and Boostnote is on that display, it now moves it to the main display with sensible defaults.
## Issue fixed
fix #2804 

This has been tested by having Boostnote on a display and disconnecting it. It moves to the primary display as anticipated.

## Type of changes

- ✔️  (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- ✔️  My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- ✔️  All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
