### PR TITLE
Fixed bug 2931

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -20,6 +20,7 @@ function createGutter (str, firstLineNumber) {
 
 class Markdown {
   constructor (options = {}) {
+    this.escapedHtmlEntities = ['&lt;', '&gt;']
     const config = ConfigManager.get()
     const defaultOptions = {
       typographer: config.preview.smartQuotes,
@@ -298,6 +299,10 @@ class Markdown {
   }
 
   render (content) {
+    this.escapedHtmlEntities.forEach(function (entity) {
+      content = content.replace(entity, `\\${entity}`)
+    })
+    
     if (!_.isString(content)) content = ''
     return this.md.render(content)
   }

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -302,7 +302,6 @@ class Markdown {
     this.escapedHtmlEntities.forEach(function (entity) {
       content = content.replace(entity, `\\${entity}`)
     })
-    
     if (!_.isString(content)) content = ''
     return this.md.render(content)
   }


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
This PR fixes bug 2931

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
[HTML entities](https://www.w3schools.com/html/html_entities.asp) seem to be escaped by markdown-it.
The fix is to double escape these values in the content before passing it to markdown-it.

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :black_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :black_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :black_circle: All existing tests have been passed
-:black_circle: I have attached a screenshot/video to visualize my change if possible

<img width="1198" alt="Screen Shot 2019-03-21 at 10 31 14 PM" src="https://user-images.githubusercontent.com/691009/54797077-1e770f00-4c29-11e9-9b33-286ba30e3803.png">
<img width="1198" alt="Screen Shot 2019-03-21 at 10 31 22 PM" src="https://user-images.githubusercontent.com/691009/54797078-1e770f00-4c29-11e9-9891-5a3f5e4504cc.png">