### PR TITLE
updated snippettab to use componentDidUpdate instead of componentWillUpdate

### DIFF
--- a/browser/components/SnippetTab.js
+++ b/browser/components/SnippetTab.js
@@ -14,11 +14,9 @@ class SnippetTab extends React.Component {
     }
   }
 
-  componentWillUpdate (nextProps) {
-    if (nextProps.snippet.name !== this.props.snippet.name) {
-      this.setState({
-        name: nextProps.snippet.name
-      })
+  componentDidUpdate (prevProps, prevState) {
+    if (this.state.snippet.name !== prevState.snippet.name) {
+      this.props.onChange(this.state.snippet.name)
     }
   }
 


### PR DESCRIPTION
Follwing the official React guide
 https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

Converted depreciated componentWillUpdate to componentDidUpdate.

Removes ESlint warning and prepares for forward compatibility.

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- ✔️  Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- ✔️  My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- ✔️  All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
