### PR TITLE
Initialize storage ignores now tags from skipped notes

### DIFF
--- a/browser/main/store.js
+++ b/browser/main/store.js
@@ -44,7 +44,9 @@ function data (state = defaultDataMap(), action) {
         const folderNoteSet = getOrInitItem(state.folderNoteMap, folderKey)
         folderNoteSet.add(uniqueKey)
 
-        assignToTags(note.tags, state, uniqueKey)
+        if (!note.isTrashed) {
+          assignToTags(note.tags, state, uniqueKey)
+        }
       })
       return state
     case 'UPDATE_NOTE':


### PR DESCRIPTION
## Description
I also can only reproduce the issue #2836 that on startup all tags are listed. I've changed the behavior that only tags from notes which are not trashed will be listed.

## Issue fixed
#2836 

## Type of changes

- :large_blue_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :large_blue_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :large_blue_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
