### PR TITLE
fix newNoteModal create note twice after double click quickly

### DIFF
--- a/browser/main/modals/NewNoteModal.js
+++ b/browser/main/modals/NewNoteModal.js
@@ -8,7 +8,7 @@ import { createMarkdownNote, createSnippetNote } from 'browser/lib/newNote'
 class NewNoteModal extends React.Component {
   constructor (props) {
     super(props)
-
+    this.lock = false
     this.state = {}
   }
 
@@ -22,9 +22,12 @@ class NewNoteModal extends React.Component {
 
   handleMarkdownNoteButtonClick (e) {
     const { storage, folder, dispatch, location, params, config } = this.props
-    createMarkdownNote(storage, folder, dispatch, location, params, config).then(() => {
-      setTimeout(this.props.close, 200)
-    })
+    if (!this.lock) {
+      this.lock = true
+      createMarkdownNote(storage, folder, dispatch, location, params, config).then(() => {
+        setTimeout(this.props.close, 200)
+      })
+    }
   }
 
   handleMarkdownNoteButtonKeyDown (e) {
@@ -36,9 +39,12 @@ class NewNoteModal extends React.Component {
 
   handleSnippetNoteButtonClick (e) {
     const { storage, folder, dispatch, location, params, config } = this.props
-    createSnippetNote(storage, folder, dispatch, location, params, config).then(() => {
-      setTimeout(this.props.close, 200)
-    })
+    if (!this.lock) {
+      this.lock = true
+      createSnippetNote(storage, folder, dispatch, location, params, config).then(() => {
+        setTimeout(this.props.close, 200)
+      })
+    }
   }
 
   handleSnippetNoteButtonKeyDown (e) {


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->

add a lock sign to fix create new note twice when you click Button again before NewNoteModel was closed.

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
