### PR TITLE
[Fix] Cloning a note will now clone more note properties

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -716,7 +716,11 @@ class NoteList extends React.Component {
         folder: folder.key,
         title: firstNote.title + ' ' + i18n.__('copy'),
         content: firstNote.content,
-        linesHighlighted: firstNote.linesHighlighted
+        linesHighlighted: firstNote.linesHighlighted,
+        description: firstNote.description,
+        snippets: firstNote.snippets,
+        tags: firstNote.tags,
+        isStarred: firstNote.isStarred
       })
       .then((note) => {
         attachmentManagement.cloneAttachments(firstNote, note)


### PR DESCRIPTION
## Description
Cloning a note will now copy the missing following note properties to the new note
* `description`
* `snippets`
* `tags`
* `isStarred`

I'm adding the properties tags and `isStarred` also to this PR because I'm sure after clone a note with tag they should also be on the new note.

## Issue fixed
#2859 Cloning of snippets doesn't work (win 10)

## Type of changes

- :large_blue_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :large_blue_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :large_blue_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
