### PR TITLE
Multiple minor changes at the preferences tabs

### DIFF
--- a/browser/main/modals/PreferencesModal/ConfigTab.styl
+++ b/browser/main/modals/PreferencesModal/ConfigTab.styl
@@ -156,10 +156,12 @@ body[data-theme="dark"]
     color $ui-dark-text-color
 
   .group-header
+  .group-header--sub
     color $ui-dark-text-color
     border-color $ui-dark-borderColor
 
   .group-header2
+  .group-header2--sub
     color $ui-dark-text-color
 
   .group-section-control-input
@@ -184,10 +186,12 @@ body[data-theme="solarized-dark"]
     color $ui-solarized-dark-text-color
 
   .group-header
+  .group-header--sub
     color $ui-solarized-dark-text-color
     border-color $ui-solarized-dark-borderColor
 
   .group-header2
+  .group-header2--sub
     color $ui-solarized-dark-text-color
 
   .group-section-control-input
@@ -211,10 +215,12 @@ body[data-theme="monokai"]
     color $ui-monokai-text-color
 
   .group-header
+  .group-header--sub
     color $ui-monokai-text-color
     border-color $ui-monokai-borderColor
 
   .group-header2
+  .group-header2--sub
     color $ui-monokai-text-color
 
   .group-section-control-input
@@ -238,10 +244,12 @@ body[data-theme="dracula"]
     color $ui-dracula-text-color
 
   .group-header
+  .group-header--sub
     color $ui-dracula-text-color
     border-color $ui-dracula-borderColor
 
   .group-header2
+  .group-header2--sub
     color $ui-dracula-text-color
 
   .group-section-control-input

--- a/browser/main/modals/PreferencesModal/ConfigTab.styl
+++ b/browser/main/modals/PreferencesModal/ConfigTab.styl
@@ -18,6 +18,14 @@
   margin-bottom 15px
   margin-top 30px
 
+.group-header--sub
+  @extend .group-header
+  margin-bottom 10px
+
+.group-header2--sub
+  @extend .group-header2
+  margin-bottom 10px
+
 .group-section
   margin-bottom 20px
   display flex

