### PR TITLE
Sorting notes alphabetically now sort starting numbers in titles right

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -41,8 +41,9 @@ function sortByAlphabetical (a, b) {
     const floatA = parseFloat(matchA[1])
     const floatB = parseFloat(matchB[1])
 
-    if (Math.abs(floatA - floatB) > 0.01) {
-      return floatA - floatB
+    const diff = floatA - floatB
+    if (diff !== 0) {
+      return diff
     }
 
     // The float values are equal. We will compare the full title.

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -26,15 +26,15 @@ const { remote } = require('electron')
 const { dialog } = remote
 const WP_POST_PATH = '/wp/v2/posts'
 
-const matchStartingTitleNumber = new RegExp('^([0-9]*\.?[0-9]+).*$')
+const regexMatchStartingTitleNumber = new RegExp('^([0-9]*\.?[0-9]+).*$')
 
 function sortByCreatedAt (a, b) {
   return new Date(b.createdAt) - new Date(a.createdAt)
 }
 
 function sortByAlphabetical (a, b) {
-  const matchA = matchStartingTitleNumber.exec(a.title)
-  const matchB = matchStartingTitleNumber.exec(b.title)
+  const matchA = regexMatchStartingTitleNumber.exec(a.title)
+  const matchB = regexMatchStartingTitleNumber.exec(b.title)
 
   if (matchA && matchA.length === 2 && matchB && matchB.length === 2) {
     // Both note titles are starting with a float. We will compare it now.

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -26,11 +26,30 @@ const { remote } = require('electron')
 const { dialog } = remote
 const WP_POST_PATH = '/wp/v2/posts'
 
+const matchStartingTitleNumber = new RegExp('^([0-9]*\.?[0-9]+).*$')
+
 function sortByCreatedAt (a, b) {
   return new Date(b.createdAt) - new Date(a.createdAt)
 }
 
 function sortByAlphabetical (a, b) {
+  const matchA = matchStartingTitleNumber.exec(a.title)
+  const matchB = matchStartingTitleNumber.exec(b.title)
+
+  if (matchA && matchA.length === 2 && matchB && matchB.length === 2) {
+    // Both note titles are starting with a float. We will compare it now.
+    const floatA = parseFloat(matchA[1])
+    const floatB = parseFloat(matchB[1])
+
+    if (floatA < floatB) {
+      return -1
+    } else if (floatA > floatB) {
+      return 1
+    }
+
+    // The float values are equal. We will compare the full title.
+  }
+
   return a.title.localeCompare(b.title)
 }
 

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -41,10 +41,8 @@ function sortByAlphabetical (a, b) {
     const floatA = parseFloat(matchA[1])
     const floatB = parseFloat(matchB[1])
 
-    if (floatA < floatB) {
-      return -1
-    } else if (floatA > floatB) {
-      return 1
+    if (Math.abs(floatA - floatB) > 0.01) {
+      return floatA - floatB
     }
 
     // The float values are equal. We will compare the full title.


### PR DESCRIPTION
## Description
Sorting titles with numbers tries to match float values of left and right titles at comparison. When both numbers are floats and not equal we can do a direct compare. In all other cases the full title will compare.

## Screenshot before
<img width="211" alt="screen shot 2019-03-02 at 14 22 26" src="https://user-images.githubusercontent.com/731073/53682654-231a6880-3cf8-11e9-93b3-28ef26295941.png">

## Screenshot after
<img width="209" alt="screen shot 2019-03-02 at 14 22 58" src="https://user-images.githubusercontent.com/731073/53682652-20b80e80-3cf8-11e9-888a-2403af3c258c.png">

## Issue fixed
#2894

## Type of changes

- :large_blue_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :large_blue_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :large_blue_circle: All existing tests have been passed
- :large_blue_circle: I have attached a screenshot/video to visualize my change if possible
