### PR TITLE
Fetch page title when paste valid markdown title with one valid URL

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -808,7 +808,7 @@ export default class CodeEditor extends React.Component {
     }
 
     const pastedTxt = clipboard.readText()
-    console.log(pastedTxt);
+
     if (isInFencedCodeBlock(editor)) {
       this.handlePasteText(editor, pastedTxt)
     } else if (fetchUrlTitle && isMarkdownTitleURL(pastedTxt) && !isInLinkTag(editor)) {
@@ -853,15 +853,15 @@ export default class CodeEditor extends React.Component {
     }
   }
 
-  handlePasteUrl(editor, pastedTxt) {
+  handlePasteUrl (editor, pastedTxt) {
     let taggedUrl = `<${pastedTxt}>`
-    let urlToFetch = pastedTxt;
-    let titleMark = '';
+    let urlToFetch = pastedTxt
+    let titleMark = ''
 
     if (isMarkdownTitleURL(pastedTxt)) {
       const pastedTxtSplitted = pastedTxt.split(' ')
-      titleMark = `${pastedTxtSplitted[0]} `;
-      urlToFetch = pastedTxtSplitted[1];
+      titleMark = `${pastedTxtSplitted[0]} `
+      urlToFetch = pastedTxtSplitted[1]
       taggedUrl = `<${urlToFetch}>`
     }
 
@@ -876,7 +876,7 @@ export default class CodeEditor extends React.Component {
     const replaceTaggedUrl = replacement => {
       const value = editor.getValue()
       const cursor = editor.getCursor()
-      const newValue =  value.replace(taggedUrl, titleMark + replacement)
+      const newValue = value.replace(taggedUrl, titleMark + replacement)
       const newCursor = Object.assign({}, cursor, {
         ch: cursor.ch + newValue.length - (value.length - titleMark.length)
       })

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -876,7 +876,7 @@ export default class CodeEditor extends React.Component {
     const replaceTaggedUrl = replacement => {
       const value = editor.getValue()
       const cursor = editor.getCursor()
-      const newValue = titleMark + value.replace(taggedUrl, replacement)
+      const newValue =  value.replace(taggedUrl, titleMark + replacement)
       const newCursor = Object.assign({}, cursor, {
         ch: cursor.ch + newValue.length - (value.length - titleMark.length)
       })

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -14,6 +14,8 @@ import {
 import TextEditorInterface from 'browser/lib/TextEditorInterface'
 import eventEmitter from 'browser/main/lib/eventEmitter'
 import iconv from 'iconv-lite'
+
+import { isMarkdownTitleURL } from 'browser/lib/utils'
 import styles from '../components/CodeEditor.styl'
 const { ipcRenderer, remote, clipboard } = require('electron')
 import normalizeEditorFontFamily from 'browser/lib/normalizeEditorFontFamily'
@@ -806,9 +808,11 @@ export default class CodeEditor extends React.Component {
     }
 
     const pastedTxt = clipboard.readText()
-
+    console.log(pastedTxt);
     if (isInFencedCodeBlock(editor)) {
       this.handlePasteText(editor, pastedTxt)
+    } else if (fetchUrlTitle && isMarkdownTitleURL(pastedTxt) && !isInLinkTag(editor)) {
+      this.handlePasteUrl(editor, pastedTxt)
     } else if (fetchUrlTitle && isURL(pastedTxt) && !isInLinkTag(editor)) {
       this.handlePasteUrl(editor, pastedTxt)
     } else if (attachmentManagement.isAttachmentLink(pastedTxt)) {
@@ -849,8 +853,18 @@ export default class CodeEditor extends React.Component {
     }
   }
 
-  handlePasteUrl (editor, pastedTxt) {
-    const taggedUrl = `<${pastedTxt}>`
+  handlePasteUrl(editor, pastedTxt) {
+    let taggedUrl = `<${pastedTxt}>`
+    let urlToFetch = pastedTxt;
+    let titleMark = '';
+
+    if (isMarkdownTitleURL(pastedTxt)) {
+      const pastedTxtSplitted = pastedTxt.split(' ')
+      titleMark = `${pastedTxtSplitted[0]} `;
+      urlToFetch = pastedTxtSplitted[1];
+      taggedUrl = `<${urlToFetch}>`
+    }
+
     editor.replaceSelection(taggedUrl)
 
     const isImageReponse = response => {
@@ -862,22 +876,23 @@ export default class CodeEditor extends React.Component {
     const replaceTaggedUrl = replacement => {
       const value = editor.getValue()
       const cursor = editor.getCursor()
-      const newValue = value.replace(taggedUrl, replacement)
+      const newValue = titleMark + value.replace(taggedUrl, replacement)
       const newCursor = Object.assign({}, cursor, {
-        ch: cursor.ch + newValue.length - value.length
+        ch: cursor.ch + newValue.length - (value.length - titleMark.length)
       })
+
       editor.setValue(newValue)
       editor.setCursor(newCursor)
     }
 
-    fetch(pastedTxt, {
+    fetch(urlToFetch, {
       method: 'get'
     })
       .then(response => {
         if (isImageReponse(response)) {
-          return this.mapImageResponse(response, pastedTxt)
+          return this.mapImageResponse(response, urlToFetch)
         } else {
-          return this.mapNormalResponse(response, pastedTxt)
+          return this.mapNormalResponse(response, urlToFetch)
         }
       })
       .then(replacement => {

--- a/browser/lib/utils.js
+++ b/browser/lib/utils.js
@@ -132,8 +132,13 @@ export function isObjectEqual (a, b) {
   return true
 }
 
+export function isMarkdownTitleURL (str) {
+  return /(^#{1,6}\s)(?:\w+:|^)\/\/(?:[^\s\.]+\.\S{2}|localhost[\:?\d]*)/.test(str)
+}
+
 export default {
   lastFindInArray,
   escapeHtmlCharacters,
-  isObjectEqual
+  isObjectEqual,
+  isMarkdownTitleURL
 }

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -1,0 +1,14 @@
+import test from 'ava'
+import { isMarkdownTitleURL } from '../../browser/lib/utils'
+
+test('isMarkdownTitleURL returns true for valid Markdown title with url', (t) => {
+  t.true(isMarkdownTitleURL('# https://validurl.com'))
+  t.true(isMarkdownTitleURL('## https://validurl.com'))
+  t.true(isMarkdownTitleURL('###### https://validurl.com'))
+})
+
+test('isMarkdownTitleURL returns true for invalid Markdown title with url', (t) => {
+  t.false(isMarkdownTitleURL('1 https://validurl.com'))
+  t.false(isMarkdownTitleURL('24 https://validurl.com'))
+  t.false(isMarkdownTitleURL('####### https://validurl.com'))
+})

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -1,14 +1,15 @@
-import test from 'ava'
 import { isMarkdownTitleURL } from '../../browser/lib/utils'
 
-test('isMarkdownTitleURL returns true for valid Markdown title with url', (t) => {
-  t.true(isMarkdownTitleURL('# https://validurl.com'))
-  t.true(isMarkdownTitleURL('## https://validurl.com'))
-  t.true(isMarkdownTitleURL('###### https://validurl.com'))
-})
+describe('isMarkdownTitleURL', () => {
+  it('returns true for valid Markdown title with url', () => {
+    expect(isMarkdownTitleURL('# https://validurl.com')).toBe(true)
+    expect(isMarkdownTitleURL('## https://validurl.com')).toBe(true)
+    expect(isMarkdownTitleURL('###### https://validurl.com')).toBe(true)
+  })
 
-test('isMarkdownTitleURL returns true for invalid Markdown title with url', (t) => {
-  t.false(isMarkdownTitleURL('1 https://validurl.com'))
-  t.false(isMarkdownTitleURL('24 https://validurl.com'))
-  t.false(isMarkdownTitleURL('####### https://validurl.com'))
+  it('returns true for invalid Markdown title with url', () => {
+    expect(isMarkdownTitleURL('1 https://validurl.com')).toBe(false)
+    expect(isMarkdownTitleURL('24 https://validurl.com')).toBe(false)
+    expect(isMarkdownTitleURL('####### https://validurl.com')).toBe(false)
+  })
 })


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->

Now you can paste a valid markdown title with a link, eg: `# https://boostnote.io` and it gets the right page title.

![boostnote](https://user-images.githubusercontent.com/1998649/53588266-46fc7380-3b6b-11e9-9a4f-7ecaf423b1f5.gif)

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#2907 

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :radio_button: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :radio_button: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
