### PR TITLE
Click a note link will now select the right folder note and not /home

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -269,10 +269,9 @@ class NoteList extends React.Component {
     const selectedNoteKeys = [noteHash]
 
     let locationToSelect = '/home'
-    const notesByHash = data.noteMap.map((note) => note).filter((note) => note.key === noteHash)
-    if (notesByHash.length > 0) {
-      const note = notesByHash[0]
-      locationToSelect = '/storages/' + note.storage + '/folders/' + note.folder
+    const noteByHash = data.noteMap.map((note) => note).find(note => { return note.key === noteHash })
+    if (noteByHash !== undefined) {
+      locationToSelect = '/storages/' + noteByHash.storage + '/folders/' + noteByHash.folder
     }
 
     this.focusNote(selectedNoteKeys, noteHash, locationToSelect)

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -269,7 +269,7 @@ class NoteList extends React.Component {
     const selectedNoteKeys = [noteHash]
 
     let locationToSelect = '/home'
-    const noteByHash = data.noteMap.map((note) => note).find(note => { return note.key === noteHash })
+    const noteByHash = data.noteMap.map((note) => note).find(note => note.key === noteHash)
     if (noteByHash !== undefined) {
       locationToSelect = '/storages/' + noteByHash.storage + '/folders/' + noteByHash.folder
     }

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -259,13 +259,23 @@ class NoteList extends React.Component {
   }
 
   jumpNoteByHashHandler (event, noteHash) {
+    const { data } = this.props
+
     // first argument event isn't used.
     if (this.notes === null || this.notes.length === 0) {
       return
     }
 
     const selectedNoteKeys = [noteHash]
-    this.focusNote(selectedNoteKeys, noteHash, '/home')
+
+    let locationToSelect = '/home'
+    const notesByHash = data.noteMap.map((note) => note).filter((note) => note.key === noteHash)
+    if (notesByHash.length > 0) {
+      const note = notesByHash[0]
+      locationToSelect = '/storages/' + note.storage + '/folders/' + note.folder
+    }
+
+    this.focusNote(selectedNoteKeys, noteHash, locationToSelect)
 
     ee.emit('list:moved')
   }


### PR DESCRIPTION
## Description
After following a link to an other note the folder /home (All Notes) will be selected. The expected behavior is that the storage folder of the requested note will be selected.

## Screenshot before
![Kapture 2019-03-22 at 7 30 09](https://user-images.githubusercontent.com/731073/54804765-f2817b00-4c74-11e9-903b-eec4acc500e9.gif)

## Screenshot after
![Kapture 2019-03-22 at 7 32 14](https://user-images.githubusercontent.com/731073/54804759-ed243080-4c74-11e9-9db0-5b8886d3d06a.gif)

## Type of changes

- :large_blue_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :large_blue_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :large_blue_circle: I have attached a screenshot/video to visualize my change if possible
