### PR TITLE
Added cheatsheets to menu

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -383,6 +383,27 @@ const help = {
     {
       label: 'Changelog',
       click () { shell.openExternal('https://github.com/BoostIO/boost-releases') }
+    },
+    {
+      label: 'Cheatsheets',
+      submenu: [
+        {
+          label: 'Markdown',
+          click () { shell.openExternal('https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet') }
+        },
+        {
+          label: 'Latex',
+          click () { shell.openExternal('https://katex.org/docs/supported.html') }
+        },
+        {
+          label: 'HTML',
+          click () { shell.openExternal('https://htmlcheatsheet.com/') }
+        },
+        {
+          label: 'Boostnote',
+          click () { shell.openExternal('https://github.com/TobseF/boostnote-markdown-cheatsheet/blob/master/BOOSTNOTE_MARKDOWN_CHEAT_SHEET.md') }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds an option under the Help menu to open various syntax cheatsheets in a browser window. 
![image](https://user-images.githubusercontent.com/21070668/51286845-96b32100-19a9-11e9-8def-9458ad9f776f.png)



- ✔️  Improvement (Change that improves the code. Maybe performance or development improvement)
-✔️ Feature (Change that adds new functionality)

## Checklist:

- ✔️ My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
-✔️ All existing tests have been passed
-✔️ I have attached a screenshot/video to visualize my change if possible
