### PR TITLE
Replace invalid regex for storage placeholder the export functions

### DIFF
--- a/browser/main/lib/dataApi/attachmentManagement.js
+++ b/browser/main/lib/dataApi/attachmentManagement.js
@@ -490,7 +490,7 @@ function replaceNoteKeyWithNewNoteKey (noteContent, oldNoteKey, newNoteKey) {
  * @returns {String} Input without the references
  */
 function removeStorageAndNoteReferences (input, noteKey) {
-  return input.replace(new RegExp('/?' + STORAGE_FOLDER_PLACEHOLDER + '.*?\\)', 'g'), function (match) {
+  return input.replace(new RegExp('/?' + STORAGE_FOLDER_PLACEHOLDER + '.*?("|\\))', 'g'), function (match) {
     const storagePath = match
       .replace(new RegExp(mdurl.encode(path.win32.sep), 'g'), path.sep)
       .replace(new RegExp(mdurl.encode(path.posix.sep), 'g'), path.sep)

--- a/browser/main/lib/dataApi/attachmentManagement.js
+++ b/browser/main/lib/dataApi/attachmentManagement.js
@@ -490,13 +490,13 @@ function replaceNoteKeyWithNewNoteKey (noteContent, oldNoteKey, newNoteKey) {
  * @returns {String} Input without the references
  */
 function removeStorageAndNoteReferences (input, noteKey) {
-  return input.replace(new RegExp('/?' + STORAGE_FOLDER_PLACEHOLDER + '.*?("|])', 'g'), function (match) {
-    const temp = match
+  return input.replace(new RegExp('/?' + STORAGE_FOLDER_PLACEHOLDER + '.*?\\)', 'g'), function (match) {
+    const storagePath = match
       .replace(new RegExp(mdurl.encode(path.win32.sep), 'g'), path.sep)
       .replace(new RegExp(mdurl.encode(path.posix.sep), 'g'), path.sep)
       .replace(new RegExp(escapeStringRegexp(path.win32.sep), 'g'), path.sep)
       .replace(new RegExp(escapeStringRegexp(path.posix.sep), 'g'), path.sep)
-    return temp.replace(new RegExp(STORAGE_FOLDER_PLACEHOLDER + '(' + escapeStringRegexp(path.sep) + noteKey + ')?', 'g'), DESTINATION_FOLDER)
+    return storagePath.replace(new RegExp(STORAGE_FOLDER_PLACEHOLDER + escapeStringRegexp(path.sep) + noteKey, 'g'), DESTINATION_FOLDER)
   })
 }
 

--- a/tests/dataApi/attachmentManagement.test.js
+++ b/tests/dataApi/attachmentManagement.test.js
@@ -462,13 +462,12 @@ it('should make sure that "removeStorageAndNoteReferences" works with markdown c
   const noteKey = 'noteKey'
   const testInput =
     'Test input' +
-    '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + noteKey + path.win32.sep + 'image.jpg](imageName}) \n' +
-    '[' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + noteKey + path.posix.sep + 'pdf.pdf](pdf})'
-
+    '![imageName}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + noteKey + path.win32.sep + 'image.jpg) \n' +
+    '[pdf}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + noteKey + path.posix.sep + 'pdf.pdf)'
   const expectedOutput =
     'Test input' +
-    '![' + systemUnderTest.DESTINATION_FOLDER + path.sep + 'image.jpg](imageName}) \n' +
-    '[' + systemUnderTest.DESTINATION_FOLDER + path.sep + 'pdf.pdf](pdf})'
+    '![imageName}](' + systemUnderTest.DESTINATION_FOLDER + path.sep + 'image.jpg) \n' +
+    '[pdf}](' + systemUnderTest.DESTINATION_FOLDER + path.sep + 'pdf.pdf)'
   const actual = systemUnderTest.removeStorageAndNoteReferences(testInput, noteKey)
   expect(actual).toEqual(expectedOutput)
 })

--- a/tests/dataApi/attachmentManagement.test.js
+++ b/tests/dataApi/attachmentManagement.test.js
@@ -48,7 +48,7 @@ it('should test that copyAttachment works correctly assuming correct working of 
   const dummyExtension = '.ext'
   const sourcePath = 'path' + dummyExtension
   const storageKey = 'storageKey'
-  const noteKey = 'noteKey'
+  const noteKey = 'abc234-8266-49b9-b438-084003c2e723'
   const dummyUniquePath = 'dummyPath'
   const dummyStorage = {path: 'dummyStoragePath'}
   const dummyReadStream = {}
@@ -77,7 +77,7 @@ it('should test that copyAttachment works correctly assuming correct working of 
 
 it('should test that copyAttachment creates a new folder if the attachment folder doesn\'t exist', function () {
   const dummyStorage = {path: 'dummyStoragePath'}
-  const noteKey = 'noteKey'
+  const noteKey = 'abc234-8266-49b9-b438-084003c2e723'
   const attachmentFolderPath = path.join(dummyStorage.path, systemUnderTest.DESTINATION_FOLDER)
   const attachmentFolderNoteKyPath = path.join(dummyStorage.path, systemUnderTest.DESTINATION_FOLDER, noteKey)
   const dummyReadStream = {}
@@ -95,7 +95,7 @@ it('should test that copyAttachment creates a new folder if the attachment folde
   findStorage.findStorage.mockReturnValue(dummyStorage)
   uniqueSlug.mockReturnValue('dummyPath')
 
-  return systemUnderTest.copyAttachment('path', 'storageKey', 'noteKey').then(
+  return systemUnderTest.copyAttachment('path', 'storageKey', noteKey).then(
     function () {
       expect(fs.existsSync).toHaveBeenCalledWith(attachmentFolderPath)
       expect(fs.mkdirSync).toHaveBeenCalledWith(attachmentFolderPath)
@@ -372,7 +372,7 @@ it('should test that migrateAttachments work when they have different path separ
   const dummyStoragePath = 'dummyStoragePath'
   const imagesPath = path.join(dummyStoragePath, 'images')
   const attachmentsPath = path.join(dummyStoragePath, 'attachments')
-  const noteKey = 'noteKey'
+  const noteKey = 'abc234-8266-49b9-b438-084003c2e723'
   const testInput = '"# Test\n' +
   '\n' +
   '![Screenshot1](:storage' + path.win32.sep + '0.3b88d0dc.png)\n' +
@@ -417,7 +417,7 @@ it('should test that getAbsolutePathsOfAttachmentsInContent returns all absolute
 
 it('should remove the all ":storage" and noteKey references', function () {
   const storageFolder = systemUnderTest.DESTINATION_FOLDER
-  const noteKey = 'noteKey'
+  const noteKey = 'abc234-8266-49b9-b438-084003c2e723'
   const testInput =
     '<html>\n' +
     '    <head>\n' +
@@ -459,11 +459,12 @@ it('should remove the all ":storage" and noteKey references', function () {
 })
 
 it('should make sure that "removeStorageAndNoteReferences" works with markdown content as well', function () {
-  const noteKey = 'noteKey'
+  const noteKey = 'abc234-8266-49b9-b438-084003c2e723'
   const testInput =
     'Test input' +
     '![imageName}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + noteKey + path.win32.sep + 'image.jpg) \n' +
     '[pdf}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + noteKey + path.posix.sep + 'pdf.pdf)'
+
   const expectedOutput =
     'Test input' +
     '![imageName}](' + systemUnderTest.DESTINATION_FOLDER + path.sep + 'image.jpg) \n' +
@@ -475,7 +476,7 @@ it('should make sure that "removeStorageAndNoteReferences" works with markdown c
 it('should delete the correct attachment folder if a note is deleted', function () {
   const dummyStorage = {path: 'dummyStoragePath'}
   const storageKey = 'storageKey'
-  const noteKey = 'noteKey'
+  const noteKey = 'abc234-8266-49b9-b438-084003c2e723'
   findStorage.findStorage = jest.fn(() => dummyStorage)
   sander.rimrafSync = jest.fn()
 
@@ -487,7 +488,7 @@ it('should delete the correct attachment folder if a note is deleted', function 
 
 it('should test that deleteAttachmentsNotPresentInNote deletes all unreferenced attachments ', function () {
   const dummyStorage = {path: 'dummyStoragePath'}
-  const noteKey = 'noteKey'
+  const noteKey = 'abc234-8266-49b9-b438-084003c2e723'
   const storageKey = 'storageKey'
   const markdownContent = ''
   const dummyFilesInFolder = ['file1.txt', 'file2.pdf', 'file3.jpg']
@@ -614,12 +615,12 @@ it('should test that moveAttachments returns a correct modified content version'
   const newNoteKey = 'newNoteKey'
   const testInput =
     'Test input' +
-    '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNoteKey + path.win32.sep + 'image.jpg](imageName}) \n' +
-    '[' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + oldNoteKey + path.posix.sep + 'pdf.pdf](pdf})'
+    '![image}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNoteKey + path.win32.sep + 'image.jpg) \n' +
+    '[pdf}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + oldNoteKey + path.posix.sep + 'pdf.pdf)'
   const expectedOutput =
     'Test input' +
-    '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNoteKey + path.sep + 'image.jpg](imageName}) \n' +
-    '[' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNoteKey + path.sep + 'pdf.pdf](pdf})'
+    '![image}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNoteKey + path.sep + 'image.jpg) \n' +
+    '[pdf}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNoteKey + path.sep + 'pdf.pdf)'
 
   const actualContent = systemUnderTest.moveAttachments(oldPath, newPath, oldNoteKey, newNoteKey, testInput)
   expect(actualContent).toBe(expectedOutput)
@@ -630,16 +631,16 @@ it('should test that cloneAttachments modifies the content of the new note corre
   const newNote = {key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKey', type: 'MARKDOWN_NOTE'}
   const testInput =
     'Test input' +
-    '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNote.key + path.win32.sep + 'image.jpg](imageName}) \n' +
-    '[' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + oldNote.key + path.posix.sep + 'pdf.pdf](pdf})'
+    '![image}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNote.key + path.win32.sep + 'image.jpg) \n' +
+    '[pdf}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + oldNote.key + path.posix.sep + 'pdf.pdf)'
   newNote.content = testInput
   findStorage.findStorage = jest.fn()
   findStorage.findStorage.mockReturnValue({path: 'dummyStoragePath'})
 
   const expectedOutput =
     'Test input' +
-    '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNote.key + path.sep + 'image.jpg](imageName}) \n' +
-    '[' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNote.key + path.sep + 'pdf.pdf](pdf})'
+    '![image}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNote.key + path.sep + 'image.jpg) \n' +
+    '[pdf}](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.sep + newNote.key + path.sep + 'pdf.pdf)'
   systemUnderTest.cloneAttachments(oldNote, newNote)
 
   expect(newNote.content).toBe(expectedOutput)
@@ -654,8 +655,8 @@ it('should test that cloneAttachments finds all attachments and copies them to t
   const newNote = {key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKeyNewNote', type: 'MARKDOWN_NOTE'}
   const testInput =
     'Test input' +
-    '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNote.key + path.win32.sep + 'image.jpg](imageName}) \n' +
-    '[' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + oldNote.key + path.posix.sep + 'pdf.pdf](pdf})'
+    '![image](' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNote.key + path.win32.sep + 'image.jpg) \n' +
+    '[pdf' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + oldNote.key + path.posix.sep + 'pdf.pdf)'
   oldNote.content = testInput
   newNote.content = testInput
 


### PR DESCRIPTION
This pull request will fix the issue #2884. The match to `("|])` doesn't make sense for me. The or match `]` should match `)`. I also removed the group match at the replacement with `DESTINATION_FOLDER`. The group is not needed.

## Issue fixed
Fix wrong test
#2884

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :large_blue_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :large_blue_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :large_blue_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
