### PR TITLE
README: removed mobile app mention (#2828)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 ![Boostnote app screenshot](./resources/repository/top.png)
 
 <h4 align="center">Note-taking app for programmers. </h4>
-<h5 align="center">Apps available for Mac, Windows, Linux, Android, and iOS.</h5>
+<h5 align="center">Apps available for Mac, Windows and Linux.</h5>
 <h5 align="center">Built with Electron, React + Redux, Webpack, and CSSModules.</h5>
 <p align="center">
   <a href="https://travis-ci.org/BoostIO/Boostnote">


### PR DESCRIPTION
## Description

removed mobile app mention in the README

## Issue fixed

#2828

## Type of changes

- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)
