### PR TITLE
Spellcheck dropdown fix

### DIFF
--- a/browser/components/CodeEditor.styl
+++ b/browser/components/CodeEditor.styl
@@ -3,4 +3,3 @@
 
 .spellcheck-select
   border: none
-  text-decoration underline wavy red


### PR DESCRIPTION
## Description
Modification of the CodeEditor.styl to remove spellcheck squiggle from the dropdown menu itself.
## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
Before there was a squiggle present under all options for selecting language of spell checker:

Before:

![image](https://user-images.githubusercontent.com/21070668/54392911-03733080-4666-11e9-8052-73bfd8141b58.png)

After:

![image](https://user-images.githubusercontent.com/21070668/54392950-24d41c80-4666-11e9-90e0-78d74d2b4556.png)

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- ✔️ Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- ✔️ My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- ✔️ All existing tests have been passed
- ✔️ I have attached a screenshot/video to visualize my change if possible
