### PR TITLE
Removed erroneous parameter resulting in PlantUML server URL not being used

### DIFF
--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -181,7 +181,7 @@ class Markdown {
     })
 
     const deflate = require('markdown-it-plantuml/lib/deflate')
-    this.md.use(require('markdown-it-plantuml'), '', {
+    this.md.use(require('markdown-it-plantuml'), {
       generateSource: function (umlCode) {
         const stripTrailingSlash = (url) => url.endsWith('/') ? url.slice(0, -1) : url
         const serverAddress = stripTrailingSlash(config.preview.plantUMLServerAddress) + '/svg'


### PR DESCRIPTION
## Description

When calling into `markdown-it-plantuml` an additional parameter was being passed that results in custom PlantUML server configs not being picked up. A few lines lower is similar code for dittaa (via PlantUML server) that is missing this parameter and that works correctly

## Issue fixed

#2733 

## Type of changes

- 🔘 Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
