### PR TITLE
After select an other note now scroll to top

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -907,6 +907,8 @@ export default class MarkdownPreview extends React.Component {
         document.body.appendChild(overlay)
       }
     }
+
+    this.getWindow().scrollTo(0, 0)
   }
 
   focus () {


### PR DESCRIPTION
## Issue fixed
After change the current note to an other note, scrolling to the top of the new selected note. Now thats the same behavior as it implemented at the markdown split editor.

## Type of changes

- :large_blue_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :large_blue_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
