### PR TITLE
fix #2816 Application window bigger after every restart

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -18,7 +18,6 @@ const mainWindow = new BrowserWindow({
   y: windowSize.y,
   width: windowSize.width,
   height: windowSize.height,
-  useContentSize: true,
   minWidth: 500,
   minHeight: 320,
   webPreferences: {


### PR DESCRIPTION
Removed option in new BrowserWindow:

useContentSize Boolean (optional) - The width and height would be used as web page's size, which means the actual window's size will include window frame's size and be slightly larger. Default is false.

Which was set to true.

Boostnote now opens to the same size as previous isntead of slightly larger each time. 


## Issue fixed
fix #2816 

## Type of changes
 
- ✔️ Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- ✔️ My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- ✔️ All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