--- a/browser/main/modals/PreferencesModal/Crowdfunding.js
+++ b/browser/main/modals/PreferencesModal/Crowdfunding.js
@@ -27,11 +27,11 @@ class Crowdfunding extends React.Component {
         <br />
         <p>{i18n.__('We launched IssueHunt which is an issue-based crowdfunding / sourcing platform for open source projects.')}</p>
         <p>{i18n.__('Anyone can put a bounty on not only a bug but also on OSS feature requests listed on IssueHunt. Collected funds will be distributed to project owners and contributors.')}</p>
-        <div styleName='group-header2--sub'>{i18n.__('### Sustainable Open Source Ecosystem')}</div>
+        <div styleName='group-header2--sub'>{i18n.__('Sustainable Open Source Ecosystem')}</div>
         <p>{i18n.__('We discussed about open-source ecosystem and IssueHunt concept with the Boostnote team repeatedly. We actually also discussed with Matz who father of Ruby.')}</p>
         <p>{i18n.__('The original reason why we made IssueHunt was to reward our contributors of Boostnote project. We’ve got tons of Github stars and hundred of contributors in two years.')}</p>
         <p>{i18n.__('We thought that it will be nice if we can pay reward for our contributors.')}</p>
-        <div styleName='group-header2--sub'>{i18n.__('### We believe Meritocracy')}</div>
+        <div styleName='group-header2--sub'>{i18n.__('We believe Meritocracy')}</div>
         <p>{i18n.__('We think developers who have skills and do great things must be rewarded properly.')}</p>
         <p>{i18n.__('OSS projects are used in everywhere on the internet, but no matter how they great, most of owners of those projects need to have another job to sustain their living.')}</p>
         <p>{i18n.__('It sometimes looks like exploitation.')}</p>

--- a/browser/main/modals/PreferencesModal/Crowdfunding.js
+++ b/browser/main/modals/PreferencesModal/Crowdfunding.js
@@ -22,18 +22,16 @@ class Crowdfunding extends React.Component {
   render () {
     return (
       <div styleName='root'>
-        <div styleName='header'>{i18n.__('Crowdfunding')}</div>
+        <div styleName='group-header'>{i18n.__('Crowdfunding')}</div>
         <p>{i18n.__('Thank you for using Boostnote!')}</p>
         <br />
         <p>{i18n.__('We launched IssueHunt which is an issue-based crowdfunding / sourcing platform for open source projects.')}</p>
         <p>{i18n.__('Anyone can put a bounty on not only a bug but also on OSS feature requests listed on IssueHunt. Collected funds will be distributed to project owners and contributors.')}</p>
-        <br />
-        <p>{i18n.__('### Sustainable Open Source Ecosystem')}</p>
+        <div styleName='group-header2--sub'>{i18n.__('### Sustainable Open Source Ecosystem')}</div>
         <p>{i18n.__('We discussed about open-source ecosystem and IssueHunt concept with the Boostnote team repeatedly. We actually also discussed with Matz who father of Ruby.')}</p>
         <p>{i18n.__('The original reason why we made IssueHunt was to reward our contributors of Boostnote project. We’ve got tons of Github stars and hundred of contributors in two years.')}</p>
         <p>{i18n.__('We thought that it will be nice if we can pay reward for our contributors.')}</p>
-        <br />
-        <p>{i18n.__('### We believe Meritocracy')}</p>
+        <div styleName='group-header2--sub'>{i18n.__('### We believe Meritocracy')}</div>
         <p>{i18n.__('We think developers who have skills and do great things must be rewarded properly.')}</p>
         <p>{i18n.__('OSS projects are used in everywhere on the internet, but no matter how they great, most of owners of those projects need to have another job to sustain their living.')}</p>
         <p>{i18n.__('It sometimes looks like exploitation.')}</p>

--- a/browser/main/modals/PreferencesModal/Crowdfunding.styl
+++ b/browser/main/modals/PreferencesModal/Crowdfunding.styl
@@ -1,14 +1,8 @@
-@import('./Tab')
+@import('./ConfigTab')
 
-.root
-  padding 15px
-  white-space pre
-  line-height 1.4
-  color alpha($ui-text-color, 90%)
-  width 100%
-  font-size 14px
 p
   font-size 16px
+  line-height 1.4
 
 .cf-link
   height 35px

--- a/browser/main/modals/PreferencesModal/InfoTab.js
+++ b/browser/main/modals/PreferencesModal/InfoTab.js
@@ -69,8 +69,7 @@ class InfoTab extends React.Component {
   render () {
     return (
       <div styleName='root'>
-
-        <div styleName='header--sub'>{i18n.__('Community')}</div>
+        <div styleName='group-header'>{i18n.__('Community')}</div>
         <div styleName='top'>
           <ul styleName='list'>
             <li>
@@ -108,7 +107,7 @@ class InfoTab extends React.Component {
 
         <hr />
 
-        <div styleName='header--sub'>{i18n.__('About')}</div>
+        <div styleName='group-header--sub'>{i18n.__('About')}</div>
 
         <div styleName='top'>
           <div styleName='icon-space'>
@@ -143,7 +142,7 @@ class InfoTab extends React.Component {
 
         <hr styleName='separate-line' />
 
-        <div styleName='policy'>{i18n.__('Analytics')}</div>
+        <div styleName='group-header2--sub'>{i18n.__('Analytics')}</div>
         <div>{i18n.__('Boostnote collects anonymous data for the sole purpose of improving the application, and strictly does not collect any personal information such the contents of your notes.')}</div>
         <div>{i18n.__('You can see how it works on ')}<a href='https://github.com/BoostIO/Boostnote' onClick={(e) => this.handleLinkClick(e)}>GitHub</a>.</div>
         <br />

--- a/browser/main/modals/PreferencesModal/InfoTab.styl
+++ b/browser/main/modals/PreferencesModal/InfoTab.styl
@@ -35,11 +35,23 @@
 
 .policy-submit
   margin-top 10px
+  height 35px
+  border-radius 2px
+  border none
+  background-color alpha(#1EC38B, 90%)
+  padding-left 20px
+  padding-right 20px
+  text-decoration none
+  color white
+  font-weight 600
+  font-size 16px
+  &:hover
+    background-color #1EC38B
+    transition 0.2s
 
 .policy-confirm
   margin-top 10px
   font-size 12px
-
 
 body[data-theme="dark"]
   .root

--- a/browser/main/modals/PreferencesModal/InfoTab.styl
+++ b/browser/main/modals/PreferencesModal/InfoTab.styl
@@ -40,13 +40,17 @@
   margin-top 10px
   font-size 12px
 
+
 body[data-theme="dark"]
   .root
     color alpha($tab--dark-text-color, 80%)
-
+  .appId
+    color $ui-dark-text-color
 
 body[data-theme="solarized-dark"]
   .root
+    color $ui-solarized-dark-text-color
+  .appId
     color $ui-solarized-dark-text-color
 .list
   a
@@ -55,12 +59,16 @@ body[data-theme="solarized-dark"]
 body[data-theme="monokai"]
   .root
     color $ui-monokai-text-color
+  .appId
+    color $ui-monokai-text-color
 .list
   a
     color $ui-monokai-active-color
 
 body[data-theme="dracula"]
   .root
+    color $ui-dracula-text-color
+  .appId
     color $ui-dracula-text-color
 .list
   a

--- a/browser/main/modals/PreferencesModal/InfoTab.styl
+++ b/browser/main/modals/PreferencesModal/InfoTab.styl
@@ -1,16 +1,4 @@
-@import('./Tab')
-
-.root
-  padding 15px
-  white-space pre
-  line-height 1.4
-  color alpha($ui-text-color, 90%)
-  width 100%
-  font-size 14px
-
-.top
-  text-align left
-  margin-bottom 20px
+@import('./ConfigTab.styl')
 
 .icon-space
   margin 20px 0
@@ -44,11 +32,6 @@
 
 .separate-line
   margin 40px 0
-
-.policy
-  width 100%
-  font-size 20px
-  margin-bottom 10px
 
 .policy-submit
   margin-top 10px

--- a/browser/main/modals/PreferencesModal/SnippetTab.js
+++ b/browser/main/modals/PreferencesModal/SnippetTab.js
@@ -91,7 +91,7 @@ class SnippetTab extends React.Component {
     if (!(editorFontSize > 0 && editorFontSize < 132)) editorIndentSize = 4
     return (
       <div styleName='root'>
-        <div styleName='header'>{i18n.__('Snippets')}</div>
+        <div styleName='group-header'>{i18n.__('Snippets')}</div>
         <SnippetList
           onSnippetSelect={this.handleSnippetSelect.bind(this)}
           onSnippetDeleted={this.handleDeleteSnippet.bind(this)}

--- a/browser/main/modals/PreferencesModal/SnippetTab.styl
+++ b/browser/main/modals/PreferencesModal/SnippetTab.styl
@@ -1,13 +1,4 @@
-@import('./Tab')
 @import('./ConfigTab')
-
-.root
-  padding 15px
-  white-space pre
-  line-height 1.4
-  color alpha($ui-text-color, 90%)
-  width 100%
-  font-size 14px
 
 .group
   margin-bottom 45px
@@ -127,7 +118,7 @@
     background darken(#f5f5f5, 5)
 
 .snippet-detail
-  width 70%
+  width calc(100% - 33%)
   height calc(100% - 200px)
   position absolute
   left 33%

--- a/browser/main/modals/PreferencesModal/SnippetTab.styl
+++ b/browser/main/modals/PreferencesModal/SnippetTab.styl
@@ -118,7 +118,7 @@
     background darken(#f5f5f5, 5)
 
 .snippet-detail
-  width calc(100% - 33%)
+  width 67%
   height calc(100% - 200px)
   position absolute
   left 33%

--- a/browser/main/modals/PreferencesModal/StoragesTab.styl
+++ b/browser/main/modals/PreferencesModal/StoragesTab.styl
@@ -1,8 +1,4 @@
-@import('./Tab')
-
-.root
-  padding 15px
-  color $ui-text-color
+@import('./ConfigTab')
 
 .list
   margin-bottom 15px


### PR DESCRIPTION
## Issue fixed

- This pull request will adjust all first headlines in all preferences tabs.
- At the Crowdfunding tab, the paragraph headlines are now real headlines (not only text with `###`)
- The snippet editor has now the right width of 100% (before 103%)

## Type of changes

- :large_blue_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :large_blue_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
