### PR TITLE
Fix context menu / note selection bug

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -527,6 +527,7 @@ class NoteList extends React.Component {
   }
 
   handleNoteContextMenu (e, uniqueKey) {
+    this.setState({ ctrlKeyDown: false })
     const { location } = this.props
     const { selectedNoteKeys } = this.state
     const note = findNoteByKey(this.notes, uniqueKey)


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description

This PR fixes the following bug:

When right-clicking a note, the ctrl key flag is enabled. Upon exiting the context menu, the ctrl key flag is not disabled, however. As a result, as you select other notes, the number of selected notes only continues to grow.

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- ✅  Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- ✅ My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- ✅  All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
