### PR TITLE
Standardx setup for linting & code formatting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,24 +1,33 @@
 {
-  "extends": ["standard", "standard-jsx", "plugin:react/recommended"],
-  "plugins": ["react"],
+  "extends": [
+    "react-app"
+  ],
   "rules": {
     "no-useless-escape": 0,
-    "prefer-const": ["warn", {
-      "destructuring": "all"
-    }],
+    "prefer-const": [
+      "warn",
+      {
+        "destructuring": "all"
+      }
+    ],
     "no-unused-vars": "warn",
     "no-undef": "warn",
     "no-lone-blocks": "warn",
+    "no-loop-func": 0,
+    "default-case": 0,
+    "no-useless-concat": 0,
     "react/prop-types": 0,
     "react/no-string-refs": 0,
     "react/no-find-dom-node": "warn",
     "react/no-render-return-value": "warn",
-    "react/no-deprecated": "warn"
+    "react/no-deprecated": "warn",
+    "jsx-a11y/alt-text": 0
   },
   "globals": {
     "FileReader": true,
     "localStorage": true,
-    "fetch": true
+    "fetch": true,
+    "Image": true
   },
   "env": {
     "jest": true

--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -17,14 +17,14 @@ import iconv from 'iconv-lite'
 
 import { isMarkdownTitleURL } from 'browser/lib/utils'
 import styles from '../components/CodeEditor.styl'
-const { ipcRenderer, remote, clipboard } = require('electron')
 import normalizeEditorFontFamily from 'browser/lib/normalizeEditorFontFamily'
+import TurndownService from 'turndown'
+import { languageMaps } from '../lib/CMLanguageList'
+import snippetManager from '../lib/SnippetManager'
+import { generateInEditor, tocExistsInEditor } from 'browser/lib/markdown-toc-generator'
+const { ipcRenderer, remote, clipboard } = require('electron')
 const spellcheck = require('browser/lib/spellcheck')
 const buildEditorContextMenu = require('browser/lib/contextMenuBuilder')
-import TurndownService from 'turndown'
-import {languageMaps} from '../lib/CMLanguageList'
-import snippetManager from '../lib/SnippetManager'
-import {generateInEditor, tocExistsInEditor} from 'browser/lib/markdown-toc-generator'
 
 CodeMirror.modeURL = '../node_modules/codemirror/mode/%N/%N.js'
 
@@ -113,7 +113,7 @@ export default class CodeEditor extends React.Component {
 
       function makeOverlay (query, style) {
         query = new RegExp(
-          query.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'),
+          query.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), // eslint-disable-line
           'gi'
         )
         return {
@@ -313,7 +313,7 @@ export default class CodeEditor extends React.Component {
     this.textEditorInterface = new TextEditorInterface(this.editor)
     this.tableEditor = new TableEditor(this.textEditorInterface)
     if (this.props.spellCheck) {
-      this.editor.addPanel(this.createSpellCheckPanel(), {position: 'bottom'})
+      this.editor.addPanel(this.createSpellCheckPanel(), { position: 'bottom' })
     }
 
     eventEmitter.on('code:format-table', this.formatTable)
@@ -597,7 +597,7 @@ export default class CodeEditor extends React.Component {
         const elem = document.getElementById('editor-bottom-panel')
         elem.parentNode.removeChild(elem)
       } else {
-        this.editor.addPanel(this.createSpellCheckPanel(), {position: 'bottom'})
+        this.editor.addPanel(this.createSpellCheckPanel(), { position: 'bottom' })
       }
     }
 
@@ -748,7 +748,7 @@ export default class CodeEditor extends React.Component {
       ch: 1
     }
     this.editor.setCursor(cursor)
-    const top = this.editor.charCoords({line: num, ch: 0}, 'local').top
+    const top = this.editor.charCoords({ line: num, ch: 0 }, 'local').top
     const middleHeight = this.editor.getScrollerElement().offsetHeight / 2
     this.editor.scrollTo(null, top - middleHeight - 5)
   }
@@ -804,7 +804,7 @@ export default class CodeEditor extends React.Component {
   handlePaste (editor, forceSmartPaste) {
     const { storageKey, noteKey, fetchUrlTitle, enableSmartPaste } = this.props
 
-    const isURL = str => /(?:^\w+:|^)\/\/(?:[^\s\.]+\.\S{2}|localhost[\:?\d]*)/.test(str)
+    const isURL = str => /(?:^\w+:|^)\/\/(?:[^\s\.]+\.\S{2}|localhost[\:?\d]*)/.test(str) // eslint-disable-line
 
     const isInLinkTag = editor => {
       const startCursor = editor.getCursor('start')
@@ -834,7 +834,8 @@ export default class CodeEditor extends React.Component {
         return true
       }
 
-      let line = line = cursor.line - 1
+      // Todo: Check if it's OK to remove duplicate line in next statement
+      let line = line = cursor.line - 1 // eslint-disable-line
       while (line >= 0) {
         token = editor.getTokenAt({
           ch: 3,
@@ -1061,23 +1062,21 @@ export default class CodeEditor extends React.Component {
     } = this.props
     const fontFamily = normalizeEditorFontFamily(this.props.fontFamily)
     const width = this.props.width
-    return (<
-      div className={
+    return (<div
+      className={
         className == null ? 'CodeEditor' : `CodeEditor ${className}`
       }
       ref='root'
       tabIndex='-1'
-      style={
-      {
+      style={{
         fontFamily,
         fontSize: fontSize,
         width: width
-      }
-      }
+      }}
       onDrop={
         e => this.handleDropImage(e)
       }
-      />
+    />
     )
   }
 

--- a/browser/components/ColorPicker.js
+++ b/browser/components/ColorPicker.js
@@ -18,14 +18,6 @@ class ColorPicker extends React.Component {
     this.handleConfirm = this.handleConfirm.bind(this)
   }
 
-  static getDerivedStateFromProps (nextProps, prevState) {
-    if (nextProps.color !== prevState.color) {
-      return {
-        color: nextProps.color
-      }
-    }
-  }
-
   componentWillReceiveProps (nextProps) {
     this.onColorChange(nextProps.color)
   }

--- a/browser/components/ColorPicker.js
+++ b/browser/components/ColorPicker.js
@@ -18,6 +18,14 @@ class ColorPicker extends React.Component {
     this.handleConfirm = this.handleConfirm.bind(this)
   }
 
+  static getDerivedStateFromProps (nextProps, prevState) {
+    if (nextProps.color !== prevState.color) {
+      return {
+        color: nextProps.color
+      }
+    }
+  }
+
   componentWillReceiveProps (nextProps) {
     this.onColorChange(nextProps.color)
   }
@@ -44,13 +52,22 @@ class ColorPicker extends React.Component {
     }
 
     return (
-      <div styleName='colorPicker' style={{top: `${alignY}px`, left: `${alignX}px`}}>
+      <div
+        styleName='colorPicker'
+        style={{ top: `${alignY}px`, left: `${alignX}px` }}
+      >
         <div styleName='cover' onClick={onCancel} />
         <SketchPicker color={color} onChange={this.onColorChange} />
         <div styleName='footer'>
-          <button styleName='btn-reset' onClick={onReset}>Reset</button>
-          <button styleName='btn-cancel' onClick={onCancel}>Cancel</button>
-          <button styleName='btn-confirm' onClick={this.handleConfirm}>Confirm</button>
+          <button styleName='btn-reset' onClick={onReset}>
+            Reset
+          </button>
+          <button styleName='btn-cancel' onClick={onCancel}>
+            Cancel
+          </button>
+          <button styleName='btn-confirm' onClick={this.handleConfirm}>
+            Confirm
+          </button>
         </div>
       </div>
     )

--- a/browser/components/MarkdownEditor.js
+++ b/browser/components/MarkdownEditor.js
@@ -127,7 +127,7 @@ class MarkdownEditor extends React.Component {
 
   handleDoubleClick (e) {
     if (this.state.isLocked) return
-    this.setState({keyPressed: new Set()})
+    this.setState({ keyPressed: new Set() })
     const { config } = this.props
     if (config.editor.switchPreview === 'DBL_CLICK') {
       this.setState({
@@ -159,8 +159,8 @@ class MarkdownEditor extends React.Component {
     e.preventDefault()
     e.stopPropagation()
     const idMatch = /checkbox-([0-9]+)/
-    const checkedMatch = /^\s*[\+\-\*] \[x\]/i
-    const uncheckedMatch = /^\s*[\+\-\*] \[ \]/
+    const checkedMatch = /^\s*[\+\-\*] \[x\]/i // eslint-disable-line
+    const uncheckedMatch = /^\s*[\+\-\*] \[ \]/ // eslint-disable-line
     const checkReplace = /\[x\]/i
     const uncheckReplace = /\[ \]/
     if (idMatch.test(e.target.getAttribute('id'))) {
@@ -266,7 +266,7 @@ class MarkdownEditor extends React.Component {
   }
 
   render () {
-    const {className, value, config, storageKey, noteKey, linesHighlighted} = this.props
+    const { className, value, config, storageKey, noteKey, linesHighlighted } = this.props
 
     let editorFontSize = parseInt(config.editor.fontSize, 10)
     if (!(editorFontSize > 0 && editorFontSize < 101)) editorFontSize = 14
@@ -279,7 +279,8 @@ class MarkdownEditor extends React.Component {
     const storage = findStorage(storageKey)
 
     return (
-      <div className={className == null
+      <div
+        className={className == null
           ? 'MarkdownEditor'
           : `MarkdownEditor ${className}`
         }
@@ -288,7 +289,8 @@ class MarkdownEditor extends React.Component {
         onKeyDown={(e) => this.handleKeyDown(e)}
         onKeyUp={(e) => this.handleKeyUp(e)}
       >
-        <CodeEditor styleName={this.state.status === 'CODE'
+        <CodeEditor
+          styleName={this.state.status === 'CODE'
             ? 'codeEditor'
             : 'codeEditor--hide'
           }
@@ -320,7 +322,8 @@ class MarkdownEditor extends React.Component {
           hotkey={config.hotkey}
           switchPreview={config.editor.switchPreview}
         />
-        <MarkdownPreview styleName={this.state.status === 'PREVIEW'
+        <MarkdownPreview
+          styleName={this.state.status === 'PREVIEW'
             ? 'preview'
             : 'preview--hide'
           }

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -1,3 +1,4 @@
+/* global MutationObserver */
 import PropTypes from 'prop-types'
 import React from 'react'
 import Markdown from 'browser/lib/markdown'
@@ -36,7 +37,7 @@ const dialog = remote.dialog
 
 const uri2path = require('file-uri-to-path')
 
-const markdownStyle = require('!!css!stylus?sourceMap!./markdown.styl')[0][1]
+const markdownStyle = require('!!css!stylus?sourceMap!./markdown.styl')[0][1] // eslint-disable-line
 const appPath = fileUrl(
   process.env.NODE_ENV === 'production' ? app.getAppPath() : path.resolve()
 )
@@ -344,7 +345,7 @@ export default class MarkdownPreview extends React.Component {
       allowCustomCSS,
       customCSS
     )
-    let body = this.markdown.render(noteContent)
+    const body = this.markdown.render(noteContent)
     const files = [this.GetCodeThemeLink(codeBlockTheme), ...CSS_FILES]
     files.forEach(file => {
       if (global.process.platform === 'win32') {
@@ -381,7 +382,7 @@ export default class MarkdownPreview extends React.Component {
 
   handleSaveAsPdf () {
     this.exportAsDocument('pdf', (noteContent, exportTasks, targetDir) => {
-      const printout = new remote.BrowserWindow({show: false, webPreferences: {webSecurity: false}})
+      const printout = new remote.BrowserWindow({ show: false, webPreferences: { webSecurity: false } })
       printout.loadURL('data:text/html;charset=UTF-8,' + this.htmlContentFormatter(noteContent, exportTasks, targetDir))
       return new Promise((resolve, reject) => {
         printout.webContents.on('did-finish-load', () => {
@@ -448,15 +449,16 @@ export default class MarkdownPreview extends React.Component {
    */
   escapeHtmlCharactersInCodeTag (splitWithCodeTag) {
     for (let index = 0; index < splitWithCodeTag.length; index++) {
+      // eslint-disable-next-line
       const codeTagRequired = (splitWithCodeTag[index] !== '\`\`\`' && index < splitWithCodeTag.length - 1)
       if (codeTagRequired) {
-        splitWithCodeTag.splice((index + 1), 0, '\`\`\`')
+        splitWithCodeTag.splice((index + 1), 0, '\`\`\`') // eslint-disable-line
       }
     }
     let inCodeTag = false
     let result = ''
     for (let content of splitWithCodeTag) {
-      if (content === '\`\`\`') {
+      if (content === '\`\`\`') { // eslint-disable-line
         inCodeTag = !inCodeTag
       } else if (inCodeTag) {
         content = escapeHtmlCharacters(content)
@@ -617,16 +619,16 @@ export default class MarkdownPreview extends React.Component {
     let { fontFamily, codeBlockFontFamily } = this.props
     fontFamily = _.isString(fontFamily) && fontFamily.trim().length > 0
       ? fontFamily
-          .split(',')
-          .map(fontName => fontName.trim())
-          .concat(defaultFontFamily)
+        .split(',')
+        .map(fontName => fontName.trim())
+        .concat(defaultFontFamily)
       : defaultFontFamily
     codeBlockFontFamily = _.isString(codeBlockFontFamily) &&
       codeBlockFontFamily.trim().length > 0
       ? codeBlockFontFamily
-          .split(',')
-          .map(fontName => fontName.trim())
-          .concat(defaultCodeBlockFontFamily)
+        .split(',')
+        .map(fontName => fontName.trim())
+        .concat(defaultCodeBlockFontFamily)
       : defaultCodeBlockFontFamily
 
     return {
@@ -838,7 +840,7 @@ export default class MarkdownPreview extends React.Component {
             canvas.height = height.value + 'vh'
           }
 
-          const chart = new Chart(canvas, chartConfig)
+          Chart(canvas, chartConfig)
         } catch (e) {
           el.className = 'chart-error'
           el.innerHTML = 'chartjs diagram parse error: ' + e.message
@@ -1072,6 +1074,7 @@ export default class MarkdownPreview extends React.Component {
     const { className, style, tabIndex } = this.props
     return (
       <iframe
+        title='Markdown Preview'
         className={
           className != null ? 'MarkdownPreview ' + className : 'MarkdownPreview'
         }

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -840,7 +840,7 @@ export default class MarkdownPreview extends React.Component {
             canvas.height = height.value + 'vh'
           }
 
-          Chart(canvas, chartConfig)
+          const chart = Chart(canvas, chartConfig) // eslint-disable-line
         } catch (e) {
           el.className = 'chart-error'
           el.innerHTML = 'chartjs diagram parse error: ' + e.message

--- a/browser/components/MarkdownSplitEditor.js
+++ b/browser/components/MarkdownSplitEditor.js
@@ -61,8 +61,8 @@ class MarkdownSplitEditor extends React.Component {
       const timer = setInterval(() => {
         time = frame / frames
         scrollPos = time < 0.5
-                  ? 2 * time * time // ease in
-                  : -1 + (4 - 2 * time) * time // ease out
+          ? 2 * time * time // ease in
+          : -1 + (4 - 2 * time) * time // ease out
         if (e.doc) _.set(previewDoc, 'body.scrollTop', targetTop + scrollPos * distance)
         else _.get(this, 'refs.code.editor').scrollTo(0, targetTop + scrollPos * distance)
         if (frame >= frames) {
@@ -78,8 +78,8 @@ class MarkdownSplitEditor extends React.Component {
     e.preventDefault()
     e.stopPropagation()
     const idMatch = /checkbox-([0-9]+)/
-    const checkedMatch = /^\s*[\+\-\*] \[x\]/i
-    const uncheckedMatch = /^\s*[\+\-\*] \[ \]/
+    const checkedMatch = /^\s*[\+\-\*] \[x\]/i // eslint-disable-line
+    const uncheckedMatch = /^\s*[\+\-\*] \[ \]/ // eslint-disable-line
     const checkReplace = /\[x\]/i
     const uncheckReplace = /\[ \]/
     if (idMatch.test(e.target.getAttribute('id'))) {
@@ -136,7 +136,7 @@ class MarkdownSplitEditor extends React.Component {
   }
 
   render () {
-    const {config, value, storageKey, noteKey, linesHighlighted} = this.props
+    const { config, value, storageKey, noteKey, linesHighlighted } = this.props
     const storage = findStorage(storageKey)
     let editorFontSize = parseInt(config.editor.fontSize, 10)
     if (!(editorFontSize > 0 && editorFontSize < 101)) editorFontSize = 14
@@ -179,8 +179,8 @@ class MarkdownSplitEditor extends React.Component {
           enableSmartPaste={config.editor.enableSmartPaste}
           hotkey={config.hotkey}
           switchPreview={config.editor.switchPreview}
-       />
-        <div styleName='slider' style={{left: this.state.codeEditorWidthInPercent + '%'}} onMouseDown={e => this.handleMouseDown(e)} >
+        />
+        <div styleName='slider' style={{ left: this.state.codeEditorWidthInPercent + '%' }} onMouseDown={e => this.handleMouseDown(e)} >
           <div styleName='slider-hitbox' />
         </div>
         <MarkdownPreview
@@ -209,7 +209,7 @@ class MarkdownSplitEditor extends React.Component {
           customCSS={config.preview.customCSS}
           allowCustomCSS={config.preview.allowCustomCSS}
           lineThroughCheckbox={config.preview.lineThroughCheckbox}
-       />
+        />
       </div>
     )
   }

--- a/browser/components/NavToggleButton.js
+++ b/browser/components/NavToggleButton.js
@@ -11,13 +11,13 @@ import CSSModules from 'browser/lib/CSSModules'
 * @param {Function} handleToggleButtonClick
 */
 
-const NavToggleButton = ({isFolded, handleToggleButtonClick}) => (
+const NavToggleButton = ({ isFolded, handleToggleButtonClick }) => (
   <button styleName='navToggle'
     onClick={(e) => handleToggleButtonClick(e)}
   >
     {isFolded
-     ? <i className='fa fa-angle-double-right fa-2x' />
-     : <i className='fa fa-angle-double-left fa-2x' />
+      ? <i className='fa fa-angle-double-right fa-2x' />
+      : <i className='fa fa-angle-double-left fa-2x' />
     }
   </button>
 )

--- a/browser/components/NoteItem.js
+++ b/browser/components/NoteItem.js
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types'
 import React from 'react'
-import { isArray } from 'lodash'
+import _, { isArray } from 'lodash'
 import invertColor from 'invert-color'
 import CSSModules from 'browser/lib/CSSModules'
 import { getTodoStatus } from 'browser/lib/getTodoStatus'
@@ -113,7 +113,7 @@ const NoteItem = ({
             : <span
               style={{ fontStyle: 'italic', opacity: 0.5 }}
               styleName='item-bottom-tagList-empty'
-              >
+            >
               {i18n.__('No tags')}
             </span>}
         </div>
@@ -122,7 +122,7 @@ const NoteItem = ({
             ? <img
               styleName='item-star'
               src='../resources/icon/icon-starred.svg'
-              />
+            />
             : ''}
           {note.isPinned && !pathname.match(/\/starred|\/trash/)
             ? <i styleName='item-pin' className='fa fa-thumb-tack' />
@@ -144,7 +144,7 @@ NoteItem.propTypes = {
     storage: PropTypes.string.isRequired,
     key: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
-    title: PropTypes.string.isrequired,
+    title: PropTypes.string.isRequired,
     tags: PropTypes.array,
     isStarred: PropTypes.bool.isRequired,
     isTrashed: PropTypes.bool.isRequired,

--- a/browser/components/NoteItemSimple.js
+++ b/browser/components/NoteItemSimple.js
@@ -25,10 +25,11 @@ const NoteItemSimple = ({
   pathname,
   storage
 }) => (
-  <div styleName={isActive
-    ? 'item-simple--active'
-    : 'item-simple'
-  }
+  <div
+    styleName={isActive
+      ? 'item-simple--active'
+      : 'item-simple'
+    }
     key={note.key}
     onClick={e => handleNoteClick(e, note.key)}
     onContextMenu={e => handleNoteContextMenu(e, note.key)}
@@ -63,7 +64,7 @@ NoteItemSimple.propTypes = {
     storage: PropTypes.string.isRequired,
     key: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
-    title: PropTypes.string.isrequired
+    title: PropTypes.string.isRequired
   }),
   handleNoteClick: PropTypes.func.isRequired,
   handleNoteContextMenu: PropTypes.func.isRequired,

--- a/browser/components/RealtimeNotification.js
+++ b/browser/components/RealtimeNotification.js
@@ -25,7 +25,7 @@ class RealtimeNotification extends React.Component {
         return response.json()
       })
       .then(json => {
-        this.setState({notifications: json.notifications})
+        this.setState({ notifications: json.notifications })
       })
   }
 
@@ -42,7 +42,7 @@ class RealtimeNotification extends React.Component {
       >
         Info: {notifications[0].text}
       </a>
-    : ''
+      : ''
 
     return (
       <div styleName='notification-area' style={this.props.style}>{link}</div>

--- a/browser/components/SnippetTab.js
+++ b/browser/components/SnippetTab.js
@@ -99,9 +99,9 @@ class SnippetTab extends React.Component {
     const { isActive, snippet, isDeletable } = this.props
     return (
       <div styleName={isActive
-          ? 'root--active'
-          : 'root'
-        }
+        ? 'root--active'
+        : 'root'
+      }
       >
         {!this.state.isRenaming
           ? <button styleName='button'

--- a/browser/components/StorageList.js
+++ b/browser/components/StorageList.js
@@ -10,7 +10,7 @@ import CSSModules from 'browser/lib/CSSModules'
 * @param {Array} storageList
 */
 
-const StorageList = ({storageList, isFolded}) => (
+const StorageList = ({ storageList, isFolded }) => (
   <div styleName={isFolded ? 'storageList-folded' : 'storageList'}>
     {storageList.length > 0 ? storageList : (
       <div styleName='storageList-empty'>No storage mount.</div>

--- a/browser/components/TagListItem.js
+++ b/browser/components/TagListItem.js
@@ -15,7 +15,7 @@ import CSSModules from 'browser/lib/CSSModules'
 * @param {string} bgColor tab backgroundColor
 */
 
-const TagListItem = ({name, handleClickTagListItem, handleClickNarrowToTag, handleContextMenu, isActive, isRelated, count, color}) => (
+const TagListItem = ({ name, handleClickTagListItem, handleClickNarrowToTag, handleContextMenu, isActive, isRelated, count, color }) => (
   <div styleName='tagList-itemContainer' onContextMenu={e => handleContextMenu(e, name)}>
     {isRelated
       ? <button styleName={isActive ? 'tagList-itemNarrow-active' : 'tagList-itemNarrow'} onClick={() => handleClickNarrowToTag(name)}>
@@ -24,7 +24,7 @@ const TagListItem = ({name, handleClickTagListItem, handleClickNarrowToTag, hand
       : <div styleName={isActive ? 'tagList-itemNarrow-active' : 'tagList-itemNarrow'} />
     }
     <button styleName={isActive ? 'tagList-item-active' : 'tagList-item'} onClick={() => handleClickTagListItem(name)}>
-      <span styleName='tagList-item-color' style={{backgroundColor: color || 'transparent'}} />
+      <span styleName='tagList-item-color' style={{ backgroundColor: color || 'transparent' }} />
       <span styleName='tagList-item-name'>
         {`# ${name}`}
         <span styleName='tagList-item-count'>{count !== 0 ? count : ''}</span>

--- a/browser/components/TodoListPercentage.js
+++ b/browser/components/TodoListPercentage.js
@@ -14,8 +14,8 @@ import styles from './TodoListPercentage.styl'
 const TodoListPercentage = ({
   percentageOfTodo, onClearCheckboxClick
 }) => (
-  <div styleName='percentageBar' style={{display: isNaN(percentageOfTodo) ? 'none' : ''}}>
-    <div styleName='progressBar' style={{width: `${percentageOfTodo}%`}}>
+  <div styleName='percentageBar' style={{ display: isNaN(percentageOfTodo) ? 'none' : '' }}>
+    <div styleName='progressBar' style={{ width: `${percentageOfTodo}%` }}>
       <div styleName='progressBarInner'>
         <p styleName='percentageText'>{percentageOfTodo}%</p>
       </div>

--- a/browser/components/TodoProcess.js
+++ b/browser/components/TodoProcess.js
@@ -13,13 +13,13 @@ const TodoProcess = ({
     completed: completedTodo
   }
 }) => (
-  <div styleName='todo-process' style={{display: totalTodo > 0 ? '' : 'none'}}>
+  <div styleName='todo-process' style={{ display: totalTodo > 0 ? '' : 'none' }}>
     <div styleName='todo-process-text'>
       <i className='fa fa-fw fa-check-square-o' />
       {completedTodo} of {totalTodo}
     </div>
     <div styleName='todo-process-bar'>
-      <div styleName='todo-process-bar--inner' style={{width: parseInt(completedTodo / totalTodo * 100) + '%'}} />
+      <div styleName='todo-process-bar--inner' style={{ width: parseInt(completedTodo / totalTodo * 100) + '%' }} />
     </div>
   </div>
 )

--- a/browser/lib/CSSModules.js
+++ b/browser/lib/CSSModules.js
@@ -1,5 +1,5 @@
 import CSSModules from 'react-css-modules'
 
 export default function (component, styles) {
-  return CSSModules(component, styles, {errorWhenNotFound: false})
+  return CSSModules(component, styles, { errorWhenNotFound: false })
 }

--- a/browser/lib/Languages.js
+++ b/browser/lib/Languages.js
@@ -82,4 +82,3 @@ module.exports = {
     return languages
   }
 }
-

--- a/browser/lib/contextMenuBuilder.js
+++ b/browser/lib/contextMenuBuilder.js
@@ -1,5 +1,5 @@
-const {remote} = require('electron')
-const {Menu} = remote.require('electron')
+const { remote } = require('electron')
+const { Menu } = remote.require('electron')
 const spellcheck = require('./spellcheck')
 
 /**
@@ -14,7 +14,7 @@ const buildEditorContextMenu = function (editor, event) {
   if (editor == null || event == null || event.pageX == null || event.pageY == null) {
     return null
   }
-  const cursor = editor.coordsChar({left: event.pageX, top: event.pageY})
+  const cursor = editor.coordsChar({ left: event.pageX, top: event.pageY })
   const wordRange = editor.findWordAt(cursor)
   const word = editor.getRange(wordRange.anchor, wordRange.head)
   const existingMarks = editor.findMarks(wordRange.anchor, wordRange.head) || []

--- a/browser/lib/customMeta.js
+++ b/browser/lib/customMeta.js
@@ -1,5 +1,5 @@
 import CodeMirror from 'codemirror'
 import 'codemirror-mode-elixir'
 
-CodeMirror.modeInfo.push({name: 'Stylus', mime: 'text/x-styl', mode: 'stylus', ext: ['styl'], alias: ['styl']})
-CodeMirror.modeInfo.push({name: 'Elixir', mime: 'text/x-elixir', mode: 'elixir', ext: ['ex']})
+CodeMirror.modeInfo.push({ name: 'Stylus', mime: 'text/x-styl', mode: 'stylus', ext: ['styl'], alias: ['styl'] })
+CodeMirror.modeInfo.push({ name: 'Elixir', mime: 'text/x-elixir', mode: 'elixir', ext: ['ex'] })

--- a/browser/lib/findNoteTitle.js
+++ b/browser/lib/findNoteTitle.js
@@ -20,6 +20,10 @@ export function findNoteTitle (value, enableFrontMatterTitle, frontMatterTitleFi
   }
 
   if (title === null) {
+    // Note:
+    // Not every case of below some is returning a boolean
+    // --> could probably be improved by returning null;
+    // eslint-disable-next-line
     splitted.some((line, index) => {
       const trimmedLine = line.trim()
       const trimmedNextLine = splitted[index + 1] === undefined ? '' : splitted[index + 1].trim()
@@ -35,6 +39,8 @@ export function findNoteTitle (value, enableFrontMatterTitle, frontMatterTitleFi
 
   if (title === null) {
     title = ''
+    // Note: Some is not returning a value in every case
+    // eslint-disable-next-line
     splitted.some((line) => {
       if (line.trim().length > 0) {
         title = line.trim()

--- a/browser/lib/findStorage.js
+++ b/browser/lib/findStorage.js
@@ -3,7 +3,7 @@ const _ = require('lodash')
 export function findStorage (storageKey) {
   const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
   if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
-  const storage = _.find(cachedStorageList, {key: storageKey})
+  const storage = _.find(cachedStorageList, { key: storageKey })
   if (storage === undefined) throw new Error('Target storage doesn\'t exist.')
 
   return storage

--- a/browser/lib/getTodoStatus.js
+++ b/browser/lib/getTodoStatus.js
@@ -5,10 +5,10 @@ export function getTodoStatus (content) {
 
   splitted.forEach((line) => {
     const trimmedLine = line.trim()
-    if (trimmedLine.match(/^[\+\-\*] \[(\s|x)\] ./i)) {
+    if (trimmedLine.match(/^[\+\-\*] \[(\s|x)\] ./i)) {  // eslint-disable-line
       numberOfTodo++
     }
-    if (trimmedLine.match(/^[\+\-\*] \[x\] ./i)) {
+    if (trimmedLine.match(/^[\+\-\*] \[x\] ./i)) { // eslint-disable-line
       numberOfCompletedTodo++
     }
   })

--- a/browser/lib/keygen.js
+++ b/browser/lib/keygen.js
@@ -1,5 +1,4 @@
 const crypto = require('crypto')
-const _ = require('lodash')
 const uuidv4 = require('uuid/v4')
 
 module.exports = function (uuid) {

--- a/browser/lib/markdown-it-deflist.js
+++ b/browser/lib/markdown-it-deflist.js
@@ -1,5 +1,3 @@
-'use strict'
-
 module.exports = function definitionListPlugin (md) {
   var isSpace = md.utils.isSpace
 

--- a/browser/lib/markdown-it-fence.js
+++ b/browser/lib/markdown-it-fence.js
@@ -1,5 +1,3 @@
-'use strict'
-
 module.exports = function (md, renderers, defaultRenderer) {
   const paramsRE = /^[ \t]*([\w+#-]+)?(?:\(((?:\s*\w[-\w]*(?:=(?:'(?:.*?[^\\])?'|"(?:.*?[^\\])?"|(?:[^'"][^\s]*)))?)*)\))?(?::([^:]*)(?::(\d+))?)?\s*$/
 

--- a/browser/lib/markdown-it-frontmatter.js
+++ b/browser/lib/markdown-it-frontmatter.js
@@ -1,5 +1,3 @@
-'use strict'
-
 module.exports = function frontMatterPlugin (md) {
   function frontmatter (state, startLine, endLine, silent) {
     if (startLine !== 0 || state.src.substr(startLine, state.eMarks[0]) !== '---') {

--- a/browser/lib/markdown-it-sanitize-html.js
+++ b/browser/lib/markdown-it-sanitize-html.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import sanitizeHtml from 'sanitize-html'
 import { escapeHtmlCharacters } from './utils'
 import url from 'url'
@@ -96,11 +94,11 @@ function sanitizeInline (html, options) {
 
 function naughtyHRef (href, options) {
   // href = href.replace(/[\x00-\x20]+/g, '')
-  href = href.replace(/<\!\-\-.*?\-\-\>/g, '')
+  href = href.replace(/<\!\-\-.*?\-\-\>/g, '') // eslint-disable-line
 
-  const matches = href.match(/^([a-zA-Z]+)\:/)
+  const matches = href.match(/^([a-zA-Z]+)\:/) // eslint-disable-line
   if (!matches) {
-    if (href.match(/^[\/\\]{2}/)) {
+    if (href.match(/^[\/\\]{2}/)) { // eslint-disable-line
       return !options.allowProtocolRelative
     }
 

--- a/browser/lib/markdown-toc-generator.js
+++ b/browser/lib/markdown-toc-generator.js
@@ -46,7 +46,7 @@ export function generateInEditor (editor) {
   }
 
   function addTocAtCursorPosition () {
-    const toc = generate(editor.getRange(editor.getCursor(), {line: Infinity}))
+    const toc = generate(editor.getRange(editor.getCursor(), { line: Infinity }))
     editor.replaceRange(wrapTocWithEol(toc, editor), editor.getCursor())
   }
 

--- a/browser/lib/markdown.js
+++ b/browser/lib/markdown.js
@@ -121,7 +121,7 @@ class Markdown {
       slugify: require('./slugify')
     })
     this.md.use(require('markdown-it-kbd'))
-    this.md.use(require('markdown-it-admonition'), {types: ['note', 'hint', 'attention', 'caution', 'danger', 'error']})
+    this.md.use(require('markdown-it-admonition'), { types: ['note', 'hint', 'attention', 'caution', 'danger', 'error'] })
     this.md.use(require('markdown-it-abbr'))
     this.md.use(require('markdown-it-sub'))
     this.md.use(require('markdown-it-sup'))
@@ -147,7 +147,7 @@ class Markdown {
       },
       gallery: token => {
         const content = token.content.split('\n').slice(0, -1).map(line => {
-          const match = /!\[[^\]]*]\(([^\)]*)\)/.exec(line)
+          const match = /!\[[^\]]*]\(([^\)]*)\)/.exec(line) // eslint-disable-line
           if (match) {
             return match[1]
           } else {

--- a/browser/lib/markdownTextHelper.js
+++ b/browser/lib/markdownTextHelper.js
@@ -10,16 +10,16 @@ export function strip (input) {
   let output = input
   try {
     output = output
-      .replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, '$1')
+      .replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, '$1') // eslint-disable-line
       .replace(/\n={2,}/g, '\n')
       .replace(/~~/g, '')
       .replace(/`{3}.*\n/g, '')
       .replace(/<(.*?)>/g, '$1')
-      .replace(/^[=\-]{2,}\s*$/g, '')
+      .replace(/^[=\-]{2,}\s*$/g, '')  // eslint-disable-line
       .replace(/\[\^.+?\](: .*?$)?/g, '')
       .replace(/\s{0,2}\[.*?\]: .*?$/g, '')
-      .replace(/!\[.*?\][\[\(].*?[\]\)]/g, '')
-      .replace(/\[(.*?)\][\[\(].*?[\]\)]/g, '$1')
+      .replace(/!\[.*?\][\[\(].*?[\]\)]/g, '')  // eslint-disable-line
+      .replace(/\[(.*?)\][\[\(].*?[\]\)]/g, '$1')  // eslint-disable-line
       .replace(/>/g, '')
       .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
       .replace(/^#{1,6}\s*/gm, '')

--- a/browser/lib/slugify.js
+++ b/browser/lib/slugify.js
@@ -13,5 +13,5 @@ module.exports = function slugify (title) {
 
   slug = slug.replace(/[^\w\s-]/g, '').replace(/\s+/g, '-')
 
-  return encodeURI(slug).replace(/\-+$/, '')
+  return encodeURI(slug).replace(/\-+$/, '') // eslint-disable-line
 }

--- a/browser/lib/spellcheck.js
+++ b/browser/lib/spellcheck.js
@@ -14,10 +14,10 @@ let self
 
 function getAvailableDictionaries () {
   return [
-    {label: i18n.__('Spellcheck disabled'), value: SPELLCHECK_DISABLED},
-    {label: i18n.__('English'), value: 'en_GB'},
-    {label: i18n.__('German'), value: 'de_DE'},
-    {label: i18n.__('French'), value: 'fr_FR'}
+    { label: i18n.__('Spellcheck disabled'), value: SPELLCHECK_DISABLED },
+    { label: i18n.__('English'), value: 'en_GB' },
+    { label: i18n.__('German'), value: 'de_DE' },
+    { label: i18n.__('French'), value: 'fr_FR' }
   ]
 }
 
@@ -64,8 +64,8 @@ function checkWholeDocument (editor) {
   const lastLine = editor.lineCount() - 1
   const textOfLastLine = editor.getLine(lastLine) || ''
   const lastChar = textOfLastLine.length
-  const from = {line: 0, ch: 0}
-  const to = {line: lastLine, ch: lastChar}
+  const from = { line: 0, ch: 0 }
+  const to = { line: lastLine, ch: lastChar }
   checkMultiLineRange(editor, from, to)
 }
 
@@ -78,12 +78,12 @@ function checkWholeDocument (editor) {
 function checkMultiLineRange (editor, from, to) {
   function sortRange (pos1, pos2) {
     if (pos1.line > pos2.line || (pos1.line === pos2.line && pos1.ch > pos2.ch)) {
-      return {from: pos2, to: pos1}
+      return { from: pos2, to: pos1 }
     }
-    return {from: pos1, to: pos2}
+    return { from: pos1, to: pos2 }
   }
 
-  const {from: smallerPos, to: higherPos} = sortRange(from, to)
+  const { from: smallerPos, to: higherPos } = sortRange(from, to)
   for (let l = smallerPos.line; l <= higherPos.line; l++) {
     const line = editor.getLine(l) || ''
     let w = 0
@@ -95,7 +95,7 @@ function checkMultiLineRange (editor, from, to) {
       wEnd = higherPos.ch
     }
     while (w <= wEnd) {
-      const wordRange = editor.findWordAt({line: l, ch: w})
+      const wordRange = editor.findWordAt({ line: l, ch: w })
       self.checkWord(editor, wordRange)
       w += (wordRange.head.ch - wordRange.anchor.ch) + 1
     }
@@ -116,7 +116,7 @@ function checkWord (editor, wordRange) {
     return
   }
   if (!dictionary.check(word)) {
-    editor.markText(wordRange.anchor, wordRange.head, {className: styles[CSS_ERROR_CLASS]})
+    editor.markText(wordRange.anchor, wordRange.head, { className: styles[CSS_ERROR_CLASS] })
   }
 }
 
@@ -145,13 +145,13 @@ function checkChangeRange (editor, fromChangeObject, toChangeObject) {
         biggest = currentPos
       }
     }
-    return {start: smallest, end: biggest}
+    return { start: smallest, end: biggest }
   }
 
   if (dictionary === null || editor == null) { return }
 
   try {
-    const {start, end} = getStartAndEnd(fromChangeObject, toChangeObject)
+    const { start, end } = getStartAndEnd(fromChangeObject, toChangeObject)
 
     // Expand the range to include words after/before whitespaces
     start.ch = Math.max(start.ch - 1, 0)

--- a/browser/lib/utils.js
+++ b/browser/lib/utils.js
@@ -133,7 +133,7 @@ export function isObjectEqual (a, b) {
 }
 
 export function isMarkdownTitleURL (str) {
-  return /(^#{1,6}\s)(?:\w+:|^)\/\/(?:[^\s\.]+\.\S{2}|localhost[\:?\d]*)/.test(str)
+  return /(^#{1,6}\s)(?:\w+:|^)\/\/(?:[^\s\.]+\.\S{2}|localhost[\:?\d]*)/.test(str) // eslint-disable-line
 }
 
 export default {

--- a/browser/main/Detail/FolderSelect.js
+++ b/browser/main/Detail/FolderSelect.js
@@ -210,7 +210,8 @@ class FolderSelect extends React.Component {
     const optionList = options
       .map((option, index) => {
         return (
-          <div styleName={index === this.state.optionIndex
+          <div
+            styleName={index === this.state.optionIndex
               ? 'search-optionList-item--active'
               : 'search-optionList-item'
             }
@@ -218,7 +219,7 @@ class FolderSelect extends React.Component {
             onClick={(e) => this.handleOptionClick(option.storage.key, option.folder.key)(e)}
           >
             <span styleName='search-optionList-item-name'
-              style={{borderColor: option.folder.color}}
+              style={{ borderColor: option.folder.color }}
             >
               {option.folder.name}
               <span styleName='search-optionList-item-name-surfix'>in {option.storage.name}</span>
@@ -228,15 +229,16 @@ class FolderSelect extends React.Component {
       })
 
     return (
-      <div className={_.isString(className)
+      <div
+        className={_.isString(className)
           ? 'FolderSelect ' + className
           : 'FolderSelect'
         }
         styleName={this.state.status === 'SEARCH'
           ? 'root--search'
           : this.state.status === 'FOCUS'
-          ? 'root--focus'
-          : 'root'
+            ? 'root--focus'
+            : 'root'
         }
         ref='root'
         tabIndex='0'
@@ -261,7 +263,7 @@ class FolderSelect extends React.Component {
               {optionList}
             </div>
           </div>
-          : <div styleName='idle' style={{color: currentOption.folder.color}}>
+          : <div styleName='idle' style={{ color: currentOption.folder.color }}>
             <div styleName='idle-label'>
               <i className='fa fa-folder' />
               <span styleName='idle-label-name'>

--- a/browser/main/Detail/FullscreenButton.js
+++ b/browser/main/Detail/FullscreenButton.js
@@ -6,7 +6,7 @@ import i18n from 'browser/lib/i18n'
 
 const OSX = global.process.platform === 'darwin'
 const FullscreenButton = ({
- onClick
+  onClick
 }) => {
   const hotkey = (OSX ? i18n.__('Command(⌘)') : i18n.__('Ctrl(^)')) + '+B'
   return (

--- a/browser/main/Detail/InfoPanel.js
+++ b/browser/main/Detail/InfoPanel.js
@@ -7,7 +7,7 @@ import i18n from 'browser/lib/i18n'
 
 class InfoPanel extends React.Component {
   copyNoteLink () {
-    const {noteLink} = this.props
+    const { noteLink } = this.props
     this.refs.noteLink.select()
     copy(noteLink)
   }
@@ -17,7 +17,7 @@ class InfoPanel extends React.Component {
       storageName, folderName, noteLink, updatedAt, createdAt, exportAsMd, exportAsTxt, exportAsHtml, exportAsPdf, wordCount, letterCount, type, print
     } = this.props
     return (
-      <div className='infoPanel' styleName='control-infoButton-panel' style={{display: 'none'}}>
+      <div className='infoPanel' styleName='control-infoButton-panel' style={{ display: 'none' }}>
         <div>
           <p styleName='modification-date'>{updatedAt}</p>
           <p styleName='modification-date-desc'>{i18n.__('MODIFICATION DATE')}</p>

--- a/browser/main/Detail/InfoPanelTrashed.js
+++ b/browser/main/Detail/InfoPanelTrashed.js
@@ -7,7 +7,7 @@ import i18n from 'browser/lib/i18n'
 const InfoPanelTrashed = ({
   storageName, folderName, updatedAt, createdAt, exportAsMd, exportAsTxt, exportAsHtml, exportAsPdf
 }) => (
-  <div className='infoPanel' styleName='control-infoButton-panel-trash' style={{display: 'none'}}>
+  <div className='infoPanel' styleName='control-infoButton-panel-trash' style={{ display: 'none' }}>
     <div>
       <p styleName='modification-date'>{updatedAt}</p>
       <p styleName='modification-date-desc'>{i18n.__('MODIFICATION DATE')}</p>

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -77,7 +77,7 @@ class MarkdownNoteDetail extends React.Component {
     if (!this.state.isMovingNote && (isNewNote || hasDeletedTags)) {
       if (this.saveQueue != null) this.saveNow()
       this.setState({
-        note: Object.assign({linesHighlighted: []}, nextProps.note)
+        note: Object.assign({ linesHighlighted: [] }, nextProps.note)
       }, () => {
         this.refs.content.reload()
         if (this.refs.tags) this.refs.tags.reset()
@@ -111,7 +111,7 @@ class MarkdownNoteDetail extends React.Component {
 
   updateNote (note) {
     note.updatedAt = new Date()
-    this.setState({note}, () => {
+    this.setState({ note }, () => {
       this.save()
     })
   }
@@ -242,7 +242,7 @@ class MarkdownNoteDetail extends React.Component {
 
     if (isTrashed) {
       if (confirmDeleteNote(confirmDeletion, true)) {
-        const {note, dispatch} = this.props
+        const { note, dispatch } = this.props
         dataApi
           .deleteNote(note.storage, note.key)
           .then((data) => {
@@ -308,9 +308,9 @@ class MarkdownNoteDetail extends React.Component {
   handleToggleLockButton (event, noteStatus) {
     // first argument event is not used
     if (noteStatus === 'CODE') {
-      this.setState({isLockButtonShown: true})
+      this.setState({ isLockButtonShown: true })
     } else {
-      this.setState({isLockButtonShown: false})
+      this.setState({ isLockButtonShown: false })
     }
   }
 

--- a/browser/main/Detail/SnippetNoteDetail.js
+++ b/browser/main/Detail/SnippetNoteDetail.js
@@ -8,7 +8,7 @@ import StarButton from './StarButton'
 import TagSelect from './TagSelect'
 import FolderSelect from './FolderSelect'
 import dataApi from 'browser/main/lib/dataApi'
-import {hashHistory} from 'react-router'
+import { hashHistory } from 'react-router'
 import ee from 'browser/main/lib/eventEmitter'
 import CodeMirror from 'codemirror'
 import 'codemirror-mode-elixir'
@@ -17,8 +17,7 @@ import StatusBar from '../StatusBar'
 import context from 'browser/lib/context'
 import ConfigManager from 'browser/main/lib/ConfigManager'
 import _ from 'lodash'
-import {findNoteTitle} from 'browser/lib/findNoteTitle'
-import convertModeName from 'browser/lib/convertModeName'
+import { findNoteTitle } from 'browser/lib/findNoteTitle'
 import AwsMobileAnalyticsConfig from 'browser/main/lib/AwsMobileAnalyticsConfig'
 import FullscreenButton from './FullscreenButton'
 import TrashButton from './TrashButton'
@@ -49,7 +48,7 @@ class SnippetNoteDetail extends React.Component {
       note: Object.assign({
         description: ''
       }, props.note, {
-        snippets: props.note.snippets.map((snippet) => Object.assign({linesHighlighted: []}, snippet))
+        snippets: props.note.snippets.map((snippet) => Object.assign({ linesHighlighted: [] }, snippet))
       })
     }
 
@@ -77,7 +76,7 @@ class SnippetNoteDetail extends React.Component {
       const nextNote = Object.assign({
         description: ''
       }, nextProps.note, {
-        snippets: nextProps.note.snippets.map((snippet) => Object.assign({linesHighlighted: []}, snippet))
+        snippets: nextProps.note.snippets.map((snippet) => Object.assign({ linesHighlighted: [] }, snippet))
       })
 
       this.setState({
@@ -203,7 +202,7 @@ class SnippetNoteDetail extends React.Component {
 
     if (isTrashed) {
       if (confirmDeleteNote(confirmDeletion, true)) {
-        const {note, dispatch} = this.props
+        const { note, dispatch } = this.props
         dataApi
           .deleteNote(note.storage, note.key)
           .then((data) => {
@@ -263,8 +262,8 @@ class SnippetNoteDetail extends React.Component {
         const visiblePart = lastVisibleTab.offsetWidth + lastVisibleTab.offsetLeft - left
         const isFullyVisible = visiblePart > lastVisibleTab.offsetWidth * this.scrollToNextTabThreshold
         const scrollToTab = (isFullyVisible && lastVisibleTab.previousSibling)
-            ? lastVisibleTab.previousSibling
-            : lastVisibleTab
+          ? lastVisibleTab.previousSibling
+          : lastVisibleTab
 
         // FIXME use `scrollIntoView()` instead of custom method after update to Electron2.0 (with Chrome 61 its possible animate the scroll)
         this.moveToTab(scrollToTab)
@@ -286,8 +285,8 @@ class SnippetNoteDetail extends React.Component {
       const visiblePart = width + left - lastVisibleTab.offsetLeft
       const isFullyVisible = visiblePart > lastVisibleTab.offsetWidth * this.scrollToNextTabThreshold
       const scrollToTab = (isFullyVisible && lastVisibleTab.nextSibling)
-          ? lastVisibleTab.nextSibling
-          : lastVisibleTab
+        ? lastVisibleTab.nextSibling
+        : lastVisibleTab
 
       // FIXME use `scrollIntoView()` instead of custom method after update to Electron2.0 (with Chrome 61 its possible animate the scroll)
       this.moveToTab(scrollToTab)
@@ -318,7 +317,7 @@ class SnippetNoteDetail extends React.Component {
     snippets[index] = draggedSnippet
     const snippetIndex = index
 
-    const note = Object.assign({}, this.state.note, {snippets})
+    const note = Object.assign({}, this.state.note, { snippets })
     this.setState({ note, snippetIndex }, () => {
       this.save()
       this.refs['code-' + index].reload()
@@ -347,7 +346,7 @@ class SnippetNoteDetail extends React.Component {
   deleteSnippetByIndex (index) {
     const snippets = this.state.note.snippets.slice()
     snippets.splice(index, 1)
-    const note = Object.assign({}, this.state.note, {snippets})
+    const note = Object.assign({}, this.state.note, { snippets })
     const snippetIndex = this.state.snippetIndex >= snippets.length
       ? snippets.length - 1
       : this.state.snippetIndex
@@ -381,7 +380,7 @@ class SnippetNoteDetail extends React.Component {
         name: mode
       })
     }
-    this.setState(state => ({note: Object.assign(state.note, {snippets: snippets})}))
+    this.setState(state => ({ note: Object.assign(state.note, { snippets: snippets }) }))
 
     this.setState(state => ({
       note: state.note
@@ -394,7 +393,7 @@ class SnippetNoteDetail extends React.Component {
     return (e) => {
       const snippets = this.state.note.snippets.slice()
       snippets[index].mode = name
-      this.setState(state => ({note: Object.assign(state.note, {snippets: snippets})}))
+      this.setState(state => ({ note: Object.assign(state.note, { snippets: snippets }) }))
 
       this.setState(state => ({
         note: state.note
@@ -414,7 +413,7 @@ class SnippetNoteDetail extends React.Component {
       snippets[index].content = this.refs['code-' + index].value
       snippets[index].linesHighlighted = e.options.linesHighlighted
 
-      this.setState(state => ({note: Object.assign(state.note, {snippets: snippets})}))
+      this.setState(state => ({ note: Object.assign(state.note, { snippets: snippets }) }))
       this.setState(state => ({
         note: state.note
       }), () => {
@@ -596,7 +595,7 @@ class SnippetNoteDetail extends React.Component {
     const enableRightArrow = visibleTabs.scrollLeft !== allTabs.scrollWidth - visibleTabs.offsetWidth
     const enableLeftArrow = visibleTabs.scrollLeft !== 0
 
-    return {showArrows, enableRightArrow, enableLeftArrow}
+    return { showArrows, enableRightArrow, enableLeftArrow }
   }
 
   addSnippet () {
@@ -704,7 +703,7 @@ class SnippetNoteDetail extends React.Component {
       const isActive = this.state.snippetIndex === index
       return <div styleName='tabView'
         key={index}
-        style={{zIndex: isActive ? 5 : 4}}
+        style={{ zIndex: isActive ? 5 : 4 }}
       >
         {snippet.mode === 'Markdown' || snippet.mode === 'GitHub Flavored Markdown'
           ? <MarkdownEditor styleName='tabView-content'

--- a/browser/main/Detail/StarButton.js
+++ b/browser/main/Detail/StarButton.js
@@ -36,7 +36,8 @@ class StarButton extends React.Component {
     const { className } = this.props
 
     return (
-      <button className={_.isString(className)
+      <button
+        className={_.isString(className)
           ? 'StarButton ' + className
           : 'StarButton'
         }

--- a/browser/main/Detail/TagSelect.js
+++ b/browser/main/Detail/TagSelect.js
@@ -223,7 +223,8 @@ class TagSelect extends React.Component {
     const { newTag, suggestions } = this.state
 
     return (
-      <div className={_.isString(className)
+      <div
+        className={_.isString(className)
           ? 'TagSelect ' + className
           : 'TagSelect'
         }

--- a/browser/main/Detail/ToggleModeButton.js
+++ b/browser/main/Detail/ToggleModeButton.js
@@ -20,7 +20,7 @@ const ToggleModeButton = ({
 
 ToggleModeButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  editorType: PropTypes.string.Required
+  editorType: PropTypes.string.isRequired
 }
 
 export default CSSModules(ToggleModeButton, styles)

--- a/browser/main/Main.js
+++ b/browser/main/Main.js
@@ -1,3 +1,4 @@
+/* globals CodeMirror */
 import PropTypes from 'prop-types'
 import React from 'react'
 import CSSModules from 'browser/lib/CSSModules'
@@ -184,7 +185,7 @@ class Main extends React.Component {
     const { config } = this.props
     const { ui } = config
 
-    const newUI = Object.assign(ui, {showMenuBar: !ui.showMenuBar})
+    const newUI = Object.assign(ui, { showMenuBar: !ui.showMenuBar })
     const newConfig = Object.assign(config, newUI)
     ConfigManager.set(newConfig)
   }

--- a/browser/main/NewNoteButton/index.js
+++ b/browser/main/NewNoteButton/index.js
@@ -67,7 +67,7 @@ class NewNoteButton extends React.Component {
     }
 
     if (storage == null) this.showMessageBox(i18n.__('No storage to create a note'))
-    const folder = _.find(storage.folders, {key: params.folderKey}) || storage.folders[0]
+    const folder = _.find(storage.folders, { key: params.folderKey }) || storage.folders[0]
     if (folder == null) this.showMessageBox(i18n.__('No folder to create a note'))
 
     return {

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -378,7 +378,7 @@ class NoteList extends React.Component {
     const storage = data.storageMap.get(storageKey)
     if (storage === undefined) return []
 
-    const folder = _.find(storage.folders, {key: folderKey})
+    const folder = _.find(storage.folders, { key: folderKey })
     if (folder === undefined) {
       const storageNoteSet = data.storageNoteMap.get(storage.key) || []
       return storageNoteSet.map((uniqueKey) => data.noteMap.get(uniqueKey))
@@ -614,20 +614,20 @@ class NoteList extends React.Component {
     }
 
     Promise.all(
-        selectedNotes.map((note) => {
-          note = updateFunc(note)
-          return dataApi
-              .updateNote(note.storage, note.key, note)
-        })
+      selectedNotes.map((note) => {
+        note = updateFunc(note)
+        return dataApi
+          .updateNote(note.storage, note.key, note)
+      })
     )
-        .then((updatedNotes) => {
-          updatedNotes.forEach((note) => {
-            dispatch({
-              type: 'UPDATE_NOTE',
-              note
-            })
+      .then((updatedNotes) => {
+        updatedNotes.forEach((note) => {
+          dispatch({
+            type: 'UPDATE_NOTE',
+            note
           })
         })
+      })
 
     if (cleanSelection) {
       this.selectNextNote()
@@ -665,22 +665,22 @@ class NoteList extends React.Component {
             .deleteNote(note.storage, note.key)
         })
       )
-      .then((data) => {
-        const dispatchHandler = () => {
-          data.forEach((item) => {
-            dispatch({
-              type: 'DELETE_NOTE',
-              storageKey: item.storageKey,
-              noteKey: item.noteKey
+        .then((data) => {
+          const dispatchHandler = () => {
+            data.forEach((item) => {
+              dispatch({
+                type: 'DELETE_NOTE',
+                storageKey: item.storageKey,
+                noteKey: item.noteKey
+              })
             })
-          })
-        }
-        ee.once('list:next', dispatchHandler)
-      })
-      .then(() => ee.emit('list:next'))
-      .catch((err) => {
-        console.error('Cannot Delete note: ' + err)
-      })
+          }
+          ee.once('list:next', dispatchHandler)
+        })
+        .then(() => ee.emit('list:next'))
+        .catch((err) => {
+          console.error('Cannot Delete note: ' + err)
+        })
     } else {
       if (!confirmDeleteNote(confirmDeletion, false)) return
 
@@ -689,22 +689,22 @@ class NoteList extends React.Component {
           note.isTrashed = true
 
           return dataApi
-          .updateNote(note.storage, note.key, note)
+            .updateNote(note.storage, note.key, note)
         })
       )
-      .then((newNotes) => {
-        newNotes.forEach((newNote) => {
-          dispatch({
-            type: 'UPDATE_NOTE',
-            note: newNote
+        .then((newNotes) => {
+          newNotes.forEach((newNote) => {
+            dispatch({
+              type: 'UPDATE_NOTE',
+              note: newNote
+            })
           })
+          AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
         })
-        AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
-      })
-      .then(() => ee.emit('list:next'))
-      .catch((err) => {
-        console.error('Notes could not go to trash: ' + err)
-      })
+        .then(() => ee.emit('list:next'))
+        .catch((err) => {
+          console.error('Notes could not go to trash: ' + err)
+        })
     }
     this.setState({ selectedNoteKeys: [] })
   }
@@ -748,7 +748,7 @@ class NoteList extends React.Component {
 
         hashHistory.push({
           pathname: location.pathname,
-          query: {key: note.key}
+          query: { key: note.key }
         })
       })
   }
@@ -790,12 +790,12 @@ class NoteList extends React.Component {
   }
 
   publishMarkdownNow () {
-    const {selectedNoteKeys} = this.state
+    const { selectedNoteKeys } = this.state
     const notes = this.notes.map((note) => Object.assign({}, note))
     const selectedNotes = findNotesByKeys(notes, selectedNoteKeys)
     const firstNote = selectedNotes[0]
     const config = ConfigManager.get()
-    const {address, token, authMethod, username, password} = config.blog
+    const { address, token, authMethod, username, password } = config.blog
     let authToken = ''
     if (authMethod === 'USER') {
       authToken = `Basic ${window.btoa(`${username}:${password}`)}`
@@ -830,7 +830,8 @@ class NoteList extends React.Component {
     }).then(res => res.json())
       .then(response => {
         if (_.isNil(response.link) || _.isNil(response.id)) {
-          return Promise.reject()
+          // Note: Reject should be called with new Error()
+          return Promise.reject() // eslint-disable-line
         }
         firstNote.blog = {
           blogLink: response.link,
@@ -895,7 +896,7 @@ class NoteList extends React.Component {
     if (!location.pathname.match(/\/trashed/)) this.addNotesFromFiles(filepaths)
   }
 
- // Add notes to the current folder
+  // Add notes to the current folder
   addNotesFromFiles (filepaths) {
     const { dispatch, location } = this.props
     const { storage, folder } = this.resolveTargetFolder()
@@ -905,7 +906,7 @@ class NoteList extends React.Component {
       fs.readFile(filepath, (err, data) => {
         if (err) throw Error('File reading error: ', err)
 
-        fs.stat(filepath, (err, {mtime, birthtime}) => {
+        fs.stat(filepath, (err, { mtime, birthtime }) => {
           if (err) throw Error('File stat reading error: ', err)
 
           const content = data.toString()
@@ -918,23 +919,23 @@ class NoteList extends React.Component {
             updatedAt: mtime
           }
           dataApi.createNote(storage.key, newNote)
-          .then((note) => {
-            attachmentManagement.importAttachments(note.content, filepath, storage.key, note.key)
-            .then((newcontent) => {
-              note.content = newcontent
+            .then((note) => {
+              attachmentManagement.importAttachments(note.content, filepath, storage.key, note.key)
+                .then((newcontent) => {
+                  note.content = newcontent
 
-              dataApi.updateNote(storage.key, note.key, note)
+                  dataApi.updateNote(storage.key, note.key, note)
 
-              dispatch({
-                type: 'UPDATE_NOTE',
-                note: note
-              })
-              hashHistory.push({
-                pathname: location.pathname,
-                query: {key: getNoteKey(note)}
-              })
+                  dispatch({
+                    type: 'UPDATE_NOTE',
+                    note: note
+                  })
+                  hashHistory.push({
+                    pathname: location.pathname,
+                    query: { key: getNoteKey(note) }
+                  })
+                })
             })
-          })
         })
       })
     })
@@ -961,7 +962,7 @@ class NoteList extends React.Component {
     }
 
     if (storage == null) this.showMessageBox('No storage for importing note(s)')
-    const folder = _.find(storage.folders, {key: params.folderKey}) || storage.folders[0]
+    const folder = _.find(storage.folders, { key: params.folderKey }) || storage.folders[0]
     if (folder == null) this.showMessageBox('No folder for importing note(s)')
 
     return {
@@ -1004,11 +1005,13 @@ class NoteList extends React.Component {
     const sortFunc = sortBy === 'CREATED_AT'
       ? sortByCreatedAt
       : sortBy === 'ALPHABETICAL'
-      ? sortByAlphabetical
-      : sortByUpdatedAt
+        ? sortByAlphabetical
+        : sortByUpdatedAt
     const sortedNotes = location.pathname.match(/\/starred|\/trash/)
-        ? this.getNotes().sort(sortFunc)
-        : this.sortByPin(this.getNotes().sort(sortFunc))
+      ? this.getNotes().sort(sortFunc)
+      : this.sortByPin(this.getNotes().sort(sortFunc))
+    // Note: Filter is not returning a value in every case
+    // eslint-disable-next-line
     this.notes = notes = sortedNotes.filter((note) => {
       // this is for the trash box
       if (note.isTrashed !== true || location.pathname === '/trashed') return true
@@ -1114,7 +1117,9 @@ class NoteList extends React.Component {
             </select>
           </div>
           <div styleName='control-button-area'>
-            <button title={i18n.__('Default View')} styleName={config.listStyle === 'DEFAULT'
+            <button
+              title={i18n.__('Default View')}
+              styleName={config.listStyle === 'DEFAULT'
                 ? 'control-button--active'
                 : 'control-button'
               }
@@ -1122,7 +1127,9 @@ class NoteList extends React.Component {
             >
               <img styleName='iconTag' src='../resources/icon/icon-column.svg' />
             </button>
-            <button title={i18n.__('Compressed View')} styleName={config.listStyle === 'SMALL'
+            <button
+              title={i18n.__('Compressed View')}
+              styleName={config.listStyle === 'SMALL'
                 ? 'control-button--active'
                 : 'control-button'
               }

--- a/browser/main/SideNav/ListButton.js
+++ b/browser/main/SideNav/ListButton.js
@@ -9,8 +9,8 @@ const ListButton = ({
 }) => (
   <button styleName={isTagActive ? 'non-active-button' : 'active-button'} onClick={onClick}>
     <img src={isTagActive
-        ? '../resources/icon/icon-list.svg'
-        : '../resources/icon/icon-list-active.svg'
+      ? '../resources/icon/icon-list.svg'
+      : '../resources/icon/icon-list-active.svg'
     }
     />
     <span styleName='tooltip'>{i18n.__('Notes')}</span>

--- a/browser/main/SideNav/StorageItem.js
+++ b/browser/main/SideNav/StorageItem.js
@@ -193,35 +193,35 @@ class StorageItem extends React.Component {
       multiSelections: false
     }
     dialog.showOpenDialog(remote.getCurrentWindow(), options,
-    (paths) => {
-      if (paths && paths.length === 1) {
-        const { storage, dispatch } = this.props
-        dataApi
-          .exportFolder(storage.key, folder.key, fileType, paths[0])
-          .then((data) => {
-            dispatch({
-              type: 'EXPORT_FOLDER',
-              storage: data.storage,
-              folderKey: data.folderKey,
-              fileType: data.fileType
+      (paths) => {
+        if (paths && paths.length === 1) {
+          const { storage, dispatch } = this.props
+          dataApi
+            .exportFolder(storage.key, folder.key, fileType, paths[0])
+            .then((data) => {
+              dispatch({
+                type: 'EXPORT_FOLDER',
+                storage: data.storage,
+                folderKey: data.folderKey,
+                fileType: data.fileType
+              })
+              return data
             })
-            return data
-          })
-          .then(data => {
-            dialog.showMessageBox(remote.getCurrentWindow(), {
-              type: 'info',
-              message: 'Exported to "' + data.exportDir + '"'
+            .then(data => {
+              dialog.showMessageBox(remote.getCurrentWindow(), {
+                type: 'info',
+                message: 'Exported to "' + data.exportDir + '"'
+              })
             })
-          })
-          .catch(err => {
-            dialog.showErrorBox(
-              'Export error',
-              err ? err.message || err : 'Unexpected error during export'
-            )
-            throw err
-          })
-      }
-    })
+            .catch(err => {
+              dialog.showErrorBox(
+                'Export error',
+                err ? err.message || err : 'Unexpected error during export'
+              )
+              throw err
+            })
+        }
+      })
   }
 
   handleFolderDeleteClick (e, folder) {
@@ -269,18 +269,18 @@ class StorageItem extends React.Component {
     Promise.all(
       noteData.map((note) => dataApi.moveNote(note.storage, note.key, storage.key, folder.key))
     )
-    .then((createdNoteData) => {
-      createdNoteData.forEach((newNote) => {
-        dispatch({
-          type: 'MOVE_NOTE',
-          originNote: noteData.find((note) => note.content === newNote.oldContent),
-          note: newNote
+      .then((createdNoteData) => {
+        createdNoteData.forEach((newNote) => {
+          dispatch({
+            type: 'MOVE_NOTE',
+            originNote: noteData.find((note) => note.content === newNote.oldContent),
+            note: newNote
+          })
         })
       })
-    })
-    .catch((err) => {
-      console.error(`error on delete notes: ${err}`)
-    })
+      .catch((err) => {
+        console.error(`error on delete notes: ${err}`)
+      })
   }
 
   handleDrop (e, storage, folder, dispatch, location) {
@@ -342,10 +342,11 @@ class StorageItem extends React.Component {
       <div styleName={isFolded ? 'root--folded' : 'root'}
         key={storage.key}
       >
-        <div styleName={isActive
-          ? 'header--active'
-          : 'header'
-        }
+        <div
+          styleName={isActive
+            ? 'header--active'
+            : 'header'
+          }
           onContextMenu={(e) => this.handleHeaderContextMenu(e)}
         >
           <button styleName='header-toggleButton'
@@ -370,7 +371,7 @@ class StorageItem extends React.Component {
             onClick={(e) => this.handleHeaderInfoClick(e)}
           >
             <span styleName='header-info-name'>
-              {isFolded ? _.truncate(storage.name, {length: 1, omission: ''}) : storage.name}
+              {isFolded ? _.truncate(storage.name, { length: 1, omission: '' }) : storage.name}
             </span>
             {isFolded &&
               <span styleName='header-info--folded-tooltip'>

--- a/browser/main/SideNav/TagButton.js
+++ b/browser/main/SideNav/TagButton.js
@@ -9,8 +9,8 @@ const TagButton = ({
 }) => (
   <button styleName={isTagActive ? 'active-button' : 'non-active-button'} onClick={onClick}>
     <img src={isTagActive
-        ? '../resources/icon/icon-tag-active.svg'
-        : '../resources/icon/icon-tag.svg'
+      ? '../resources/icon/icon-tag-active.svg'
+      : '../resources/icon/icon-tag.svg'
     }
     />
     <span styleName='tooltip'>{i18n.__('Tags')}</span>

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -15,12 +15,13 @@ import EventEmitter from 'browser/main/lib/eventEmitter'
 import PreferenceButton from './PreferenceButton'
 import ListButton from './ListButton'
 import TagButton from './TagButton'
-import {SortableContainer} from 'react-sortable-hoc'
+import { SortableContainer } from 'react-sortable-hoc'
 import i18n from 'browser/lib/i18n'
 import context from 'browser/lib/context'
 import { remote } from 'electron'
 import { confirmDeleteNote } from 'browser/lib/confirmDeleteNote'
 import ColorPicker from 'browser/components/ColorPicker'
+import _ from 'loadash'
 
 function matchActiveTags (tags, activeTags) {
   return _.every(activeTags, v => tags.indexOf(v) >= 0)
@@ -150,9 +151,9 @@ class SideNav extends React.Component {
   }
 
   handleColorPickerConfirm (color) {
-    const { dispatch, config: {coloredTags} } = this.props
+    const { dispatch, config: { coloredTags } } = this.props
     const { colorPicker: { tagName } } = this.state
-    const newColoredTags = Object.assign({}, coloredTags, {[tagName]: color.hex})
+    const newColoredTags = Object.assign({}, coloredTags, { [tagName]: color.hex })
 
     const config = { coloredTags: newColoredTags }
     ConfigManager.set(config)
@@ -164,7 +165,7 @@ class SideNav extends React.Component {
   }
 
   handleColorPickerReset () {
-    const { dispatch, config: {coloredTags} } = this.props
+    const { dispatch, config: { coloredTags } } = this.props
     const { colorPicker: { tagName } } = this.state
     const newColoredTags = Object.assign({}, coloredTags)
 
@@ -182,7 +183,7 @@ class SideNav extends React.Component {
   handleToggleButtonClick (e) {
     const { dispatch, config } = this.props
 
-    ConfigManager.set({isSideNavFolded: !config.isSideNavFolded})
+    ConfigManager.set({ isSideNavFolded: !config.isSideNavFolded })
     dispatch({
       type: 'SET_IS_SIDENAV_FOLDED',
       isFolded: !config.isSideNavFolded
@@ -205,7 +206,7 @@ class SideNav extends React.Component {
   }
 
   onSortEnd (storage) {
-    return ({oldIndex, newIndex}) => {
+    return ({ oldIndex, newIndex }) => {
       const { dispatch } = this.props
       dataApi
         .reorderFolder(storage.key, oldIndex, newIndex)
@@ -326,7 +327,7 @@ class SideNav extends React.Component {
       return new Set()
     }
     const relatedNotes = noteMap.map(
-      note => ({key: note.key, tags: note.tags})
+      note => ({ key: note.key, tags: note.tags })
     ).filter(
       note => activeTags.every(tag => note.tags.includes(tag))
     )
@@ -387,14 +388,14 @@ class SideNav extends React.Component {
     const { confirmDeletion } = this.props.config.ui
     if (!confirmDeleteNote(confirmDeletion, true)) return
     Promise.all(deletionPromises)
-    .then((arrayOfStorageAndNoteKeys) => {
-      arrayOfStorageAndNoteKeys.forEach(({ storageKey, noteKey }) => {
-        dispatch({ type: 'DELETE_NOTE', storageKey, noteKey })
+      .then((arrayOfStorageAndNoteKeys) => {
+        arrayOfStorageAndNoteKeys.forEach(({ storageKey, noteKey }) => {
+          dispatch({ type: 'DELETE_NOTE', storageKey, noteKey })
+        })
       })
-    })
-    .catch((err) => {
-      console.error('Cannot Delete note: ' + err)
-    })
+      .catch((err) => {
+        console.error('Cannot Delete note: ' + err)
+      })
   }
 
   handleFilterButtonContextMenu (event) {

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -1,3 +1,4 @@
+/* globals _ */
 import PropTypes from 'prop-types'
 import React from 'react'
 import CSSModules from 'browser/lib/CSSModules'
@@ -21,7 +22,6 @@ import context from 'browser/lib/context'
 import { remote } from 'electron'
 import { confirmDeleteNote } from 'browser/lib/confirmDeleteNote'
 import ColorPicker from 'browser/components/ColorPicker'
-import _ from 'loadash'
 
 function matchActiveTags (tags, activeTags) {
   return _.every(activeTags, v => tags.indexOf(v) >= 0)

--- a/browser/main/StatusBar/index.js
+++ b/browser/main/StatusBar/index.js
@@ -14,7 +14,6 @@ const { dialog } = remote
 const zoomOptions = [0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
 
 class StatusBar extends React.Component {
-
   constructor (props) {
     super(props)
     this.handleZoomInMenuItem = this.handleZoomInMenuItem.bind(this)

--- a/browser/main/TopBar/index.js
+++ b/browser/main/TopBar/index.js
@@ -56,7 +56,9 @@ class TopBar extends React.Component {
       search: '',
       isSearching: false
     })
-    this.refs.search.childNodes[0].blur
+
+    // commented next line as it has no effect - removing OK?
+    // this.refs.search.childNodes[0].blur
     router.push('/searched')
     e.preventDefault()
   }
@@ -86,7 +88,8 @@ class TopBar extends React.Component {
     }
 
     // When the key is an alphabet, del, enter or ctr
-    if (e.keyCode <= 90 || e.keyCode >= 186 && e.keyCode <= 222) {
+    // Note: Liniting complaint about mixed usage of || and && --> are braces required to fix it?
+    if (e.keyCode <= 90 || e.keyCode >= 186 && e.keyCode <= 222) { // eslint-disable-line
       this.setState({
         isAlphabet: true
       })
@@ -205,15 +208,15 @@ class TopBar extends React.Component {
           </div>
         </div>
         {location.pathname === '/trashed' ? ''
-        : <NewNoteButton
-          {..._.pick(this.props, [
-            'dispatch',
-            'data',
-            'config',
-            'params',
-            'location'
-          ])}
-        />}
+          : <NewNoteButton
+            {..._.pick(this.props, [
+              'dispatch',
+              'data',
+              'config',
+              'params',
+              'location'
+            ])}
+          />}
       </div>
     )
   }

--- a/browser/main/index.js
+++ b/browser/main/index.js
@@ -3,12 +3,12 @@ import Main from './Main'
 import store from './store'
 import React from 'react'
 import ReactDOM from 'react-dom'
-require('!!style!css!stylus?sourceMap!./global.styl')
 import { Router, Route, IndexRoute, IndexRedirect, hashHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
+import i18n from 'browser/lib/i18n'
+require('!!style!css!stylus?sourceMap!./global.styl') // eslint-disable-line
 require('./lib/ipcClient')
 require('../lib/customMeta')
-import i18n from 'browser/lib/i18n'
 
 const electron = require('electron')
 

--- a/browser/main/lib/ZoomManager.js
+++ b/browser/main/lib/ZoomManager.js
@@ -10,7 +10,7 @@ function _init () {
 }
 
 function _saveZoom (zoomFactor) {
-  ConfigManager.set({zoom: zoomFactor})
+  ConfigManager.set({ zoom: zoomFactor })
 }
 
 function setZoom (zoomFactor, noSave = false) {

--- a/browser/main/lib/dataApi/createNote.js
+++ b/browser/main/lib/dataApi/createNote.js
@@ -48,7 +48,7 @@ function createNote (storageKey, input) {
 
   return resolveStorageData(targetStorage)
     .then(function checkFolderExists (storage) {
-      if (_.find(storage.folders, {key: input.folder}) == null) {
+      if (_.find(storage.folders, { key: input.folder }) == null) {
         throw new Error('Target folder doesn\'t exist.')
       }
       return storage

--- a/browser/main/lib/dataApi/deleteFolder.js
+++ b/browser/main/lib/dataApi/deleteFolder.js
@@ -3,7 +3,6 @@ const path = require('path')
 const resolveStorageData = require('./resolveStorageData')
 const resolveStorageNotes = require('./resolveStorageNotes')
 const CSON = require('@rokt33r/season')
-const sander = require('sander')
 const { findStorage } = require('browser/lib/findStorage')
 const deleteSingleNote = require('./deleteNote')
 

--- a/browser/main/lib/dataApi/exportFolder.js
+++ b/browser/main/lib/dataApi/exportFolder.js
@@ -46,7 +46,7 @@ function exportFolder (storageKey, folderKey, fileType, exportDir) {
       return Promise.all(notes
         .filter(note => note.folder === folderKey && note.isTrashed === false && note.type === 'MARKDOWN_NOTE')
         .map(note => {
-          const notePath = path.join(exportDir, `${filenamify(note.title, {replacement: '_'})}.${fileType}`)
+          const notePath = path.join(exportDir, `${filenamify(note.title, { replacement: '_' })}.${fileType}`)
           return exportNote(note.key, storage.path, note.content, notePath, null)
         })
       ).then(() => ({

--- a/browser/main/lib/dataApi/exportNote.js
+++ b/browser/main/lib/dataApi/exportNote.js
@@ -51,13 +51,13 @@ function exportNote (nodeKey, storageKey, noteContent, targetPath, outputFormatt
   const tasks = prepareTasks(exportTasks, storagePath, path.dirname(targetPath))
 
   return Promise.all(tasks.map((task) => copyFile(task.src, task.dst)))
-  .then(() => exportedData)
-  .then(data => {
-    return saveToFile(data, targetPath)
-  }).catch((err) => {
-    rollbackExport(tasks)
-    throw err
-  })
+    .then(() => exportedData)
+    .then(data => {
+      return saveToFile(data, targetPath)
+    }).catch((err) => {
+      rollbackExport(tasks)
+      throw err
+    })
 }
 
 function prepareTasks (tasks, storagePath, targetPath) {

--- a/browser/main/lib/dataApi/exportStorage.js
+++ b/browser/main/lib/dataApi/exportStorage.js
@@ -30,13 +30,13 @@ function exportStorage (storageKey, fileType, exportDir) {
 
   return resolveStorageData(targetStorage)
     .then(storage => (
-      resolveStorageNotes(storage).then(notes => ({storage, notes}))
+      resolveStorageNotes(storage).then(notes => ({ storage, notes }))
     ))
     .then(function exportNotes (data) {
       const { storage, notes } = data
       const folderNamesMapping = {}
       storage.folders.forEach(folder => {
-        const folderExportedDir = path.join(exportDir, filenamify(folder.name, {replacement: '_'}))
+        const folderExportedDir = path.join(exportDir, filenamify(folder.name, { replacement: '_' }))
         folderNamesMapping[folder.key] = folderExportedDir
         // make sure directory exists
         try {
@@ -47,7 +47,7 @@ function exportStorage (storageKey, fileType, exportDir) {
         .filter(note => !note.isTrashed && note.type === 'MARKDOWN_NOTE')
         .forEach(markdownNote => {
           const folderExportedDir = folderNamesMapping[markdownNote.folder]
-          const snippetName = `${filenamify(markdownNote.title, {replacement: '_'})}.${fileType}`
+          const snippetName = `${filenamify(markdownNote.title, { replacement: '_' })}.${fileType}`
           const notePath = path.join(folderExportedDir, snippetName)
           fs.writeFileSync(notePath, markdownNote.content)
         })

--- a/browser/main/lib/dataApi/init.js
+++ b/browser/main/lib/dataApi/init.js
@@ -1,4 +1,3 @@
-'use strict'
 const _ = require('lodash')
 const resolveStorageData = require('./resolveStorageData')
 const resolveStorageNotes = require('./resolveStorageNotes')
@@ -40,7 +39,7 @@ function init () {
 
   const fetchNotes = function (storages) {
     const findNotesFromEachStorage = storages
-    .filter(storage => fs.existsSync(storage.path))
+      .filter(storage => fs.existsSync(storage.path))
       .map((storage) => {
         return resolveStorageNotes(storage)
           .then((notes) => {

--- a/browser/main/lib/dataApi/migrateFromV5Storage.js
+++ b/browser/main/lib/dataApi/migrateFromV5Storage.js
@@ -12,7 +12,7 @@ function migrateFromV5Storage (storageKey, data) {
     const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
     if (!_.isArray(cachedStorageList)) throw new Error('Target storage doesn\'t exist.')
 
-    targetStorage = _.find(cachedStorageList, {key: storageKey})
+    targetStorage = _.find(cachedStorageList, { key: storageKey })
     if (targetStorage == null) throw new Error('Target storage doesn\'t exist.')
   } catch (e) {
     return Promise.reject(e)

--- a/browser/main/lib/dataApi/migrateFromV6Storage.js
+++ b/browser/main/lib/dataApi/migrateFromV6Storage.js
@@ -64,8 +64,9 @@ function migrateFromV5Storage (storagePath) {
           })
 
           const noteDirPath = path.join(storagePath, 'notes')
+          // Note: We could probably use a forEach instead of map
           notes
-            .map(function saveNote (note) {
+            .map(function saveNote (note) { // eslint-disable-line
               CSON.writeFileSync(path.join(noteDirPath, note.key) + '.cson', note)
             })
           return true
@@ -86,4 +87,3 @@ function migrateFromV5Storage (storagePath) {
 }
 
 module.exports = migrateFromV5Storage
-

--- a/browser/main/lib/dataApi/moveNote.js
+++ b/browser/main/lib/dataApi/moveNote.js
@@ -1,7 +1,6 @@
 const resolveStorageData = require('./resolveStorageData')
 const _ = require('lodash')
 const path = require('path')
-const fs = require('fs')
 const CSON = require('@rokt33r/season')
 const keygen = require('browser/lib/keygen')
 const sander = require('sander')
@@ -58,7 +57,7 @@ function moveNote (storageKey, noteKey, newStorageKey, newFolderKey) {
             })
         })
         .then(function checkFolderExistsAndPrepareNoteData (newStorage) {
-          if (_.find(newStorage.folders, {key: newFolderKey}) == null) throw new Error('Target folder doesn\'t exist.')
+          if (_.find(newStorage.folders, { key: newFolderKey }) == null) throw new Error('Target folder doesn\'t exist.')
 
           noteData.folder = newFolderKey
           noteData.key = newNoteKey

--- a/browser/main/lib/dataApi/renameStorage.js
+++ b/browser/main/lib/dataApi/renameStorage.js
@@ -17,13 +17,15 @@ function renameStorage (key, name) {
     console.error(err)
     return Promise.reject(err)
   }
-  const targetStorage = _.find(cachedStorageList, {key: key})
-  if (targetStorage == null) return Promise.reject('Storage')
+  const targetStorage = _.find(cachedStorageList, { key: key })
+  // Note: Promise.reject should create new Error - disabled liniting for now
+  if (targetStorage == null) return Promise.reject('Storage') // eslint-disable-line
 
   targetStorage.name = name
   localStorage.setItem('storages', JSON.stringify(cachedStorageList))
 
-  targetStorage.path
+  // commented next line as it has no effect - removing OK?
+  // targetStorage.path
 
   return resolveStorageData(targetStorage)
 }

--- a/browser/main/lib/dataApi/resolveStorageData.js
+++ b/browser/main/lib/dataApi/resolveStorageData.js
@@ -21,7 +21,7 @@ function resolveStorageData (storageCache) {
   } catch (err) {
     if (err.code === 'ENOENT') {
       console.warn('boostnote.json file doesn\'t exist the given path')
-      CSON.writeFileSync(boostnoteJSONPath, {folders: [], version: '1.0'})
+      CSON.writeFileSync(boostnoteJSONPath, { folders: [], version: '1.0' })
     } else {
       console.error(err)
     }

--- a/browser/main/lib/dataApi/resolveStorageNotes.js
+++ b/browser/main/lib/dataApi/resolveStorageNotes.js
@@ -16,6 +16,8 @@ function resolveStorageNotes (storage) {
     }
     notePathList = []
   }
+  // Note: Map is not returning a value on error
+  /* eslint-disable */
   const notes = notePathList
     .filter(function filterOnlyCSONFile (notePath) {
       return /\.cson$/.test(notePath)
@@ -33,6 +35,7 @@ function resolveStorageNotes (storage) {
     .filter(function filterOnlyNoteObject (noteObj) {
       return typeof noteObj === 'object'
     })
+  /* eslint-enable */
 
   return Promise.resolve(notes)
 }

--- a/browser/main/lib/dataApi/toggleStorage.js
+++ b/browser/main/lib/dataApi/toggleStorage.js
@@ -15,8 +15,10 @@ function toggleStorage (key, isOpen) {
     console.error(err)
     return Promise.reject(err)
   }
-  const targetStorage = _.find(cachedStorageList, {key: key})
-  if (targetStorage == null) return Promise.reject('Storage')
+  const targetStorage = _.find(cachedStorageList, { key: key })
+  // Note:
+  // Promise.reject should be creating new Error('Storage') - not changed as the calling side have to handle it properly
+  if (targetStorage == null) return Promise.reject('Storage') // eslint-disable-line
 
   targetStorage.isOpen = isOpen
   localStorage.setItem('storages', JSON.stringify(cachedStorageList))

--- a/browser/main/lib/dataApi/updateFolder.js
+++ b/browser/main/lib/dataApi/updateFolder.js
@@ -36,7 +36,7 @@ function updateFolder (storageKey, folderKey, input) {
 
   return resolveStorageData(targetStorage)
     .then(function updateFolder (storage) {
-      const targetFolder = _.find(storage.folders, {key: folderKey})
+      const targetFolder = _.find(storage.folders, { key: folderKey })
       if (targetFolder == null) throw new Error('Target folder doesn\'t exist.')
       targetFolder.name = input.name
       targetFolder.color = input.color

--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -120,9 +120,10 @@ function updateNote (storageKey, noteKey, input) {
         noteData.isPinned = false
       }
 
-      if (noteData.type === 'SNIPPET_NOTE') {
-        noteData.title
-      }
+      // Commented as it's doing nothing - Should it be removed?
+      // if (noteData.type === 'SNIPPET_NOTE') {
+      //   noteData.title
+      // }
 
       Object.assign(noteData, input, {
         key: noteKey,

--- a/browser/main/lib/ipcClient.js
+++ b/browser/main/lib/ipcClient.js
@@ -17,10 +17,10 @@ nodeIpc.connectTo(
       console.error(err)
     })
     nodeIpc.of.node.on('connect', function () {
-      ipcRenderer.send('config-renew', {config: ConfigManager.get()})
+      ipcRenderer.send('config-renew', { config: ConfigManager.get() })
     })
     nodeIpc.of.node.on('disconnect', function () {
-      return
+      return // eslint-disable-line
     })
   }
 )

--- a/browser/main/lib/modal.js
+++ b/browser/main/lib/modal.js
@@ -14,7 +14,7 @@ class ModalBase extends React.Component {
   }
 
   close () {
-    if (modalBase != null) modalBase.setState({component: null, componentProps: null, isHidden: true})
+    if (modalBase != null) modalBase.setState({ component: null, componentProps: null, isHidden: true })
     // Toggle overflow style on NoteList
     const list = document.querySelector('.NoteList__list___browser-main-NoteList-')
     list.style.overflow = 'auto'
@@ -36,7 +36,9 @@ class ModalBase extends React.Component {
 
 const el = document.createElement('div')
 document.body.appendChild(el)
-const modalBase = ReactDOM.render(<ModalBase />, el)
+
+// Note: Use React.createPortal instead - for now just disabled linting error
+const modalBase = ReactDOM.render(<ModalBase />, el) // eslint-disable-line
 
 export function openModal (component, props) {
   if (modalBase == null) { return }
@@ -44,7 +46,7 @@ export function openModal (component, props) {
   const list = document.querySelector('.NoteList__list___browser-main-NoteList-')
   list.style.overflow = 'hidden'
   document.body.setAttribute('data-modal', 'open')
-  modalBase.setState({component: component, componentProps: props, isHidden: false})
+  modalBase.setState({ component: component, componentProps: props, isHidden: false })
 }
 
 export function closeModal () {

--- a/browser/main/lib/shortcutManager.js
+++ b/browser/main/lib/shortcutManager.js
@@ -2,8 +2,8 @@ import Mousetrap from 'mousetrap'
 import CM from 'browser/main/lib/ConfigManager'
 import ee from 'browser/main/lib/eventEmitter'
 import { isObjectEqual } from 'browser/lib/utils'
-require('mousetrap-global-bind')
 import functions from './shortcut'
+require('mousetrap-global-bind')
 
 let shortcuts = CM.get().hotkey
 

--- a/browser/main/modals/PreferencesModal/Blog.js
+++ b/browser/main/modals/PreferencesModal/Blog.js
@@ -35,16 +35,16 @@ class Blog extends React.Component {
 
   componentDidMount () {
     this.handleSettingDone = () => {
-      this.setState({BlogAlert: {
+      this.setState({ BlogAlert: {
         type: 'success',
         message: i18n.__('Successfully applied!')
-      }})
+      } })
     }
     this.handleSettingError = (err) => {
-      this.setState({BlogAlert: {
+      this.setState({ BlogAlert: {
         type: 'error',
         message: err.message != null ? err.message : i18n.__('An error occurred!')
-      }})
+      } })
     }
     this.oldBlog = this.state.config.blog
     ipc.addListener('APP_SETTING_DONE', this.handleSettingDone)
@@ -91,7 +91,7 @@ class Blog extends React.Component {
   }
 
   render () {
-    const {config, BlogAlert} = this.state
+    const { config, BlogAlert } = this.state
     const blogAlertElement = BlogAlert != null
       ? <p className={`alert ${BlogAlert.type}`}>
         {BlogAlert.message}

--- a/browser/main/modals/PreferencesModal/FolderItem.js
+++ b/browser/main/modals/PreferencesModal/FolderItem.js
@@ -61,13 +61,14 @@ class FolderItem extends React.Component {
       // After the color picker has been painted, re-calculate its position
       // by comparing its dimensions to the host dimensions.
       const { hostBoundingBox } = this.props
-      const colorPickerNode = ReactDOM.findDOMNode(this.refs.colorPicker)
+      // Note: Avoid findDOMNode --> refactor to a ref later
+      const colorPickerNode = ReactDOM.findDOMNode(this.refs.colorPicker) // eslint-disable-line
       const colorPickerBox = colorPickerNode.getBoundingClientRect()
       const offsetTop = hostBoundingBox.bottom - colorPickerBox.bottom
       const folder = Object.assign({}, this.state.folder, {
         colorPickerPos: {
           left: 25,
-          top: offsetTop < 0 ? offsetTop - 5 : 0  // subtract 5px for aestetics
+          top: offsetTop < 0 ? offsetTop - 5 : 0 // subtract 5px for aestetics
         }
       })
       this.setState({ folder })
@@ -120,7 +121,7 @@ class FolderItem extends React.Component {
         ref='root'
       >
         <div styleName='folderItem-left'>
-          <button styleName='folderItem-left-colorButton' style={{color: this.state.folder.color}}
+          <button styleName='folderItem-left-colorButton' style={{ color: this.state.folder.color }}
             onClick={(e) => !this.state.folder.showColumnPicker && this.handleColorButtonClick(e)}
           >
             {this.state.folder.showColumnPicker
@@ -223,7 +224,7 @@ class FolderItem extends React.Component {
         onDoubleClick={(e) => this.handleEditButtonClick(e)}
       >
         <div styleName='folderItem-left'
-          style={{borderColor: folder.color}}
+          style={{ borderColor: folder.color }}
         >
           <span styleName='folderItem-left-name'>{folder.name}</span>
           <span styleName='folderItem-left-key'>({folder.key})</span>

--- a/browser/main/modals/PreferencesModal/FolderList.js
+++ b/browser/main/modals/PreferencesModal/FolderList.js
@@ -54,7 +54,7 @@ FolderList.propTypes = {
 class SortableFolderListComponent extends React.Component {
   constructor (props) {
     super(props)
-    this.onSortEnd = ({oldIndex, newIndex}) => {
+    this.onSortEnd = ({ oldIndex, newIndex }) => {
       const { storage } = this.props
       dataApi
         .reorderFolder(storage.key, oldIndex, newIndex)

--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -22,25 +22,25 @@ class HotkeyTab extends React.Component {
 
   componentDidMount () {
     this.handleSettingDone = () => {
-      this.setState({keymapAlert: {
+      this.setState({ keymapAlert: {
         type: 'success',
         message: i18n.__('Successfully applied!')
-      }})
+      } })
     }
     this.handleSettingError = (err) => {
       if (
         this.state.config.hotkey.toggleMain === '' ||
         this.state.config.hotkey.toggleMode === ''
       ) {
-        this.setState({keymapAlert: {
+        this.setState({ keymapAlert: {
           type: 'success',
           message: i18n.__('Successfully applied!')
-        }})
+        } })
       } else {
-        this.setState({keymapAlert: {
+        this.setState({ keymapAlert: {
           type: 'error',
           message: err.message != null ? err.message : i18n.__('An error occurred!')
-        }})
+        } })
       }
     }
     this.oldHotkey = this.state.config.hotkey

--- a/browser/main/modals/PreferencesModal/SnippetEditor.js
+++ b/browser/main/modals/PreferencesModal/SnippetEditor.js
@@ -11,7 +11,6 @@ const buildCMRulers = (rulers, enableRulers) =>
   enableRulers ? rulers.map(ruler => ({ column: ruler })) : []
 
 class SnippetEditor extends React.Component {
-
   componentDidMount () {
     this.props.onRef(this)
     const { rulers, enableRulers } = this.props

--- a/browser/main/modals/PreferencesModal/SnippetList.js
+++ b/browser/main/modals/PreferencesModal/SnippetList.js
@@ -21,7 +21,7 @@ class SnippetList extends React.Component {
 
   reloadSnippetList () {
     dataApi.fetchSnippet().then(snippets => {
-      this.setState({snippets})
+      this.setState({ snippets })
       this.props.onSnippetSelect(this.props.currentSnippet)
     })
   }

--- a/browser/main/modals/PreferencesModal/SnippetTab.js
+++ b/browser/main/modals/PreferencesModal/SnippetTab.js
@@ -46,7 +46,7 @@ class SnippetTab extends React.Component {
         dataApi.fetchSnippet(snippet.id).then(changedSnippet => {
           // notify the snippet editor to load the content of the new snippet
           this.snippetEditor.onSnippetChanged(changedSnippet)
-          this.setState({currentSnippet: changedSnippet})
+          this.setState({ currentSnippet: changedSnippet })
         })
       }
     }
@@ -66,7 +66,7 @@ class SnippetTab extends React.Component {
   handleDeleteSnippet (snippet) {
     // prevent old snippet still display when deleted
     if (snippet.id === this.state.currentSnippet.id) {
-      this.setState({currentSnippet: null})
+      this.setState({ currentSnippet: null })
     }
   }
 
@@ -96,7 +96,7 @@ class SnippetTab extends React.Component {
           onSnippetSelect={this.handleSnippetSelect.bind(this)}
           onSnippetDeleted={this.handleDeleteSnippet.bind(this)}
           currentSnippet={currentSnippet} />
-        <div styleName='snippet-detail' style={{visibility: currentSnippet ? 'visible' : 'hidden'}}>
+        <div styleName='snippet-detail' style={{ visibility: currentSnippet ? 'visible' : 'hidden' }}>
           <div styleName='group-section'>
             <div styleName='group-section-control'>
               <button styleName='group-control-rightButton'
@@ -148,7 +148,7 @@ class SnippetTab extends React.Component {
   }
 }
 
-SnippetTab.PropTypes = {
-}
+// SnippetTab.PropTypes = {
+// }
 
 export default CSSModules(SnippetTab, styles)

--- a/browser/main/modals/PreferencesModal/StorageItem.js
+++ b/browser/main/modals/PreferencesModal/StorageItem.js
@@ -127,7 +127,7 @@ class StorageItem extends React.Component {
             >
               <i className='fa fa-plus' />
               <span styleName='header-control-button-tooltip'
-                style={{left: -20}}
+                style={{ left: -20 }}
               >{i18n.__('Add Folder')}</span>
             </button>
             <button styleName='header-control-button'
@@ -135,7 +135,7 @@ class StorageItem extends React.Component {
             >
               <i className='fa fa-external-link' />
               <span styleName='header-control-button-tooltip'
-                style={{left: -50}}
+                style={{ left: -50 }}
               >{i18n.__('Open Storage folder')}</span>
             </button>
             <button styleName='header-control-button'
@@ -143,7 +143,7 @@ class StorageItem extends React.Component {
             >
               <i className='fa fa-unlink' />
               <span styleName='header-control-button-tooltip'
-                style={{left: -10}}
+                style={{ left: -10 }}
               >{i18n.__('Unlink')}</span>
             </button>
           </div>

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -32,16 +32,16 @@ class UiTab extends React.Component {
     CodeMirror.autoLoadMode(this.customCSSCM.getCodeMirror(), 'css')
     this.customCSSCM.getCodeMirror().setSize('400px', '400px')
     this.handleSettingDone = () => {
-      this.setState({UiAlert: {
+      this.setState({ UiAlert: {
         type: 'success',
         message: i18n.__('Successfully applied!')
-      }})
+      } })
     }
     this.handleSettingError = (err) => {
-      this.setState({UiAlert: {
+      this.setState({ UiAlert: {
         type: 'error',
         message: err.message != null ? err.message : i18n.__('An error occurred!')
-      }})
+      } })
     }
     ipc.addListener('APP_SETTING_DONE', this.handleSettingDone)
     ipc.addListener('APP_SETTING_ERROR', this.handleSettingError)
@@ -131,8 +131,8 @@ class UiTab extends React.Component {
       checkHighLight.setAttribute('href', `../node_modules/codemirror/theme/${newCodemirrorTheme.split(' ')[0]}.css`)
     }
     this.setState({ config: newConfig, codemirrorTheme: newCodemirrorTheme }, () => {
-      const {ui, editor, preview} = this.props.config
-      this.currentConfig = {ui, editor, preview}
+      const { ui, editor, preview } = this.props.config
+      this.currentConfig = { ui, editor, preview }
       if (_.isEqual(this.currentConfig, this.state.config)) {
         this.props.haveToSave()
       } else {
@@ -271,18 +271,18 @@ class UiTab extends React.Component {
           </div>
           {
             global.process.platform === 'win32'
-            ? <div styleName='group-checkBoxSection'>
-              <label>
-                <input onChange={(e) => this.handleUIChange(e)}
-                  checked={this.state.config.ui.disableDirectWrite}
-                  refs='uiD2w'
-                  disabled={OSX}
-                  type='checkbox'
-                />&nbsp;
-                {i18n.__('Disable Direct Write (It will be applied after restarting)')}
-              </label>
-            </div>
-            : null
+              ? <div styleName='group-checkBoxSection'>
+                <label>
+                  <input onChange={(e) => this.handleUIChange(e)}
+                    checked={this.state.config.ui.disableDirectWrite}
+                    refs='uiD2w'
+                    disabled={OSX}
+                    type='checkbox'
+                  />&nbsp;
+                  {i18n.__('Disable Direct Write (It will be applied after restarting)')}
+                </label>
+              </div>
+              : null
           }
 
           <div styleName='group-header2'>Tags</div>
@@ -359,7 +359,7 @@ class UiTab extends React.Component {
                   })
                 }
               </select>
-              <div styleName='code-mirror' style={{fontFamily}}>
+              <div styleName='code-mirror' style={{ fontFamily }}>
                 <ReactCodeMirror
                   ref={e => (this.codeMirrorInstance = e)}
                   value={codemirrorSampleCode}
@@ -756,10 +756,10 @@ class UiTab extends React.Component {
                 ref='previewSanitize'
                 onChange={(e) => this.handleUIChange(e)}
               >
-                <option value='STRICT'>✅ {i18n.__('Only allow secure html tags (recommended)')}
+                <option value='STRICT'><span role='img' aria-label='Strict - Only allow secure html - check mark symbol'>✅</span> {i18n.__('Only allow secure html tags (recommended)')}
                 </option>
-                <option value='ALLOW_STYLES'>⚠️ {i18n.__('Allow styles')}</option>
-                <option value='NONE'>❌ {i18n.__('Allow dangerous html tags')}</option>
+                <option value='ALLOW_STYLES'><span role='img' aria-label='Allow styles - warning symbol'>⚠️</span> {i18n.__('Allow styles')}</option>
+                <option value='NONE'><span role='img' aria-label='None - allow dangerous html tags - cross symbol'>❌</span> {i18n.__('Allow dangerous html tags')}</option>
               </select>
             </div>
           </div>
@@ -839,7 +839,7 @@ class UiTab extends React.Component {
                 type='checkbox'
               />&nbsp;
               {i18n.__('Allow custom CSS for preview')}
-              <div style={{fontFamily}}>
+              <div style={{ fontFamily }}>
                 <ReactCodeMirror
                   width='400px'
                   height='400px'

--- a/browser/main/modals/PreferencesModal/index.js
+++ b/browser/main/modals/PreferencesModal/index.js
@@ -34,12 +34,12 @@ class Preferences extends React.Component {
   }
 
   switchTeam (teamId) {
-    this.setState({currentTeamId: teamId})
+    this.setState({ currentTeamId: teamId })
   }
 
   handleNavButtonClick (tab) {
     return (e) => {
-      this.setState({currentTab: tab})
+      this.setState({ currentTab: tab })
     }
   }
 
@@ -64,7 +64,7 @@ class Preferences extends React.Component {
           <HotkeyTab
             dispatch={dispatch}
             config={config}
-            haveToSave={alert => this.setState({HotkeyAlert: alert})}
+            haveToSave={alert => this.setState({ HotkeyAlert: alert })}
           />
         )
       case 'UI':
@@ -72,7 +72,7 @@ class Preferences extends React.Component {
           <UiTab
             dispatch={dispatch}
             config={config}
-            haveToSave={alert => this.setState({UIAlert: alert})}
+            haveToSave={alert => this.setState({ UIAlert: alert })}
           />
         )
       case 'CROWDFUNDING':
@@ -84,7 +84,7 @@ class Preferences extends React.Component {
           <Blog
             dispatch={dispatch}
             config={config}
-            haveToSave={alert => this.setState({BlogAlert: alert})}
+            haveToSave={alert => this.setState({ BlogAlert: alert })}
           />
         )
       case 'SNIPPET':
@@ -127,20 +127,21 @@ class Preferences extends React.Component {
     const content = this.renderContent()
 
     const tabs = [
-      {target: 'STORAGES', label: i18n.__('Storage')},
-      {target: 'HOTKEY', label: i18n.__('Hotkeys'), Hotkey: this.state.HotkeyAlert},
-      {target: 'UI', label: i18n.__('Interface'), UI: this.state.UIAlert},
-      {target: 'INFO', label: i18n.__('About')},
-      {target: 'CROWDFUNDING', label: i18n.__('Crowdfunding')},
-      {target: 'BLOG', label: i18n.__('Blog'), Blog: this.state.BlogAlert},
-      {target: 'SNIPPET', label: i18n.__('Snippets')}
+      { target: 'STORAGES', label: i18n.__('Storage') },
+      { target: 'HOTKEY', label: i18n.__('Hotkeys'), Hotkey: this.state.HotkeyAlert },
+      { target: 'UI', label: i18n.__('Interface'), UI: this.state.UIAlert },
+      { target: 'INFO', label: i18n.__('About') },
+      { target: 'CROWDFUNDING', label: i18n.__('Crowdfunding') },
+      { target: 'BLOG', label: i18n.__('Blog'), Blog: this.state.BlogAlert },
+      { target: 'SNIPPET', label: i18n.__('Snippets') }
     ]
 
     const navButtons = tabs.map((tab) => {
       const isActive = this.state.currentTab === tab.target
       const isUiHotkeyTab = _.isObject(tab[tab.label]) && tab.label === tab[tab.label].tab
       return (
-        <button styleName={isActive
+        <button
+          styleName={isActive
             ? 'nav-button--active'
             : 'nav-button'
           }

--- a/extra_scripts/boost/boostNewLineIndentContinueMarkdownList.js
+++ b/extra_scripts/boost/boostNewLineIndentContinueMarkdownList.js
@@ -1,3 +1,4 @@
+/* globals CodeMirror, define */
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // Common JS
     mod(require('../codemirror/lib/codemirror'))
@@ -7,8 +8,6 @@
     mod(CodeMirror)
   }
 })(function (CodeMirror) {
-  'use strict'
-
   var listRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/
   var emptyListRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/
   var unorderedListRE = /[*+-]\s/
@@ -52,30 +51,30 @@
   }
   // Auto-updating Markdown list numbers when a new item is added to the
   // middle of a list
-  function incrementRemainingMarkdownListNumbers(cm, pos) {
-    var startLine = pos.line, lookAhead = 0, skipCount = 0
-    var startItem = listRE.exec(cm.getLine(startLine)), startIndent = startItem[1]
+  function incrementRemainingMarkdownListNumbers (cm, pos) {
+    var startLine = pos.line; var lookAhead = 0; var skipCount = 0
+    var startItem = listRE.exec(cm.getLine(startLine)); var startIndent = startItem[1]
 
     do {
       lookAhead += 1
       var nextLineNumber = startLine + lookAhead
-      var nextLine = cm.getLine(nextLineNumber), nextItem = listRE.exec(nextLine)
+      var nextLine = cm.getLine(nextLineNumber); var nextItem = listRE.exec(nextLine)
 
       if (nextItem) {
         var nextIndent = nextItem[1]
         var newNumber = (parseInt(startItem[3], 10) + lookAhead - skipCount)
-        var nextNumber = (parseInt(nextItem[3], 10)), itemNumber = nextNumber
+        var nextNumber = (parseInt(nextItem[3], 10)); var itemNumber = nextNumber
 
         if (startIndent === nextIndent && !isNaN(nextNumber)) {
           if (newNumber === nextNumber) itemNumber = nextNumber + 1
           if (newNumber > nextNumber) itemNumber = newNumber + 1
           cm.replaceRange(
             nextLine.replace(listRE, nextIndent + itemNumber + nextItem[4] + nextItem[5]),
-          {
-            line: nextLineNumber, ch: 0
-          }, {
-            line: nextLineNumber, ch: nextLine.length
-          })
+            {
+              line: nextLineNumber, ch: 0
+            }, {
+              line: nextLineNumber, ch: nextLine.length
+            })
         } else {
           if (startIndent.length > nextIndent.length) return
           // This doesn't run if the next line immediatley indents, as it is

--- a/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
+++ b/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
@@ -1,3 +1,4 @@
+/* globals CodeMirror, define */
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // Common JS
     mod(require('../codemirror/lib/codemirror'))
@@ -7,8 +8,6 @@
     mod(CodeMirror)
   }
 })(function (CodeMirror) {
-  'use strict'
-
   const shell = require('electron').shell
   const yOffset = 2
 
@@ -16,7 +15,7 @@
   const modifier = macOS ? 'metaKey' : 'ctrlKey'
 
   class HyperLink {
-    constructor(cm) {
+    constructor (cm) {
       this.cm = cm
       this.lineDiv = cm.display.lineDiv
 
@@ -47,7 +46,7 @@
         passive: true
       })
     }
-    getUrl(el) {
+    getUrl (el) {
       const className = el.className.split(' ')
 
       if (className.indexOf('cm-url') !== -1) {
@@ -60,7 +59,7 @@
 
       return null
     }
-    onMouseDown(e) {
+    onMouseDown (e) {
       const { target } = e
       if (!e[modifier]) {
         return
@@ -73,39 +72,37 @@
         shell.openExternal(url)
       }
     }
-    onMouseEnter(e) {
+    onMouseEnter (e) {
       const { target } = e
 
       const url = this.getUrl(target)
       if (url) {
         if (e[modifier]) {
           target.classList.add('CodeMirror-activeline-background', 'CodeMirror-hyperlink')
-        }
-        else {
+        } else {
           target.classList.add('CodeMirror-activeline-background')
         }
 
         this.showInfo(target)
       }
     }
-    onMouseLeave(e) {
+    onMouseLeave (e) {
       if (this.tooltip.parentElement === this.lineDiv) {
         e.target.classList.remove('CodeMirror-activeline-background', 'CodeMirror-hyperlink')
 
         this.lineDiv.removeChild(this.tooltip)
       }
     }
-    onMouseMove(e) {
+    onMouseMove (e) {
       if (this.tooltip.parentElement === this.lineDiv) {
         if (e[modifier]) {
           e.target.classList.add('CodeMirror-hyperlink')
-        }
-        else {
+        } else {
           e.target.classList.remove('CodeMirror-hyperlink')
         }
       }
     }
-    showInfo(relatedTo) {
+    showInfo (relatedTo) {
       const b1 = relatedTo.getBoundingClientRect()
       const b2 = this.lineDiv.getBoundingClientRect()
       const tdiv = this.tooltip
@@ -117,14 +114,13 @@
       const top = b1.top - b2.top - b3.height - yOffset
       if (top < 0) {
         tdiv.style.top = (b1.top - b2.top + b1.height + yOffset) + 'px'
-      }
-      else {
+      } else {
         tdiv.style.top = top + 'px'
       }
     }
   }
 
   CodeMirror.defineOption('hyperlink', true, (cm) => {
-    const addon = new HyperLink(cm)
+    HyperLink(cm)
   })
 })

--- a/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
+++ b/extra_scripts/codemirror/addon/hyperlink/hyperlink.js
@@ -121,6 +121,6 @@
   }
 
   CodeMirror.defineOption('hyperlink', true, (cm) => {
-    HyperLink(cm)
+    const addon = new HyperLink(cm) // eslint-disable-line
   })
 })

--- a/extra_scripts/codemirror/mode/bfm/bfm.js
+++ b/extra_scripts/codemirror/mode/bfm/bfm.js
@@ -1,16 +1,16 @@
-(function(mod) {
-  if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../codemirror/lib/codemirror"), require("../codemirror/mode/gfm/gfm"), require("../codemirror/mode/yaml-frontmatter/yaml-frontmatter"))
-  else if (typeof define == "function" && define.amd) // AMD
-    define(["../codemirror/lib/codemirror", "../codemirror/mode/gfm/gfm", "../codemirror/mode/yaml-frontmatter/yaml-frontmatter"], mod)
-  else // Plain browser env
+/* globals CodeMirror, define */
+(function (mod) {
+  if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
+    mod(require('../codemirror/lib/codemirror'), require('../codemirror/mode/gfm/gfm'), require('../codemirror/mode/yaml-frontmatter/yaml-frontmatter'))
+  } else if (typeof define === 'function' && define.amd) { // AMD
+    define(['../codemirror/lib/codemirror', '../codemirror/mode/gfm/gfm', '../codemirror/mode/yaml-frontmatter/yaml-frontmatter'], mod)
+  } else { // Plain browser env
     mod(CodeMirror)
-})(function(CodeMirror) {
-  'use strict'
-
+  }
+})(function (CodeMirror) {
   const fencedCodeRE = /^(~~~+|```+)[ \t]*([\w+#-]+)?(?:\(((?:\s*\w[-\w]*(?:=(?:'(?:.*?[^\\])?'|"(?:.*?[^\\])?"|(?:[^'"][^\s]*)))?)*)\))?(?::([^:]*)(?::(\d+))?)?\s*$/
 
-  function getMode(name, params, config, cm) {
+  function getMode (name, params, config, cm) {
     if (!name) {
       return null
     }
@@ -50,7 +50,7 @@
     const baseMode = CodeMirror.getMode(config, baseConfig)
 
     return {
-      startState: function() {
+      startState: function () {
         return {
           baseState: CodeMirror.startState(baseMode),
 
@@ -66,7 +66,7 @@
           rowIndex: 0
         }
       },
-      copyState: function(s) {
+      copyState: function (s) {
         return {
           baseState: CodeMirror.copyState(baseMode, s.baseState),
 
@@ -84,7 +84,7 @@
           rowIndex: s.rowIndex
         }
       },
-      token: function(stream, state) {
+      token: function (stream, state) {
         const initialPos = stream.pos
 
         if (state.fencedEndRE && stream.match(state.fencedEndRE)) {
@@ -93,8 +93,7 @@
           state.fencedState = null
 
           stream.pos = initialPos
-        }
-        else {
+        } else {
           if (state.fencedMode) {
             return state.fencedMode.token(stream, state.fencedState)
           }
@@ -112,15 +111,20 @@
           }
         }
 
+        // Note disable linting - check if it's safe to change to tripple equals
+        // eslint-disable-next-line
         if (stream != state.streamSeen || Math.min(state.basePos, state.overlayPos) < stream.start) {
           state.streamSeen = stream
           state.basePos = state.overlayPos = stream.start
         }
 
+        // eslint-disable-next-line
         if (stream.start == state.basePos) {
           state.baseCur = baseMode.token(stream, state.baseState)
           state.basePos = stream.pos
         }
+
+        // eslint-disable-next-line
         if (stream.start == state.overlayPos) {
           stream.pos = stream.start
           state.overlayCur = this.overlayToken(stream, state)
@@ -130,15 +134,13 @@
 
         if (state.overlayCur == null) {
           return state.baseCur
-        }
-        else if (state.baseCur != null && state.combineTokens) {
+        } else if (state.baseCur != null && state.combineTokens) {
           return state.baseCur + ' ' + state.overlayCur
-        }
-        else {
+        } else {
           return state.overlayCur
         }
       },
-      overlayToken: function(stream, state) {
+      overlayToken: function (stream, state) {
         state.combineTokens = false
 
         if (state.fencedEndRE && stream.match(state.fencedEndRE)) {
@@ -198,7 +200,7 @@
         return null
       },
       electricChars: baseMode.electricChars,
-      innerMode: function(state) {
+      innerMode: function (state) {
         if (state.fencedMode) {
           return {
             mode: state.fencedMode,
@@ -211,7 +213,7 @@
           }
         }
       },
-      blankLine: function(state) {
+      blankLine: function (state) {
         state.inTable = false
 
         if (state.fencedMode) {
@@ -226,8 +228,8 @@
   CodeMirror.defineMIME('text/x-bfm', 'bfm')
 
   CodeMirror.modeInfo.push({
-    name: "Boost Flavored Markdown",
-    mime: "text/x-bfm",
-    mode: "bfm"
+    name: 'Boost Flavored Markdown',
+    mime: 'text/x-bfm',
+    mode: 'bfm'
   })
 })

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -187,6 +187,7 @@ module.exports = function (grunt) {
       return
     }
 
+    // eslint-disable-next-line
     ChildProcess.exec(`codesign --verbose --deep --force --sign \"${OSX_COMMON_NAME}\" dist/Boostnote-darwin-x64/Boostnote.app`,
       function (err, stdout, stderr) {
         grunt.log.writeln(stdout)
@@ -238,7 +239,6 @@ module.exports = function (grunt) {
         break
       default:
         done()
-        return
     }
   })
 
@@ -306,6 +306,9 @@ module.exports = function (grunt) {
 
     const root = path.join(__dirname, 'node_modules/codemirror/theme/')
 
+    // Note:
+    // Map doesn't return a value - probably using forEach would be better
+    // eslint-disable-next-line
     const colors = fs.readdirSync(root).filter(file => file !== 'solarized.css').map(file => {
       const css = parseCSS(fs.readFileSync(path.join(root, file), 'utf8'))
 

--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -418,5 +418,5 @@ const help = {
 module.exports = process.platform === 'darwin'
   ? [boost, file, edit, view, window, help]
   : process.platform === 'win32'
-  ? [boost, file, view, help]
-  : [file, view, help]
+    ? [boost, file, view, help]
+    : [file, view, help]

--- a/lib/touchbar-menu.js
+++ b/lib/touchbar-menu.js
@@ -1,5 +1,5 @@
-const {TouchBar} = require('electron')
-const {TouchBarButton, TouchBarSpacer} = TouchBar
+const { TouchBar } = require('electron')
+const { TouchBarButton, TouchBarSpacer } = TouchBar
 const mainWindow = require('./main-window')
 
 const allNotes = new TouchBarButton({
@@ -35,7 +35,6 @@ module.exports = new TouchBar([
   allNotes,
   starredNotes,
   trash,
-  new TouchBarSpacer({size: 'small'}),
+  new TouchBarSpacer({ size: 'small' }),
   newNote
 ])
-

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx,mjs}": [
-        "lint:fix",
+        "npm run lint:fix",
         "git add"
       ]
     }
@@ -220,6 +220,7 @@
   },
   "standard": {
     "globals": [
+      "fetch",
       "FileReader",
       "Image"
     ],

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx,mjs}": [
-        "npm run lint:fix",
+        "npm run lint",
         "git add"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "env FORCE_COLOR=1 lint-staged"
     }
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "merge-stream": "^1.0.0",
     "mock-require": "^3.0.1",
     "nib": "^1.1.0",
-    "prettier-standard": "^9.1.1",
     "react-css-modules": "^3.7.6",
     "react-input-autosize": "^1.1.0",
     "react-router": "^2.4.0",
@@ -209,14 +208,14 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx,mjs}": [
-        "npm run prettier",
+        "lint:fix",
         "git add"
       ]
     }
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint"
+      "pre-commit": "lint-staged"
     }
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "compile": "grunt compile",
     "test": "PWD=$(pwd) NODE_ENV=test ava --serial",
     "jest": "jest",
-    "fix": "eslint . --fix",
-    "lint": "eslint .",
+    "lint": "standardx **/*.js --verbose | snazzy",
+    "lint:fix": "standardx **/*.js --fix | snazzy",
+    "prettier": "prettier-standard",
     "dev": "node dev-scripts/dev.js",
     "watch": "webpack-dev-server --hot"
   },
@@ -120,6 +121,7 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "babel-core": "^6.14.0",
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^22.4.3",
     "babel-loader": "^6.2.0",
     "babel-plugin-react-transform": "^2.0.0",
@@ -139,31 +141,39 @@
     "dom-storage": "^2.0.2",
     "electron": "3.0.8",
     "electron-packager": "^12.2.0",
-    "eslint": "^3.13.1",
+    "eslint": "^5.16.0",
+    "eslint-config-react-app": "^4.0.0",
     "eslint-config-standard": "^6.2.1",
     "eslint-config-standard-jsx": "^3.2.0",
+    "eslint-plugin-flowtype": "^3.7.0",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.8.2",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "faker": "^3.1.0",
     "grunt": "^0.4.5",
     "grunt-electron-installer": "2.1.0",
     "history": "^1.17.0",
-    "husky": "^1.1.0",
+    "husky": "^2.2.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^22.4.3",
     "jest-localstorage-mock": "^2.2.0",
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
+    "lint-staged": "^8.1.6",
     "merge-stream": "^1.0.0",
     "mock-require": "^3.0.1",
     "nib": "^1.1.0",
+    "prettier-standard": "^9.1.1",
     "react-css-modules": "^3.7.6",
     "react-input-autosize": "^1.1.0",
     "react-router": "^2.4.0",
     "react-router-redux": "^4.0.4",
     "react-test-renderer": "^15.6.2",
     "signale": "^1.2.1",
-    "standard": "^8.4.0",
+    "snazzy": "^8.0.0",
+    "standard": "^12.0.1",
+    "standardx": "^3.0.1",
     "style-loader": "^0.12.4",
     "stylus": "^0.52.4",
     "stylus-loader": "^2.3.1",
@@ -196,9 +206,26 @@
       "jest-localstorage-mock"
     ]
   },
+  "lint-staged": {
+    "linters": {
+      "*.{js,jsx,mjs}": [
+        "npm run prettier",
+        "git add"
+      ]
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "npm run lint"
+    }
+  },
+  "standard": {
+    "globals": [
+      "FileReader",
+      "Image"
+    ],
+    "env": {
+      "jest": true
     }
   }
 }

--- a/tests/dataApi/addStorage.js
+++ b/tests/dataApi/addStorage.js
@@ -53,7 +53,7 @@ test.serial('Add Storage', (t) => {
       })
 
       // Check localStorage
-      const cacheData = _.find(JSON.parse(localStorage.getItem('storages')), {key: data.storage.key})
+      const cacheData = _.find(JSON.parse(localStorage.getItem('storages')), { key: data.storage.key })
       t.is(cacheData.name, input.name)
       t.is(cacheData.type, input.type)
       t.is(cacheData.path, input.path)

--- a/tests/dataApi/attachmentManagement.test.js
+++ b/tests/dataApi/attachmentManagement.test.js
@@ -1,5 +1,3 @@
-'use strict'
-
 jest.mock('fs')
 const fs = require('fs')
 const path = require('path')
@@ -50,7 +48,7 @@ it('should test that copyAttachment works correctly assuming correct working of 
   const storageKey = 'storageKey'
   const noteKey = 'noteKey'
   const dummyUniquePath = 'dummyPath'
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   const dummyReadStream = {}
 
   dummyReadStream.pipe = jest.fn()
@@ -76,7 +74,7 @@ it('should test that copyAttachment works correctly assuming correct working of 
 })
 
 it('should test that copyAttachment creates a new folder if the attachment folder doesn\'t exist', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   const noteKey = 'noteKey'
   const attachmentFolderPath = path.join(dummyStorage.path, systemUnderTest.DESTINATION_FOLDER)
   const attachmentFolderNoteKyPath = path.join(dummyStorage.path, systemUnderTest.DESTINATION_FOLDER, noteKey)
@@ -105,7 +103,7 @@ it('should test that copyAttachment creates a new folder if the attachment folde
 })
 
 it('should test that copyAttachment don\'t uses a random file name if not intended ', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   const dummyReadStream = {}
 
   dummyReadStream.pipe = jest.fn()
@@ -127,7 +125,7 @@ it('should test that copyAttachment don\'t uses a random file name if not intend
 })
 
 it('should test that copyAttachment with url (with extension, without query)', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
 
   const dummyReadStream = {
     pipe: jest.fn(),
@@ -162,7 +160,7 @@ it('should test that copyAttachment with url (with extension, without query)', f
 })
 
 it('should test that copyAttachment with url (with extension, with query)', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
 
   const dummyReadStream = {
     pipe: jest.fn(),
@@ -197,7 +195,7 @@ it('should test that copyAttachment with url (with extension, with query)', func
 })
 
 it('should test that copyAttachment with url (without extension, without query)', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
 
   const dummyReadStream = {
     pipe: jest.fn(),
@@ -232,7 +230,7 @@ it('should test that copyAttachment with url (without extension, without query)'
 })
 
 it('should test that copyAttachment with url (without extension, with query)', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
 
   const dummyReadStream = {
     pipe: jest.fn(),
@@ -474,7 +472,7 @@ it('should make sure that "removeStorageAndNoteReferences" works with markdown c
 })
 
 it('should delete the correct attachment folder if a note is deleted', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   const storageKey = 'storageKey'
   const noteKey = 'noteKey'
   findStorage.findStorage = jest.fn(() => dummyStorage)
@@ -487,7 +485,7 @@ it('should delete the correct attachment folder if a note is deleted', function 
 })
 
 it('should test that deleteAttachmentsNotPresentInNote deletes all unreferenced attachments ', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   const noteKey = 'noteKey'
   const storageKey = 'storageKey'
   const markdownContent = ''
@@ -516,7 +514,7 @@ it('should test that deleteAttachmentsNotPresentInNote deletes all unreferenced 
 })
 
 it('should test that deleteAttachmentsNotPresentInNote does not delete referenced attachments', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   const noteKey = 'noteKey'
   const storageKey = 'storageKey'
   const dummyFilesInFolder = ['file1.txt', 'file2.pdf', 'file3.jpg']
@@ -627,15 +625,15 @@ it('should test that moveAttachments returns a correct modified content version'
 })
 
 it('should test that cloneAttachments modifies the content of the new note correctly', function () {
-  const oldNote = {key: 'oldNoteKey', content: 'oldNoteContent', storage: 'storageKey', type: 'MARKDOWN_NOTE'}
-  const newNote = {key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKey', type: 'MARKDOWN_NOTE'}
+  const oldNote = { key: 'oldNoteKey', content: 'oldNoteContent', storage: 'storageKey', type: 'MARKDOWN_NOTE' }
+  const newNote = { key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKey', type: 'MARKDOWN_NOTE' }
   const testInput =
     'Test input' +
     '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNote.key + path.win32.sep + 'image.jpg](imageName}) \n' +
     '[' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.posix.sep + oldNote.key + path.posix.sep + 'pdf.pdf](pdf})'
   newNote.content = testInput
   findStorage.findStorage = jest.fn()
-  findStorage.findStorage.mockReturnValue({path: 'dummyStoragePath'})
+  findStorage.findStorage.mockReturnValue({ path: 'dummyStoragePath' })
 
   const expectedOutput =
     'Test input' +
@@ -649,10 +647,10 @@ it('should test that cloneAttachments modifies the content of the new note corre
 it('should test that cloneAttachments finds all attachments and copies them to the new location', function () {
   const storagePathOld = 'storagePathOld'
   const storagePathNew = 'storagePathNew'
-  const dummyStorageOld = {path: storagePathOld}
-  const dummyStorageNew = {path: storagePathNew}
-  const oldNote = {key: 'oldNoteKey', content: 'oldNoteContent', storage: 'storageKeyOldNote', type: 'MARKDOWN_NOTE'}
-  const newNote = {key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKeyNewNote', type: 'MARKDOWN_NOTE'}
+  const dummyStorageOld = { path: storagePathOld }
+  const dummyStorageNew = { path: storagePathNew }
+  const oldNote = { key: 'oldNoteKey', content: 'oldNoteContent', storage: 'storageKeyOldNote', type: 'MARKDOWN_NOTE' }
+  const newNote = { key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKeyNewNote', type: 'MARKDOWN_NOTE' }
   const testInput =
     'Test input' +
     '![' + systemUnderTest.STORAGE_FOLDER_PLACEHOLDER + path.win32.sep + oldNote.key + path.win32.sep + 'image.jpg](imageName}) \n' +
@@ -660,7 +658,7 @@ it('should test that cloneAttachments finds all attachments and copies them to t
   oldNote.content = testInput
   newNote.content = testInput
 
-  const copyFileSyncResp = {to: jest.fn()}
+  const copyFileSyncResp = { to: jest.fn() }
   sander.copyFileSync = jest.fn()
   sander.copyFileSync.mockReturnValue(copyFileSyncResp)
   findStorage.findStorage = jest.fn()
@@ -686,8 +684,8 @@ it('should test that cloneAttachments finds all attachments and copies them to t
 })
 
 it('should test that cloneAttachments finds all attachments and copies them to the new location', function () {
-  const oldNote = {key: 'oldNoteKey', content: 'oldNoteContent', storage: 'storageKeyOldNote', type: 'SOMETHING_ELSE'}
-  const newNote = {key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKeyNewNote', type: 'SOMETHING_ELSE'}
+  const oldNote = { key: 'oldNoteKey', content: 'oldNoteContent', storage: 'storageKeyOldNote', type: 'SOMETHING_ELSE' }
+  const newNote = { key: 'newNoteKey', content: 'oldNoteContent', storage: 'storageKeyNewNote', type: 'SOMETHING_ELSE' }
   const testInput = 'Test input'
   oldNote.content = testInput
   newNote.content = testInput
@@ -724,7 +722,7 @@ it('should test that isAttachmentLink works correctly', function () {
 })
 
 it('should test that handleAttachmentLinkPaste copies the attachments to the new location', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -744,7 +742,7 @@ it('should test that handleAttachmentLinkPaste copies the attachments to the new
 })
 
 it('should test that handleAttachmentLinkPaste copies the attachments to the new location - win32 path', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -764,7 +762,7 @@ it('should test that handleAttachmentLinkPaste copies the attachments to the new
 })
 
 it('should test that handleAttachmentLinkPaste don\'t try to copy the file if it does not exist - win32 path', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -785,7 +783,7 @@ it('should test that handleAttachmentLinkPaste don\'t try to copy the file if it
 })
 
 it('should test that handleAttachmentLinkPaste don\'t try to copy the file if it does not exist -- posix', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -806,7 +804,7 @@ it('should test that handleAttachmentLinkPaste don\'t try to copy the file if it
 })
 
 it('should test that handleAttachmentLinkPaste copies multiple attachments if multiple were pasted', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -830,7 +828,7 @@ it('should test that handleAttachmentLinkPaste copies multiple attachments if mu
 })
 
 it('should test that handleAttachmentLinkPaste returns the correct modified paste text', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -849,7 +847,7 @@ it('should test that handleAttachmentLinkPaste returns the correct modified past
 })
 
 it('should test that handleAttachmentLinkPaste returns the correct modified paste text if multiple links are posted', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -873,7 +871,7 @@ it('should test that handleAttachmentLinkPaste returns the correct modified past
 })
 
 it('should test that handleAttachmentLinkPaste calls the copy method correct if multiple links are posted where one file was found and one was not', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -900,7 +898,7 @@ it('should test that handleAttachmentLinkPaste calls the copy method correct if 
 })
 
 it('should test that handleAttachmentLinkPaste returns the correct modified paste text if the file was not found', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -919,7 +917,7 @@ it('should test that handleAttachmentLinkPaste returns the correct modified past
 })
 
 it('should test that handleAttachmentLinkPaste returns the correct modified paste text if multiple files were not found', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -939,7 +937,7 @@ it('should test that handleAttachmentLinkPaste returns the correct modified past
 })
 
 it('should test that handleAttachmentLinkPaste returns the correct modified paste text if one file was found and one was not found', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'
@@ -963,7 +961,7 @@ it('should test that handleAttachmentLinkPaste returns the correct modified past
 })
 
 it('should test that handleAttachmentLinkPaste returns the correct modified paste text if one file was found and one was not found', function () {
-  const dummyStorage = {path: 'dummyStoragePath'}
+  const dummyStorage = { path: 'dummyStoragePath' }
   findStorage.findStorage = jest.fn(() => dummyStorage)
   const pastedNoteKey = 'b1e06f81-8266-49b9-b438-084003c2e723'
   const newNoteKey = 'abc234-8266-49b9-b438-084003c2e723'

--- a/tests/dataApi/copyFile-test.js
+++ b/tests/dataApi/copyFile-test.js
@@ -32,4 +32,3 @@ test.after((t) => {
   fs.rmdirSync(srcFolder)
   fs.rmdirSync(dstFolder)
 })
-

--- a/tests/dataApi/deleteFolder-test.js
+++ b/tests/dataApi/deleteFolder-test.js
@@ -58,10 +58,10 @@ test.serial('Delete a folder', (t) => {
       return deleteFolder(storageKey, folderKey)
     })
     .then(function assert (data) {
-      t.true(_.find(data.storage.folders, {key: folderKey}) == null)
+      t.true(_.find(data.storage.folders, { key: folderKey }) == null)
       const jsonData = CSON.readFileSync(path.join(data.storage.path, 'boostnote.json'))
 
-      t.true(_.find(jsonData.folders, {key: folderKey}) == null)
+      t.true(_.find(jsonData.folders, { key: folderKey }) == null)
       const notePaths = sander.readdirSync(data.storage.path, 'notes')
       t.is(notePaths.length, t.context.storage.notes.filter((note) => note.folder !== folderKey).length)
 

--- a/tests/dataApi/init.js
+++ b/tests/dataApi/init.js
@@ -21,8 +21,8 @@ const emptyDirPath = path.join(os.tmpdir(), 'test/init-empty-storage')
 test.beforeEach((t) => {
   localStorage.clear()
   // Prepare 3 types of dir
-  t.context.v1StorageData = TestDummy.dummyStorage(v1StoragePath, {cache: {name: 'v1'}})
-  t.context.legacyStorageData = TestDummy.dummyLegacyStorage(legacyStoragePath, {cache: {name: 'legacy'}})
+  t.context.v1StorageData = TestDummy.dummyStorage(v1StoragePath, { cache: { name: 'v1' } })
+  t.context.legacyStorageData = TestDummy.dummyLegacyStorage(legacyStoragePath, { cache: { name: 'legacy' } })
   t.context.emptyStorageData = {
     cache: {
       type: 'FILESYSTEM',

--- a/tests/dataApi/migrateFromV6Storage-test.js
+++ b/tests/dataApi/migrateFromV6Storage-test.js
@@ -42,7 +42,7 @@ test.serial('Migrate legacy storage into v1 storage', (t) => {
         })
       dummyData.notes
         .forEach(function (targetNote) {
-          t.true(_.find(noteMap, {title: targetNote.title, folder: targetNote.folder}) != null)
+          t.true(_.find(noteMap, { title: targetNote.title, folder: targetNote.folder }) != null)
         })
 
       // Check legacy folder directory is removed

--- a/tests/dataApi/renameStorage-test.js
+++ b/tests/dataApi/renameStorage-test.js
@@ -28,7 +28,7 @@ test.serial('Rename a storage', (t) => {
     })
     .then(function assert (data) {
       const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
-      t.true(_.find(cachedStorageList, {key: storageKey}).name === 'changed')
+      t.true(_.find(cachedStorageList, { key: storageKey }).name === 'changed')
     })
 })
 

--- a/tests/dataApi/toggleStorage-test.js
+++ b/tests/dataApi/toggleStorage-test.js
@@ -28,7 +28,7 @@ test.serial('Toggle a storage location', (t) => {
     })
     .then(function assert (data) {
       const cachedStorageList = JSON.parse(localStorage.getItem('storages'))
-      t.true(_.find(cachedStorageList, {key: storageKey}).isOpen === true)
+      t.true(_.find(cachedStorageList, { key: storageKey }).isOpen === true)
     })
 })
 

--- a/tests/fixtures/TestDummy.js
+++ b/tests/fixtures/TestDummy.js
@@ -161,7 +161,7 @@ function dummyLegacyStorage (storagePath, override = {}) {
       folderNotes.push(noteData)
     }
     notesData = notesData.concat(folderNotes)
-    CSON.writeFileSync(path.join(storagePath, jsonData.folders[j].key, 'data.json'), {notes: folderNotes.map((note) => _.omit(note, ['folder']))})
+    CSON.writeFileSync(path.join(storagePath, jsonData.folders[j].key, 'data.json'), { notes: folderNotes.map((note) => _.omit(note, ['folder'])) })
   }
 
   return {

--- a/tests/fixtures/markdowns.js
+++ b/tests/fixtures/markdowns.js
@@ -35,11 +35,13 @@ var project = 'boostnote';
 \`\`\`
 `
 
+/* eslint-disable */
 const katex = `
 $$
 c = \pm\sqrt{a^2 + b^2}
 $$
-`
+` 
+/* eslint-disable */
 
 const checkboxes = `
 - [ ] Unchecked

--- a/tests/helpers/setup-browser-env.js
+++ b/tests/helpers/setup-browser-env.js
@@ -7,7 +7,7 @@ document.body.createTextRange = function () {
     setEnd: function () {},
     setStart: function () {},
     getBoundingClientRect: function () {
-      return {right: 0}
+      return { right: 0 }
     },
     getClientRects: function () {
       return {

--- a/tests/lib/contextMenuBuilder.test.js
+++ b/tests/lib/contextMenuBuilder.test.js
@@ -1,6 +1,6 @@
 let menuBuilderParameter
 jest.mock('electron', () => {
-  return {remote: {require: jest.fn(() => { return {Menu: {buildFromTemplate: jest.fn((param) => { menuBuilderParameter = param })}} })}}
+  return { remote: { require: jest.fn(() => { return { Menu: { buildFromTemplate: jest.fn((param) => { menuBuilderParameter = param }) } } }) } }
 })
 
 const spellcheck = require('browser/lib/spellcheck')
@@ -23,7 +23,7 @@ it('should make sure that word suggestions are only requested if the word contai
   spellcheck.getSpellingSuggestion = jest.fn()
   const editor = jest.fn()
   editor.coordsChar = jest.fn()
-  editor.findWordAt = jest.fn(() => { return {anchor: {}, head: {}} })
+  editor.findWordAt = jest.fn(() => { return { anchor: {}, head: {} } })
   editor.getRange = jest.fn()
   editor.findMarks = jest.fn(() => [])
   const event = {
@@ -44,10 +44,10 @@ it('should make sure that word suggestions are only requested if the word contai
   spellcheck.getCSSClassName = jest.fn(() => 'dummyErrorClassName')
   const editor = jest.fn()
   editor.coordsChar = jest.fn()
-  editor.findWordAt = jest.fn(() => { return {anchor: {}, head: {}} })
+  editor.findWordAt = jest.fn(() => { return { anchor: {}, head: {} } })
   editor.getRange = jest.fn()
   const dummyMarks = [
-    {className: 'someStupidClassName'}
+    { className: 'someStupidClassName' }
   ]
   editor.findMarks = jest.fn(() => dummyMarks)
   const event = {
@@ -66,14 +66,14 @@ it('should make sure that word suggestions are only requested if the word contai
 it('should make sure that word suggestions calls the right editor functions', function () {
   spellcheck.getSpellingSuggestion = jest.fn()
   spellcheck.getCSSClassName = jest.fn(() => 'dummyErrorClassName')
-  const dummyCursor = {dummy: 'dummy'}
-  const dummyRange = {anchor: {test: 'test'}, head: {test2: 'test2'}}
+  const dummyCursor = { dummy: 'dummy' }
+  const dummyRange = { anchor: { test: 'test' }, head: { test2: 'test2' } }
   const editor = jest.fn()
   editor.coordsChar = jest.fn(() => dummyCursor)
   editor.findWordAt = jest.fn(() => dummyRange)
   editor.getRange = jest.fn()
   const dummyMarks = [
-    {className: 'someStupidClassName'}
+    { className: 'someStupidClassName' }
   ]
   editor.findMarks = jest.fn(() => dummyMarks)
   const event = {
@@ -81,7 +81,7 @@ it('should make sure that word suggestions calls the right editor functions', fu
     pageY: 21
   }
 
-  const expectedCoordsCharCall = {left: event.pageX, top: event.pageY}
+  const expectedCoordsCharCall = { left: event.pageX, top: event.pageY }
 
   buildEditorContextMenu(editor, event)
 
@@ -95,13 +95,13 @@ it('should make sure that word suggestions creates a correct menu if there was a
   const errorClassName = 'errorCSS'
   const wordToCorrect = 'pustekuchen'
   const dummyMarks = [
-    {className: errorClassName}
+    { className: errorClassName }
   ]
   spellcheck.getSpellingSuggestion = jest.fn(() => suggestions)
   spellcheck.getCSSClassName = jest.fn(() => errorClassName)
   const editor = jest.fn()
   editor.coordsChar = jest.fn()
-  editor.findWordAt = jest.fn(() => { return {anchor: {}, head: {}} })
+  editor.findWordAt = jest.fn(() => { return { anchor: {}, head: {} } })
   editor.getRange = jest.fn(() => wordToCorrect)
   editor.findMarks = jest.fn(() => [])
 

--- a/tests/lib/get-todo-status-test.js
+++ b/tests/lib/get-todo-status-test.js
@@ -37,4 +37,3 @@ test('getTodoStatus should return a correct hash object', t => {
     t.is(getTodoStatus(input).completed, expected.completed, `Test for getTodoStatus() input: ${input} expected: ${expected.completed}`)
   })
 })
-

--- a/tests/lib/markdown-toc-generator-test.js
+++ b/tests/lib/markdown-toc-generator-test.js
@@ -279,7 +279,7 @@ test(t => {
   const testCases = [
     [
       `***************************** Empty note, cursor at the top`,
-      {line: 0, ch: 0},
+      { line: 0, ch: 0 },
       ``,
       `
 <!-- toc -->
@@ -291,7 +291,7 @@ test(t => {
     ],
     [
       `***************************** Two level note,TOC at the beginning `,
-      {line: 0, ch: 0},
+      { line: 0, ch: 0 },
       `
 # one
 this is a level one text
@@ -329,7 +329,7 @@ this is a level one text
     ],
     [
       `***************************** Two level note, cursor just after 'header text' `,
-      {line: 1, ch: 12},
+      { line: 1, ch: 12 },
       `
 # header 
  header text
@@ -373,7 +373,7 @@ this is a level one text
     ],
     [
       `***************************** Two level note, cursor at empty line under 'header text' `,
-      {line: 2, ch: 0},
+      { line: 2, ch: 0 },
       `
 # header 
  header text
@@ -416,7 +416,7 @@ this is a level one text
     ],
     [
       `***************************** Two level note, cursor just before 'text' word`,
-      {line: 1, ch: 8},
+      { line: 1, ch: 8 },
       `
 # header 
  header text
@@ -461,7 +461,7 @@ this is a level one text
     ],
     [
       `***************************** Already generated TOC without header file, regenerate TOC in place, no changes`,
-      {line: 13, ch: 0},
+      { line: 13, ch: 0 },
       `
 # header 
  header text
@@ -511,7 +511,7 @@ this is a level one text
     ],
     [
       `***************************** Already generated TOC, needs updating in place`,
-      {line: 0, ch: 0},
+      { line: 0, ch: 0 },
       `
 # header 
  header text
@@ -561,7 +561,7 @@ this is a level one text
     ],
     [
       `***************************** Document with cursor at the last line, expecting empty TOC `,
-      {line: 13, ch: 30},
+      { line: 13, ch: 30 },
       `
 # header 
  header text
@@ -602,7 +602,7 @@ this is a level one text
     ],
     [
       `***************************** Empty, not actual TOC , should be supplemented with two new points beneath`,
-      {line: 0, ch: 0},
+      { line: 0, ch: 0 },
       `
 # header 
  header text

--- a/tests/lib/spellcheck.test.js
+++ b/tests/lib/spellcheck.test.js
@@ -14,7 +14,7 @@ it('should test that checkWord does not marks words that do not contain a typo',
   const editor = jest.fn()
   editor.getRange = jest.fn(() => testWord)
   editor.markText = jest.fn()
-  const range = {anchor: {line: 1, ch: 0}, head: {line: 1, ch: 10}}
+  const range = { anchor: { line: 1, ch: 0 }, head: { line: 1, ch: 10 } }
   const mockDictionary = jest.fn()
   mockDictionary.check = jest.fn(() => true)
   systemUnderTest.setDictionaryForTestsOnly(mockDictionary)
@@ -31,7 +31,7 @@ it('should test that checkWord should marks words that contain a typo', function
   const editor = jest.fn()
   editor.getRange = jest.fn(() => testWord)
   editor.markText = jest.fn()
-  const range = {anchor: {line: 1, ch: 0}, head: {line: 1, ch: 10}}
+  const range = { anchor: { line: 1, ch: 0 }, head: { line: 1, ch: 10 } }
   const mockDictionary = jest.fn()
   mockDictionary.check = jest.fn(() => false)
   systemUnderTest.setDictionaryForTestsOnly(mockDictionary)
@@ -40,14 +40,14 @@ it('should test that checkWord should marks words that contain a typo', function
 
   expect(editor.getRange).toHaveBeenCalledWith(range.anchor, range.head)
   expect(mockDictionary.check).toHaveBeenCalledWith(testWord)
-  expect(editor.markText).toHaveBeenCalledWith(range.anchor, range.head, {'className': systemUnderTest.CSS_ERROR_CLASS})
+  expect(editor.markText).toHaveBeenCalledWith(range.anchor, range.head, { 'className': systemUnderTest.CSS_ERROR_CLASS })
 })
 
 it('should test that setLanguage clears all marks', function () {
   const dummyMarks = [
-    {clear: jest.fn()},
-    {clear: jest.fn()},
-    {clear: jest.fn()}
+    { clear: jest.fn() },
+    { clear: jest.fn() },
+    { clear: jest.fn() }
   ]
   const editor = jest.fn()
   editor.getAllMarks = jest.fn(() => dummyMarks)
@@ -102,8 +102,8 @@ it('should test that checkMultiLineRange performs checks for each word in the st
     'In ex neque, volutpat quis ullamcorper in, vestibulum vel ligula. Quisque lobortis eget neque quis ullamcorper. Nunc purus lorem, scelerisque in malesuada id, congue a magna. Donec rutrum maximus egestas. Nulla ornare libero quis odio ultricies iaculis. Suspendisse consectetur bibendum purus ac blandit. Donec et neque quis dolor eleifend tempus. Fusce fringilla risus id venenatis rutrum. Mauris commodo posuere ipsum, sit amet hendrerit risus lacinia quis. Aenean placerat ultricies ante id dapibus. Donec imperdiet eros quis porttitor accumsan. Vestibulum ut nulla luctus velit feugiat elementum. Nam vel pharetra nisl. Nullam risus tellus, tempor quis ipsum et, pretium rutrum ipsum.\n' +
     '\n' +
     'Fusce molestie leo at facilisis mollis. Vivamus iaculis facilisis fermentum. Vivamus blandit id nisi sit amet porta. Nunc luctus porta blandit. Sed ac consequat eros, eu fringilla lorem. In blandit pharetra sollicitudin. Vivamus placerat risus ut ex faucibus, nec vehicula sapien imperdiet. Praesent luctus, leo eget ultrices cursus, neque ante porttitor mauris, id tempus tellus urna at ex. Curabitur elementum id quam vitae condimentum. Proin sit amet magna vel metus blandit iaculis. Phasellus viverra libero in lacus gravida, id laoreet ligula dapibus. Cras commodo arcu eget mi dignissim, et lobortis elit faucibus. Suspendisse potenti. ')
-  const rangeFrom = {line: 2, ch: 4}
-  const rangeTo = {line: 3, ch: 36}
+  const rangeFrom = { line: 2, ch: 4 }
+  const rangeTo = { line: 3, ch: 36 }
 
   systemUnderTest.checkMultiLineRange(editor, rangeFrom, rangeTo)
 
@@ -136,8 +136,8 @@ it('should test that checkMultiLineRange works correct even when the range is in
     'In ex neque, volutpat quis ullamcorper in, vestibulum vel ligula. Quisque lobortis eget neque quis ullamcorper. Nunc purus lorem, scelerisque in malesuada id, congue a magna. Donec rutrum maximus egestas. Nulla ornare libero quis odio ultricies iaculis. Suspendisse consectetur bibendum purus ac blandit. Donec et neque quis dolor eleifend tempus. Fusce fringilla risus id venenatis rutrum. Mauris commodo posuere ipsum, sit amet hendrerit risus lacinia quis. Aenean placerat ultricies ante id dapibus. Donec imperdiet eros quis porttitor accumsan. Vestibulum ut nulla luctus velit feugiat elementum. Nam vel pharetra nisl. Nullam risus tellus, tempor quis ipsum et, pretium rutrum ipsum.\n' +
     '\n' +
     'Fusce molestie leo at facilisis mollis. Vivamus iaculis facilisis fermentum. Vivamus blandit id nisi sit amet porta. Nunc luctus porta blandit. Sed ac consequat eros, eu fringilla lorem. In blandit pharetra sollicitudin. Vivamus placerat risus ut ex faucibus, nec vehicula sapien imperdiet. Praesent luctus, leo eget ultrices cursus, neque ante porttitor mauris, id tempus tellus urna at ex. Curabitur elementum id quam vitae condimentum. Proin sit amet magna vel metus blandit iaculis. Phasellus viverra libero in lacus gravida, id laoreet ligula dapibus. Cras commodo arcu eget mi dignissim, et lobortis elit faucibus. Suspendisse potenti. ')
-  const rangeFrom = {line: 3, ch: 36}
-  const rangeTo = {line: 2, ch: 4}
+  const rangeFrom = { line: 3, ch: 36 }
+  const rangeTo = { line: 2, ch: 4 }
 
   systemUnderTest.checkMultiLineRange(editor, rangeFrom, rangeTo)
 
@@ -170,8 +170,8 @@ it('should test that checkMultiLineRange works for single line', function () {
     'In ex neque, volutpat quis ullamcorper in, vestibulum vel ligula. Quisque lobortis eget neque quis ullamcorper. Nunc purus lorem, scelerisque in malesuada id, congue a magna. Donec rutrum maximus egestas. Nulla ornare libero quis odio ultricies iaculis. Suspendisse consectetur bibendum purus ac blandit. Donec et neque quis dolor eleifend tempus. Fusce fringilla risus id venenatis rutrum. Mauris commodo posuere ipsum, sit amet hendrerit risus lacinia quis. Aenean placerat ultricies ante id dapibus. Donec imperdiet eros quis porttitor accumsan. Vestibulum ut nulla luctus velit feugiat elementum. Nam vel pharetra nisl. Nullam risus tellus, tempor quis ipsum et, pretium rutrum ipsum.\n' +
     '\n' +
     'Fusce molestie leo at facilisis mollis. Vivamus iaculis facilisis fermentum. Vivamus blandit id nisi sit amet porta. Nunc luctus porta blandit. Sed ac consequat eros, eu fringilla lorem. In blandit pharetra sollicitudin. Vivamus placerat risus ut ex faucibus, nec vehicula sapien imperdiet. Praesent luctus, leo eget ultrices cursus, neque ante porttitor mauris, id tempus tellus urna at ex. Curabitur elementum id quam vitae condimentum. Proin sit amet magna vel metus blandit iaculis. Phasellus viverra libero in lacus gravida, id laoreet ligula dapibus. Cras commodo arcu eget mi dignissim, et lobortis elit faucibus. Suspendisse potenti. ')
-  const rangeFrom = {line: 5, ch: 14}
-  const rangeTo = {line: 5, ch: 39}
+  const rangeFrom = { line: 5, ch: 14 }
+  const rangeTo = { line: 5, ch: 39 }
 
   systemUnderTest.checkMultiLineRange(editor, rangeFrom, rangeTo)
 
@@ -196,8 +196,8 @@ it('should test that checkMultiLineRange works for single word', function () {
     'In ex neque, volutpat quis ullamcorper in, vestibulum vel ligula. Quisque lobortis eget neque quis ullamcorper. Nunc purus lorem, scelerisque in malesuada id, congue a magna. Donec rutrum maximus egestas. Nulla ornare libero quis odio ultricies iaculis. Suspendisse consectetur bibendum purus ac blandit. Donec et neque quis dolor eleifend tempus. Fusce fringilla risus id venenatis rutrum. Mauris commodo posuere ipsum, sit amet hendrerit risus lacinia quis. Aenean placerat ultricies ante id dapibus. Donec imperdiet eros quis porttitor accumsan. Vestibulum ut nulla luctus velit feugiat elementum. Nam vel pharetra nisl. Nullam risus tellus, tempor quis ipsum et, pretium rutrum ipsum.\n' +
     '\n' +
     'Fusce molestie leo at facilisis mollis. Vivamus iaculis facilisis fermentum. Vivamus blandit id nisi sit amet porta. Nunc luctus porta blandit. Sed ac consequat eros, eu fringilla lorem. In blandit pharetra sollicitudin. Vivamus placerat risus ut ex faucibus, nec vehicula sapien imperdiet. Praesent luctus, leo eget ultrices cursus, neque ante porttitor mauris, id tempus tellus urna at ex. Curabitur elementum id quam vitae condimentum. Proin sit amet magna vel metus blandit iaculis. Phasellus viverra libero in lacus gravida, id laoreet ligula dapibus. Cras commodo arcu eget mi dignissim, et lobortis elit faucibus. Suspendisse potenti. ')
-  const rangeFrom = {line: 7, ch: 6}
-  const rangeTo = {line: 7, ch: 6}
+  const rangeFrom = { line: 7, ch: 6 }
+  const rangeTo = { line: 7, ch: 6 }
 
   systemUnderTest.checkMultiLineRange(editor, rangeFrom, rangeTo)
 
@@ -221,18 +221,18 @@ it('should make sure that liveSpellcheck don\'t work if the spellcheck is not en
 
 it('should make sure that liveSpellcheck works for a range of changes', function () {
   const editor = jest.fn()
-  const marks = [{clear: jest.fn()}, {clear: jest.fn()}]
+  const marks = [{ clear: jest.fn() }, { clear: jest.fn() }]
   editor.findMarks = jest.fn(() => marks)
   const checkMultiLineRangeSpy = jest.spyOn(systemUnderTest, 'checkMultiLineRange').mockImplementation()
 
-  const inputChangeRange = {from: {line: 0, ch: 2}, to: {line: 1, ch: 1}}
-  const inputChangeRangeTo = {from: {line: 0, ch: 2}, to: {line: 1, ch: 2}}
+  const inputChangeRange = { from: { line: 0, ch: 2 }, to: { line: 1, ch: 1 } }
+  const inputChangeRangeTo = { from: { line: 0, ch: 2 }, to: { line: 1, ch: 2 } }
 
   systemUnderTest.setDictionaryForTestsOnly({})
   systemUnderTest.checkChangeRange(editor, inputChangeRange, inputChangeRangeTo)
 
-  expect(checkMultiLineRangeSpy).toHaveBeenCalledWith(editor, {line: 0, ch: 1}, {line: 1, ch: 3})
-  expect(editor.findMarks).toHaveBeenCalledWith({line: 0, ch: 1}, {line: 1, ch: 3})
+  expect(checkMultiLineRangeSpy).toHaveBeenCalledWith(editor, { line: 0, ch: 1 }, { line: 1, ch: 3 })
+  expect(editor.findMarks).toHaveBeenCalledWith({ line: 0, ch: 1 }, { line: 1, ch: 3 })
   expect(marks[0].clear).toHaveBeenCalled()
   expect(marks[1].clear).toHaveBeenCalled()
   checkMultiLineRangeSpy.mockRestore()
@@ -240,18 +240,18 @@ it('should make sure that liveSpellcheck works for a range of changes', function
 
 it('should make sure that liveSpellcheck works if ranges are inverted', function () {
   const editor = jest.fn()
-  const marks = [{clear: jest.fn()}, {clear: jest.fn()}]
+  const marks = [{ clear: jest.fn() }, { clear: jest.fn() }]
   editor.findMarks = jest.fn(() => marks)
   const checkMultiLineRangeSpy = jest.spyOn(systemUnderTest, 'checkMultiLineRange').mockImplementation()
 
-  const inputChangeRange = {from: {line: 0, ch: 2}, to: {line: 1, ch: 2}}
-  const inputChangeRangeTo = {from: {line: 0, ch: 2}, to: {line: 1, ch: 1}}
+  const inputChangeRange = { from: { line: 0, ch: 2 }, to: { line: 1, ch: 2 } }
+  const inputChangeRangeTo = { from: { line: 0, ch: 2 }, to: { line: 1, ch: 1 } }
 
   systemUnderTest.setDictionaryForTestsOnly({})
   systemUnderTest.checkChangeRange(editor, inputChangeRange, inputChangeRangeTo)
 
-  expect(checkMultiLineRangeSpy).toHaveBeenCalledWith(editor, {line: 0, ch: 1}, {line: 1, ch: 3})
-  expect(editor.findMarks).toHaveBeenCalledWith({line: 0, ch: 1}, {line: 1, ch: 3})
+  expect(checkMultiLineRangeSpy).toHaveBeenCalledWith(editor, { line: 0, ch: 1 }, { line: 1, ch: 3 })
+  expect(editor.findMarks).toHaveBeenCalledWith({ line: 0, ch: 1 }, { line: 1, ch: 3 })
   expect(marks[0].clear).toHaveBeenCalled()
   expect(marks[1].clear).toHaveBeenCalled()
   checkMultiLineRangeSpy.mockRestore()
@@ -272,8 +272,8 @@ it('should make sure that liveSpellcheck works for a single word with change at 
     'In ex neque, volutpat quis ullamcorper in, vestibulum vel ligula. Quisque lobortis eget neque quis ullamcorper. Nunc purus lorem, scelerisque in malesuada id, congue a magna. Donec rutrum maximus egestas. Nulla ornare libero quis odio ultricies iaculis. Suspendisse consectetur bibendum purus ac blandit. Donec et neque quis dolor eleifend tempus. Fusce fringilla risus id venenatis rutrum. Mauris commodo posuere ipsum, sit amet hendrerit risus lacinia quis. Aenean placerat ultricies ante id dapibus. Donec imperdiet eros quis porttitor accumsan. Vestibulum ut nulla luctus velit feugiat elementum. Nam vel pharetra nisl. Nullam risus tellus, tempor quis ipsum et, pretium rutrum ipsum.\n' +
     '\n' +
     'Fusce molestie leo at facilisis mollis. Vivamus iaculis facilisis fermentum. Vivamus blandit id nisi sit amet porta. Nunc luctus porta blandit. Sed ac consequat eros, eu fringilla lorem. In blandit pharetra sollicitudin. Vivamus placerat risus ut ex faucibus, nec vehicula sapien imperdiet. Praesent luctus, leo eget ultrices cursus, neque ante porttitor mauris, id tempus tellus urna at ex. Curabitur elementum id quam vitae condimentum. Proin sit amet magna vel metus blandit iaculis. Phasellus viverra libero in lacus gravida, id laoreet ligula dapibus. Cras commodo arcu eget mi dignissim, et lobortis elit faucibus. Suspendisse potenti. ')
-  const rangeFrom = {from: {line: 7, ch: 6}, to: {line: 7, ch: 6}}
-  const rangeTo = {from: {line: 7, ch: 6}, to: {line: 7, ch: 6}}
+  const rangeFrom = { from: { line: 7, ch: 6 }, to: { line: 7, ch: 6 } }
+  const rangeTo = { from: { line: 7, ch: 6 }, to: { line: 7, ch: 6 } }
 
   systemUnderTest.checkChangeRange(editor, rangeFrom, rangeTo)
 
@@ -296,8 +296,8 @@ it('should make sure that liveSpellcheck works for a single word with change in 
     'In ex neque, volutpat quis ullamcorper in, vestibulum vel ligula. Quisque lobortis eget neque quis ullamcorper. Nunc purus lorem, scelerisque in malesuada id, congue a magna. Donec rutrum maximus egestas. Nulla ornare libero quis odio ultricies iaculis. Suspendisse consectetur bibendum purus ac blandit. Donec et neque quis dolor eleifend tempus. Fusce fringilla risus id venenatis rutrum. Mauris commodo posuere ipsum, sit amet hendrerit risus lacinia quis. Aenean placerat ultricies ante id dapibus. Donec imperdiet eros quis porttitor accumsan. Vestibulum ut nulla luctus velit feugiat elementum. Nam vel pharetra nisl. Nullam risus tellus, tempor quis ipsum et, pretium rutrum ipsum.\n' +
     '\n' +
     'Fusce molestie leo at facilisis mollis. Vivamus iaculis facilisis fermentum. Vivamus blandit id nisi sit amet porta. Nunc luctus porta blandit. Sed ac consequat eros, eu fringilla lorem. In blandit pharetra sollicitudin. Vivamus placerat risus ut ex faucibus, nec vehicula sapien imperdiet. Praesent luctus, leo eget ultrices cursus, neque ante porttitor mauris, id tempus tellus urna at ex. Curabitur elementum id quam vitae condimentum. Proin sit amet magna vel metus blandit iaculis. Phasellus viverra libero in lacus gravida, id laoreet ligula dapibus. Cras commodo arcu eget mi dignissim, et lobortis elit faucibus. Suspendisse potenti. ')
-  const rangeFrom = {from: {line: 7, ch: 9}, to: {line: 7, ch: 9}}
-  const rangeTo = {from: {line: 7, ch: 9}, to: {line: 7, ch: 9}}
+  const rangeFrom = { from: { line: 7, ch: 9 }, to: { line: 7, ch: 9 } }
+  const rangeTo = { from: { line: 7, ch: 9 }, to: { line: 7, ch: 9 } }
 
   systemUnderTest.checkChangeRange(editor, rangeFrom, rangeTo)
 
@@ -320,8 +320,8 @@ it('should make sure that liveSpellcheck works for a single word with change at 
     'In ex neque, volutpat quis ullamcorper in, vestibulum vel ligula. Quisque lobortis eget neque quis ullamcorper. Nunc purus lorem, scelerisque in malesuada id, congue a magna. Donec rutrum maximus egestas. Nulla ornare libero quis odio ultricies iaculis. Suspendisse consectetur bibendum purus ac blandit. Donec et neque quis dolor eleifend tempus. Fusce fringilla risus id venenatis rutrum. Mauris commodo posuere ipsum, sit amet hendrerit risus lacinia quis. Aenean placerat ultricies ante id dapibus. Donec imperdiet eros quis porttitor accumsan. Vestibulum ut nulla luctus velit feugiat elementum. Nam vel pharetra nisl. Nullam risus tellus, tempor quis ipsum et, pretium rutrum ipsum.\n' +
     '\n' +
     'Fusce molestie leo at facilisis mollis. Vivamus iaculis facilisis fermentum. Vivamus blandit id nisi sit amet porta. Nunc luctus porta blandit. Sed ac consequat eros, eu fringilla lorem. In blandit pharetra sollicitudin. Vivamus placerat risus ut ex faucibus, nec vehicula sapien imperdiet. Praesent luctus, leo eget ultrices cursus, neque ante porttitor mauris, id tempus tellus urna at ex. Curabitur elementum id quam vitae condimentum. Proin sit amet magna vel metus blandit iaculis. Phasellus viverra libero in lacus gravida, id laoreet ligula dapibus. Cras commodo arcu eget mi dignissim, et lobortis elit faucibus. Suspendisse potenti. ')
-  const rangeFrom = {from: {line: 7, ch: 14}, to: {line: 7, ch: 14}}
-  const rangeTo = {from: {line: 7, ch: 14}, to: {line: 7, ch: 14}}
+  const rangeFrom = { from: { line: 7, ch: 14 }, to: { line: 7, ch: 14 } }
+  const rangeTo = { from: { line: 7, ch: 14 }, to: { line: 7, ch: 14 } }
 
   systemUnderTest.checkChangeRange(editor, rangeFrom, rangeTo)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,4 +39,3 @@ var config = Object.assign({}, skeleton, {
 })
 
 module.exports = config
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -7950,22 +7950,6 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier-standard@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/prettier-standard/-/prettier-standard-9.1.1.tgz#31926843d6d2b428fbecb3aceea59e872947d016"
-  integrity sha512-d23Hbdf7tIJ5qeEPEv+7B9cGGczJBOyq188kiKGPk/lvlrM3J8umWC8rR9LIbWmuMzbl5iDSL7kG1/wZgh3EYg==
-  dependencies:
-    find-up "^3.0.0"
-    get-stdin "^6.0.0"
-    minimist "^1.2.0"
-    prettierx "0.3.0"
-    stream-mock "1.2.0"
-
-prettierx@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/prettierx/-/prettierx-0.3.0.tgz#7c8bd8b809507bf9ba503729e6c24af152a58136"
-  integrity sha512-cMtPQ1+mhWsMPAJycwUqVYQBL30TrVJnVz8K888WN67mpXMHAHGY53jLgFR2Pr3v3YE8Rz9kxZCB7S7vAfz1iA==
-
 pretty-bytes@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
@@ -9374,13 +9358,6 @@ stream-http@^2.3.1:
     readable-stream "^2.3.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
-
-stream-mock@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/stream-mock/-/stream-mock-1.2.0.tgz#f68b5523c0e1cfe619ea09d7d1097290f405b96a"
-  integrity sha1-9otVI8Dhz+YZ6gnX0QlykPQFuWo=
-  dependencies:
-    babel-runtime "^6.26.0"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,11 +38,52 @@
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz#becd805482734440c9d137e46d77340e64d7f51b"
   dependencies:
     "@babel/highlight" "7.0.0-beta.49"
+
+"@babel/generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
+  integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
+  dependencies:
+    "@babel/types" "^7.4.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
 
 "@babel/highlight@7.0.0-beta.49":
   version "7.0.0-beta.49"
@@ -51,6 +92,60 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
+  integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
+
+"@babel/runtime@^7.0.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/template@^7.1.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
+"@babel/traverse@^7.0.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
+  integrity sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
+"@babel/types@^7.0.0", "@babel/types@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
 
 "@concordance/react@^1.0.0":
   version "1.0.0"
@@ -91,6 +186,13 @@
     fs-plus "2.x"
     optimist "~0.4.0"
 
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
+
 "@susisu/mte-kernel@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@susisu/mte-kernel/-/mte-kernel-2.0.0.tgz#da3354d6a07ea27f36ec91d9fccf6bfa9010d00e"
@@ -100,6 +202,11 @@
 "@types/node@^8.0.24":
   version "8.10.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.17.tgz#d48cf10f0dc6dcf59f827f5a3fc7a4a6004318d3"
+
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
 abab@^1.0.3, abab@^1.0.4:
   version "1.0.4"
@@ -136,13 +243,12 @@ acorn-globals@^4.1.0:
   dependencies:
     acorn "^5.0.0"
 
-acorn-jsx@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
-  dependencies:
-    acorn "^3.0.4"
+acorn-jsx@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
-acorn@^3.0.0, acorn@^3.0.4:
+acorn@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
@@ -150,7 +256,7 @@ acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.3.0, acorn@^5.5.0:
+acorn@^5.0.0, acorn@^5.3.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
@@ -158,16 +264,15 @@ acorn@^5.5.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+acorn@^6.0.2, acorn@^6.0.7:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
-ajv@^4.7.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
+ajv-keywords@^3.0.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
+  integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
 
 ajv@^5.1.0:
   version "5.5.2"
@@ -177,6 +282,16 @@ ajv@^5.1.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.0.1, ajv@^6.5.0, ajv@^6.9.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -200,13 +315,14 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-red@^0.1.1:
   version "0.1.1"
@@ -225,6 +341,11 @@ ansi-regex@^2.0.0:
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^1.1.0:
   version "1.1.0"
@@ -247,6 +368,11 @@ ansi-styles@~1.0.0:
 ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
 anymatch@^1.3.0:
   version "1.3.2"
@@ -291,6 +417,14 @@ argparse@^1.0.7, argparse@~1.0.3:
   dependencies:
     underscore "~1.7.0"
     underscore.string "~2.4.0"
+
+aria-query@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -438,6 +572,11 @@ assert@^1.1.1:
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
+ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -634,7 +773,14 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
+axobject-query@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
+  integrity sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==
+  dependencies:
+    ast-types-flow "0.0.7"
+
+babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -665,6 +811,18 @@ babel-core@^6.0.0, babel-core@^6.14.0, babel-core@^6.17.0, babel-core@^6.26.0:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.1.0, babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
@@ -1525,19 +1683,40 @@ call-signature@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/call-signature/-/call-signature-0.0.2.tgz#a84abc825a55ef4cb2b028bd74e205a65b9a4996"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  integrity sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
   dependencies:
     callsites "^0.2.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
 
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+  integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
 
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -1628,7 +1807,7 @@ chalk@^0.4.0:
     has-color "~0.1.0"
     strip-ansi "~0.1.0"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1645,6 +1824,25 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chart.js@^2.7.2:
   version "2.7.2"
@@ -1697,13 +1895,15 @@ ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
 
-ci-info@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+  integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
 
 clap@^1.0.9:
   version "1.2.3"
@@ -1736,13 +1936,7 @@ cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
-  dependencies:
-    restore-cursor "^1.0.1"
-
-cli-cursor@^2.1.0:
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
@@ -1751,6 +1945,14 @@ cli-cursor@^2.1.0:
 cli-spinners@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-truncate@^1.0.0:
   version "1.1.0"
@@ -1938,6 +2140,11 @@ commander@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
 
+commander@^2.11.0, commander@^2.14.1:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
 commander@^2.8.1, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -1984,7 +2191,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.2, concat-stream@^1.4.6, concat-stream@^1.5.2:
+concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -2043,6 +2250,11 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
+confusing-browser-globals@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz#5ae852bd541a910e7ffb2dbb864a2d21a36ad29b"
+  integrity sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==
+
 connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
@@ -2060,6 +2272,11 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
 content-disposition@0.5.2:
   version "0.5.2"
@@ -2118,12 +2335,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
+cosmiconfig@^5.0.2, cosmiconfig@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
   dependencies:
+    import-fresh "^2.0.0"
     is-directory "^0.3.1"
-    js-yaml "^3.9.0"
+    js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
 create-error-class@^3.0.0, create-error-class@^3.0.1:
@@ -2145,6 +2364,17 @@ cross-spawn@^5.0.1:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -2522,12 +2752,6 @@ d3@^4.13.0:
     d3-voronoi "1.1.2"
     d3-zoom "1.7.1"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
-  dependencies:
-    es5-ext "^0.10.9"
-
 dagre-d3-renderer@^0.5.8:
   version "0.5.8"
   resolved "http://registry.npm.taobao.org/dagre-d3-renderer/download/dagre-d3-renderer-0.5.8.tgz#aa071bb71d3c4d67426925906f3f6ddead49c1a3"
@@ -2541,6 +2765,11 @@ dagre-layout@^0.8.8:
   dependencies:
     graphlibrary "^2.2.0"
     lodash "^4.17.5"
+
+damerau-levenshtein@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+  integrity sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2559,6 +2788,11 @@ data-urls@^1.0.0:
 date-fns@^1.23.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -2581,6 +2815,7 @@ dateformat@1.0.2-1.2.3:
 debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+  integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
 
 debug@*, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
@@ -2588,11 +2823,18 @@ debug@*, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
+
+debug@^4.0.1, debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -2625,6 +2867,11 @@ decompress-zip@0.3.0:
     q "^1.1.2"
     readable-stream "^1.1.8"
     touch "0.0.3"
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-equal@^1.0.0:
   version "1.0.1"
@@ -2674,9 +2921,10 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
-deglob@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/deglob/-/deglob-2.1.0.tgz#4d44abe16ef32c779b4972bd141a80325029a14a"
+deglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deglob/-/deglob-2.1.1.tgz#d268e168727799862e8eac07042e165957c1f3be"
+  integrity sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==
   dependencies:
     find-root "^1.0.0"
     glob "^7.0.5"
@@ -2685,16 +2933,28 @@ deglob@^2.0.0:
     run-parallel "^1.1.2"
     uniq "^1.0.1"
 
-del@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+deglob@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/deglob/-/deglob-3.1.0.tgz#1868193193d3432a5326e8fb2052b439a43a454e"
+  integrity sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==
   dependencies:
-    globby "^5.0.0"
+    find-root "^1.0.0"
+    glob "^7.0.5"
+    ignore "^5.0.0"
+    pkg-config "^1.1.0"
+    run-parallel "^1.1.2"
+    uniq "^1.0.1"
+
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
+  dependencies:
+    globby "^6.1.0"
     is-path-cwd "^1.0.0"
     is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
     rimraf "^2.2.8"
 
 delayed-stream@0.0.5:
@@ -2755,16 +3015,24 @@ diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
-doctrine@^1.2.2:
+doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0, doctrine@^2.0.2:
+doctrine@^2.0.2, doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
@@ -2960,6 +3228,16 @@ electron@3.0.8:
     electron-download "^4.1.0"
     extract-zip "^1.0.3"
 
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+emoji-regex@^7.0.1, emoji-regex@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -2980,6 +3258,13 @@ encoding@^0.1.11:
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
+
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@~0.9.0:
   version "0.9.1"
@@ -3037,66 +3322,13 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.42"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.42.tgz#8c07dd33af04d5dcd1310b5cef13bea63a89ba8d"
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.1"
-    next-tick "1"
-
 es6-error@^4.0.1, es6-error@^4.0.2:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
 
-es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-map@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-set "~0.1.5"
-    es6-symbol "~3.1.1"
-    event-emitter "~0.3.5"
-
 es6-promise@^3.1.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
-
-es6-set@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-symbol "3.1.1"
-    event-emitter "~0.3.5"
-
-es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -3128,30 +3360,113 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+eslint-config-react-app@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-4.0.0.tgz#1651f44b3830d863817af6ebed0916193aa870c3"
+  integrity sha512-SeFxaI+0NAzWPFAI9AT+Vp9Xe2u5RCnn0JVEXkE338HgoPujc38Bc0upCJw4BWmavvIN/ODmE6EuzHoAEn3ozw==
   dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
+    confusing-browser-globals "^1.0.7"
 
-eslint-config-standard-jsx@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-3.2.0.tgz#c240e26ed919a11a42aa4de8059472b38268d620"
+eslint-config-standard-jsx@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz#90c9aa16ac2c4f8970c13fc7efc608bacd02da70"
+  integrity sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==
 
 eslint-config-standard-jsx@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-3.3.0.tgz#cab0801a15a360bf63facb97ab22fbdd88d8a5e0"
 
-eslint-config-standard@6.2.1, eslint-config-standard@^6.2.1:
+eslint-config-standard@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz#638b4c65db0bd5a41319f96bba1f15ddad2107d9"
+  integrity sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==
+
+eslint-config-standard@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-6.2.1.tgz#d3a68aafc7191639e7ee441e7348739026354292"
 
-eslint-plugin-promise@~3.4.0:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.2.tgz#1be2793eafe2d18b5b123b8136c269f804fe7122"
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  integrity sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
+  integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-es@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz#475f65bb20c993fc10e8c8fe77d1d60068072da6"
+  integrity sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==
+  dependencies:
+    eslint-utils "^1.3.0"
+    regexpp "^2.0.1"
+
+eslint-plugin-flowtype@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.7.0.tgz#6662392f2daf6056138448b46ebc17c7a83ad337"
+  integrity sha512-6PAYrfSAd23C6ZTc9OhEpSn4uz5HnaXSOYzBLPiKNAE+WmNnWkgkfrswOK2Rlvn91ofZoba7SR04gitnmW9sqg==
+  dependencies:
+    lodash "^4.17.11"
+
+eslint-plugin-import@~2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
+  integrity sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==
+  dependencies:
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.2.0"
+    has "^1.0.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+    resolve "^1.6.0"
+
+eslint-plugin-jsx-a11y@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz#4ebba9f339b600ff415ae4166e3e2e008831cf0c"
+  integrity sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==
+  dependencies:
+    aria-query "^3.0.0"
+    array-includes "^3.0.3"
+    ast-types-flow "^0.0.7"
+    axobject-query "^2.0.2"
+    damerau-levenshtein "^1.0.4"
+    emoji-regex "^7.0.2"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
+
+eslint-plugin-node@~7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz#a6e054e50199b2edd85518b89b4e7b323c9f36db"
+  integrity sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==
+  dependencies:
+    eslint-plugin-es "^1.3.1"
+    eslint-utils "^1.3.1"
+    ignore "^4.0.2"
+    minimatch "^3.0.4"
+    resolve "^1.8.1"
+    semver "^5.5.0"
+
+eslint-plugin-promise@~4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz#2d074b653f35a23d1ba89d8e976a985117d1c6a2"
+  integrity sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==
+
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
 
 eslint-plugin-react@^7.8.2:
   version "7.8.2"
@@ -3162,99 +3477,137 @@ eslint-plugin-react@^7.8.2:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.0"
 
-eslint-plugin-react@~6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.7.1.tgz#1af96aea545856825157d97c1b50d5a8fb64a5a7"
+eslint-plugin-react@~7.11.1:
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
+  integrity sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==
   dependencies:
-    doctrine "^1.2.2"
-    jsx-ast-utils "^1.3.3"
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
+    prop-types "^15.6.2"
 
 eslint-plugin-standard@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz#2a9e21259ba4c47c02d53b2d0c9135d4b1022d47"
 
-eslint-plugin-standard@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-2.0.1.tgz#3589699ff9c917f2c25f76a916687f641c369ff3"
+eslint-plugin-standard@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz#f845b45109c99cd90e77796940a344546c8f6b5c"
+  integrity sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==
 
-eslint@^3.13.1:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
   dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.5.2"
-    debug "^2.1.1"
-    doctrine "^2.0.0"
-    escope "^3.6.0"
-    espree "^3.4.0"
-    esquery "^1.0.0"
-    estraverse "^4.2.0"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-scope@^4.0.0, eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.3.0, eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint@^5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
+  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.9.1"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.1"
+    esquery "^1.0.1"
     esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    inquirer "^6.2.2"
+    js-yaml "^3.13.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
-    strip-json-comments "~2.0.1"
-    table "^3.7.8"
-    text-table "~0.2.0"
-    user-home "^2.0.0"
+    path-is-inside "^1.0.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
 
-eslint@~3.10.2:
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.10.2.tgz#c9a10e8bf6e9d65651204778c503341f1eac3ce7"
+eslint@~5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.4.0.tgz#d068ec03006bb9e06b429dc85f7e46c1b69fac62"
+  integrity sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==
   dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.4.6"
-    debug "^2.1.1"
-    doctrine "^1.2.2"
-    escope "^3.6.0"
-    espree "^3.3.1"
-    estraverse "^4.2.0"
+    ajv "^6.5.0"
+    babel-code-frame "^6.26.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.2.0"
-    ignore "^3.2.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.2"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    inquirer "^5.2.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.11.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
-    strip-json-comments "~1.0.1"
-    table "^3.7.8"
-    text-table "~0.2.0"
-    user-home "^2.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.5.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
 
 espower-location-detector@^1.0.0:
   version "1.0.0"
@@ -3265,12 +3618,23 @@ espower-location-detector@^1.0.0:
     source-map "^0.5.0"
     xtend "^4.0.0"
 
-espree@^3.3.1, espree@^3.4.0:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+espree@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"
+  integrity sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==
   dependencies:
-    acorn "^5.5.0"
-    acorn-jsx "^3.0.0"
+    acorn "^6.0.2"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
 
 esprima@^2.6.0:
   version "2.7.3"
@@ -3294,7 +3658,7 @@ espurify@^1.6.0:
   dependencies:
     core-js "^2.0.0"
 
-esquery@^1.0.0:
+esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
@@ -3325,13 +3689,6 @@ eve-raphael@0.5.0:
 "eve@git://github.com/adobe-webplatform/eve.git#eef80ed":
   version "0.4.1"
   resolved "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
-
-event-emitter@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
 
 event-pubsub@4.2.3:
   version "4.2.3"
@@ -3373,21 +3730,18 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
   dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 exit@^0.1.2, exit@~0.1.1:
   version "0.1.2"
@@ -3480,6 +3834,24 @@ extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+external-editor@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
+external-editor@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -3523,6 +3895,11 @@ faker@^3.1.0:
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-diff@^1.1.1:
   version "1.1.2"
@@ -3576,7 +3953,7 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
-figures@^1.3.5:
+figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -3592,9 +3969,17 @@ figures@^2.0.0:
 file-entry-cache@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  integrity sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
 
 file-uri-to-path@^1.0.0:
   version "1.0.0"
@@ -3674,9 +4059,15 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
 find-root@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -3705,13 +4096,28 @@ findup-sync@~0.1.2:
     lodash "~2.4.1"
 
 flat-cache@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
+  integrity sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==
   dependencies:
     circular-json "^0.3.1"
-    del "^2.0.2"
     graceful-fs "^4.1.2"
+    rimraf "~2.6.2"
     write "^0.2.1"
+
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -3730,7 +4136,7 @@ flowchart.js@^1.6.5:
   dependencies:
     raphael "2.2.7"
 
-fn-name@^2.0.0:
+fn-name@^2.0.0, fn-name@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
@@ -3868,6 +4274,20 @@ function-name-support@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/function-name-support/-/function-name-support-0.2.0.tgz#55d3bfaa6eafd505a50f9bc81fdf57564a0bb071"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+g-status@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/g-status/-/g-status-2.0.2.tgz#270fd32119e8fc9496f066fe5fe88e0a6bc78b97"
+  integrity sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==
+  dependencies:
+    arrify "^1.0.1"
+    matcher "^1.0.0"
+    simple-git "^1.85.0"
+
 galactus@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/galactus/-/galactus-0.2.1.tgz#cbed2d20a40c1f5679a35908e2b9415733e78db9"
@@ -3914,6 +4334,11 @@ get-folder-size@^1.0.0:
     async "^1.4.2"
     gar "^1.0.2"
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
+  integrity sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==
+
 get-package-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/get-package-info/-/get-package-info-1.0.0.tgz#6432796563e28113cd9474dbbd00052985a4999c"
@@ -3931,17 +4356,26 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
-get-stdin@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
-
 get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
 
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -4019,6 +4453,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@~3.1.21:
   version "3.1.21"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.1.21.tgz#d29e0a055dea5138f4d07ed40e8982e83c2066cd"
@@ -4040,22 +4486,16 @@ global@^4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^9.14.0, globals@^9.18.0, globals@^9.2.0:
+globals@^11.1.0, globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
-globby@^6.0.0:
+globby@^6.0.0, globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
   dependencies:
@@ -4311,6 +4751,13 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
 hawk@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-2.3.1.tgz#1e731ce39447fa1d0f6d707f7bceebec0fd1ec1f"
@@ -4481,18 +4928,19 @@ humanize-plus@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
 
-husky@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.0.tgz#7271e85f5d98b54349788839b720c9a60cd95dba"
+husky@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-2.2.0.tgz#4dda4370ba0f145b6594be4a4e4e4d4c82a6f2d5"
+  integrity sha512-lG33E7zq6v//H/DQIojPEi1ZL9ebPFt3MxUMD8MR0lrS2ljEPiuUUxlziKIs/o9EafF0chL7bAtLQkcPvXmdnA==
   dependencies:
-    cosmiconfig "^5.0.6"
-    execa "^0.9.0"
+    cosmiconfig "^5.2.0"
+    execa "^1.0.0"
     find-up "^3.0.0"
-    get-stdin "^6.0.0"
-    is-ci "^1.2.1"
-    pkg-dir "^3.0.0"
+    get-stdin "^7.0.0"
+    is-ci "^2.0.0"
+    pkg-dir "^4.1.0"
     please-upgrade-node "^3.1.1"
-    read-pkg "^4.0.1"
+    read-pkg "^5.0.0"
     run-node "^1.0.0"
     slash "^2.0.0"
 
@@ -4512,6 +4960,13 @@ iconv-lite@0.4, iconv-lite@^0.4.19, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@^0.4.17, iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@~0.2.11:
   version "0.2.11"
@@ -4541,13 +4996,40 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.0.9, ignore@^3.2.0:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
+ignore@^3.0.9:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
+ignore@^4.0.2, ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.1.tgz#2fc6b8f518aff48fef65a7f348ed85632448e4a5"
+  integrity sha512-DWjnQIFLenVrwyRCKZT+7a7/U4Cqgar4WG8V++K3hw+lrW1hc/SIwdiGmtxKCVACmHULTuGeBbHJmbwW7/sAvA==
 
 immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -4612,31 +5094,47 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+  integrity sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.2.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.11"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
-
-interpret@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.4"
@@ -4711,11 +5209,12 @@ is-ci@^1.0.10, is-ci@^1.0.7:
   dependencies:
     ci-info "^1.0.0"
 
-is-ci@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
-    ci-info "^1.5.0"
+    ci-info "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -4781,7 +5280,7 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
-is-extglob@^2.1.0:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
@@ -4817,6 +5316,13 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-glob@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-installed-globally@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
@@ -4828,7 +5334,7 @@ is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
 
-is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.0:
+is-my-json-valid@^2.12.0:
   version "2.17.2"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz#6b2103a288e94ef3de5cf15d29dd85fc4b78d65c"
   dependencies:
@@ -4858,7 +5364,7 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
 
-is-obj@^1.0.0:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
@@ -4868,7 +5374,7 @@ is-observable@^0.2.0:
   dependencies:
     symbol-observable "^0.2.2"
 
-is-observable@^1.0.0:
+is-observable@^1.0.0, is-observable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
   dependencies:
@@ -4936,9 +5442,15 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-resolvable@^1.0.0:
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
+is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+  integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
@@ -5376,18 +5888,26 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.10.0, js-yaml@^3.5.1, js-yaml@^3.7.0:
+js-yaml@^3.10.0, js-yaml@^3.7.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.12.0, js-yaml@^3.8.1, js-yaml@^3.9.0:
+js-yaml@^3.11.0, js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.12.0, js-yaml@^3.8.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -5533,6 +6053,11 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
@@ -5549,11 +6074,21 @@ json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -5599,10 +6134,6 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
-
-jsx-ast-utils@^1.3.3:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
 jsx-ast-utils@^2.0.1:
   version "2.0.1"
@@ -5691,6 +6222,37 @@ linkify-it@~1.2.0, linkify-it@~1.2.2:
   dependencies:
     uc.micro "^1.0.1"
 
+lint-staged@^8.1.6:
+  version "8.1.6"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.1.6.tgz#128a9bc5effbf69a359fb8f7eeb2da71a998daf6"
+  integrity sha512-QT13AniHN6swAtTjsrzxOfE4TVCiQ39xESwLmjGVNCMMZ/PK5aopwvbxLrzw+Zf9OxM3cQG6WCx9lceLzETOnQ==
+  dependencies:
+    chalk "^2.3.1"
+    commander "^2.14.1"
+    cosmiconfig "^5.0.2"
+    debug "^3.1.0"
+    dedent "^0.7.0"
+    del "^3.0.0"
+    execa "^1.0.0"
+    find-parent-dir "^0.3.0"
+    g-status "^2.0.2"
+    is-glob "^4.0.0"
+    is-windows "^1.0.2"
+    listr "^0.14.2"
+    listr-update-renderer "^0.5.0"
+    lodash "^4.17.11"
+    log-symbols "^2.2.0"
+    micromatch "^3.1.8"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
+    please-upgrade-node "^3.0.2"
+    staged-git-files "1.1.2"
+    string-argv "^0.0.2"
+    stringify-object "^3.2.2"
+    yup "^0.27.0"
+
 list-item@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/list-item/-/list-item-1.1.1.tgz#0c65d00e287cb663ccb3cb3849a77e89ec268a56"
@@ -5699,6 +6261,50 @@ list-item@^1.1.1:
     extend-shallow "^2.0.1"
     is-number "^2.1.0"
     repeat-string "^1.5.2"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
+
+listr@^0.14.2:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -5846,9 +6452,14 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.11.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.11.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lodash@^4.17.11, lodash@^4.3.0:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@~0.9.2:
   version "0.9.2"
@@ -5857,6 +6468,29 @@ lodash@~0.9.2:
 lodash@~2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -6315,7 +6949,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.0.0:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -6328,9 +6962,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nan@^2.9.2:
   version "2.10.0"
@@ -6373,15 +7008,16 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-next-tick@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-
 nib@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/nib/-/nib-1.1.2.tgz#6a69ede4081b95c0def8be024a4c8ae0c2cbb6c7"
   dependencies:
     stylus "0.54.5"
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -6498,6 +7134,16 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-package-data@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -6528,11 +7174,27 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
+npm-path@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  integrity sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -6654,15 +7316,11 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
-
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 onetime@^2.0.0:
   version "2.0.1"
@@ -6730,7 +7388,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -6769,6 +7427,16 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
+
+p-map@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -6804,6 +7472,13 @@ package-json@^4.0.0:
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-author@^2.0.0:
   version "2.0.0"
@@ -6875,17 +7550,22 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -6952,9 +7632,10 @@ pkg-conf@^2.0.0, pkg-conf@^2.1.0:
     find-up "^2.0.0"
     load-json-file "^4.0.0"
 
-pkg-config@^1.0.1, pkg-config@^1.1.0:
+pkg-config@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pkg-config/-/pkg-config-1.1.1.tgz#557ef22d73da3c8837107766c52eadabde298fe4"
+  integrity sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=
   dependencies:
     debug-log "^1.0.0"
     find-root "^1.0.0"
@@ -6972,9 +7653,10 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+pkg-dir@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.1.0.tgz#aaeb91c0d3b9c4f74a44ad849f4de34781ae01de"
+  integrity sha512-55k9QN4saZ8q518lE6EFgYiu95u3BWkSajCifhdQjvLvmr8IpnRbhI+UGpWJQfa0KzDguHeeWT1ccO1PmkOi3A==
   dependencies:
     find-up "^3.0.0"
 
@@ -6984,9 +7666,10 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-please-upgrade-node@^3.1.1:
+please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
   dependencies:
     semver-compare "^1.0.0"
 
@@ -7004,9 +7687,10 @@ plur@^2.0.0:
   dependencies:
     irregular-plurals "^1.0.0"
 
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+  integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
 pn@^1.1.0:
   version "1.1.0"
@@ -7266,6 +7950,22 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier-standard@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/prettier-standard/-/prettier-standard-9.1.1.tgz#31926843d6d2b428fbecb3aceea59e872947d016"
+  integrity sha512-d23Hbdf7tIJ5qeEPEv+7B9cGGczJBOyq188kiKGPk/lvlrM3J8umWC8rR9LIbWmuMzbl5iDSL7kG1/wZgh3EYg==
+  dependencies:
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    minimist "^1.2.0"
+    prettierx "0.3.0"
+    stream-mock "1.2.0"
+
+prettierx@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/prettierx/-/prettierx-0.3.0.tgz#7c8bd8b809507bf9ba503729e6c24af152a58136"
+  integrity sha512-cMtPQ1+mhWsMPAJycwUqVYQBL30TrVJnVz8K888WN67mpXMHAHGY53jLgFR2Pr3v3YE8Rz9kxZCB7S7vAfz1iA==
+
 pretty-bytes@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
@@ -7315,9 +8015,10 @@ progress-stream@^1.1.0:
     speedometer "~0.1.2"
     through2 "~0.2.3"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise@^7.1.1:
   version "7.3.1"
@@ -7346,6 +8047,11 @@ prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+property-expr@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
+  integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
+
 proxy-addr@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
@@ -7364,6 +8070,14 @@ pseudomap@^1.0.2:
 psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -7668,13 +8382,15 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-read-pkg@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+read-pkg@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.1.1.tgz#5cf234dde7a405c90c88a519ab73c467e9cb83f5"
+  integrity sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==
   dependencies:
-    normalize-package-data "^2.3.2"
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
     parse-json "^4.0.0"
-    pify "^3.0.0"
+    type-fest "^0.4.1"
 
 readable-stream@^1.1.8, readable-stream@~1.1.9:
   version "1.1.14"
@@ -7697,6 +8413,15 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.0.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@~1.0.26:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -7715,25 +8440,11 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
 realpath-native@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
 
 redbox-react@^1.2.2:
   version "1.6.0"
@@ -7782,6 +8493,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -7802,6 +8518,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexpp@^2.0.0, regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^2.0.0:
   version "2.0.0"
@@ -7939,9 +8660,10 @@ require-precompiled@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
@@ -7959,10 +8681,16 @@ resolve-cwd@^2.0.0:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+  integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
 
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -7978,12 +8706,12 @@ resolve@^1.1.6:
   dependencies:
     path-parse "^1.0.5"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+resolve@^1.10.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
   dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -8001,6 +8729,13 @@ right-align@^0.1.1:
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
   dependencies:
     align-text "^0.1.1"
+
+rimraf@2.6.3, rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
@@ -8020,11 +8755,12 @@ rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
 run-node@^1.0.0:
   version "1.0.0"
@@ -8033,18 +8769,29 @@ run-node@^1.0.0:
 run-parallel@^1.1.2:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 rw@1:
   version "1.3.3"
   resolved "http://registry.npm.taobao.org/rw/download/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
-
 rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
+
+rxjs@^5.5.2:
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
+  dependencies:
+    symbol-observable "1.0.1"
+
+rxjs@^6.3.3, rxjs@^6.4.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
+  integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.1:
   version "5.1.1"
@@ -8142,6 +8889,11 @@ semver-diff@^2.0.0:
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.5.0, semver@^5.5.1:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 send@0.16.2:
   version "0.16.2"
@@ -8248,14 +9000,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@^0.7.5:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -8275,6 +9019,13 @@ signale@^1.2.1:
     chalk "^2.3.2"
     figures "^2.0.0"
     pkg-conf "^2.1.0"
+
+simple-git@^1.85.0:
+  version "1.112.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.112.0.tgz#2aec1b124c3705adf6baf977b663a0632f50267f"
+  integrity sha512-3vY0SW+RkO+ElWH07n/PQuKmuNLZSz3VAkxKMr3UMm/QnaSnYFjg3nqT8V6a0QCcUFpkyAWVsruQt4oSIIzPXw==
+  dependencies:
+    debug "^4.0.1"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -8300,10 +9051,19 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-slice-ansi@^1.0.0:
+slice-ansi@1.0.0, slice-ansi@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   dependencies:
+    is-fullwidth-code-point "^2.0.0"
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
 slide@^1.1.5:
@@ -8336,6 +9096,19 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+snazzy@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/snazzy/-/snazzy-8.0.0.tgz#97a6d4173d03f6549b98a9dd88362765fac0ef88"
+  integrity sha512-59GS69hQD8FvJoNGeDz8aZtbYhkCFxCPQB1BFzAWiVVwPmS/J6Vjaku0k6tGNsdSxQ0kAlButdkn8bPR2hLcBw==
+  dependencies:
+    chalk "^2.3.0"
+    inherits "^2.0.1"
+    minimist "^1.1.1"
+    readable-stream "^3.0.2"
+    standard-json "^1.0.0"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -8507,28 +9280,60 @@ stackframe@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
 
-standard-engine@~5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-5.2.0.tgz#400660ae5acce8afd4db60ff2214a9190ad790a3"
-  dependencies:
-    deglob "^2.0.0"
-    find-root "^1.0.0"
-    get-stdin "^5.0.1"
-    home-or-tmp "^2.0.0"
-    minimist "^1.1.0"
-    pkg-config "^1.0.1"
+staged-git-files@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.2.tgz#4326d33886dc9ecfa29a6193bf511ba90a46454b"
+  integrity sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==
 
-standard@^8.4.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/standard/-/standard-8.6.0.tgz#635132be7bfb567c2921005f30f9e350e4752aad"
+standard-engine@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-10.0.0.tgz#6859075130f0c677f6a9ee05869f3e8d18bb45ea"
+  integrity sha512-91BjmzIRZbFmyOY73R6vaDd/7nw5qDWsfpJW5/N+BCXFgmvreyfrRg7oBSu4ihL0gFGXfnwCImJm6j+sZDQQyw==
   dependencies:
-    eslint "~3.10.2"
-    eslint-config-standard "6.2.1"
-    eslint-config-standard-jsx "3.2.0"
-    eslint-plugin-promise "~3.4.0"
-    eslint-plugin-react "~6.7.1"
-    eslint-plugin-standard "~2.0.1"
-    standard-engine "~5.2.0"
+    deglob "^3.0.0"
+    get-stdin "^6.0.0"
+    minimist "^1.1.0"
+    pkg-conf "^2.0.0"
+
+standard-engine@~9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-9.0.0.tgz#d3a3d74c4c1b91f51a1e66362465261ca7610316"
+  integrity sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==
+  dependencies:
+    deglob "^2.1.0"
+    get-stdin "^6.0.0"
+    minimist "^1.1.0"
+    pkg-conf "^2.0.0"
+
+standard-json@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/standard-json/-/standard-json-1.0.3.tgz#5b5b21d9418810dc5644c113d5163541dcd8faa6"
+  integrity sha512-lhMP+KREBcfyyMe2ObJlEjJ0lc0ItA9uny83d9ZL6ggYtB79DuaAKCxJVoiflg5EV3D2rpuWn+n4+zXjWXk0sQ==
+  dependencies:
+    concat-stream "^1.5.0"
+
+standard@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/standard/-/standard-12.0.1.tgz#0fc5a8aa6c34c546c5562aae644242b24dae2e61"
+  integrity sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==
+  dependencies:
+    eslint "~5.4.0"
+    eslint-config-standard "12.0.0"
+    eslint-config-standard-jsx "6.0.2"
+    eslint-plugin-import "~2.14.0"
+    eslint-plugin-node "~7.0.1"
+    eslint-plugin-promise "~4.0.0"
+    eslint-plugin-react "~7.11.1"
+    eslint-plugin-standard "~4.0.0"
+    standard-engine "~9.0.0"
+
+standardx@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/standardx/-/standardx-3.0.1.tgz#342b2515f63d62a12e9574d7f044ae0aafd1dbf1"
+  integrity sha512-HU4c9V/F6TAKAokrnClUIzuETYyVpO3iYs77stT29YRJu8HR0CQ7ypM2sgW1Qmn3+VPB6/eSy4aPMt8NYPtl3A==
+  dependencies:
+    standard "^12.0.1"
+    standard-engine "^10.0.0"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -8570,9 +9375,21 @@ stream-http@^2.3.1:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
+stream-mock@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stream-mock/-/stream-mock-1.2.0.tgz#f68b5523c0e1cfe619ea09d7d1097290f405b96a"
+  integrity sha1-9otVI8Dhz+YZ6gnX0QlykPQFuWo=
+  dependencies:
+    babel-runtime "^6.26.0"
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+string-argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
+  integrity sha1-2sMECGkMIfPDYwo/86BYd73L1zY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -8589,22 +9406,47 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-object@^3.2.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 stringstream@~0.0.4:
   version "0.0.6"
@@ -8627,6 +9469,13 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@~0.1.0:
   version "0.1.1"
@@ -8662,11 +9511,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@~1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
-
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -8764,6 +9609,11 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
@@ -8776,16 +9626,32 @@ symbol-tree@^3.2.1, symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+synchronous-promise@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.7.tgz#3574b3d2fae86b145356a4b89103e1577f646fe3"
+  integrity sha512-16GbgwTmFMYFyQMLvtQjvNWh30dsFe1cAW5Fg1wm5+dg84L9Pe36mftsIRU95/W2YsISxsz/xq4VB23sqpgb/A==
+
+table@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
+  integrity sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
+table@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
+  integrity sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==
+  dependencies:
+    ajv "^6.9.1"
+    lodash "^4.17.11"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"
@@ -8826,7 +9692,7 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-table@^0.2.0, text-table@~0.2.0:
+text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -8888,6 +9754,13 @@ tmp@0.0.28:
   dependencies:
     os-tmpdir "~1.0.1"
 
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -8899,6 +9772,11 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -8929,6 +9807,11 @@ toggle-selection@^1.0.3:
 toml@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.3.tgz#8d683d729577cb286231dfc7a8affe58d31728fb"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 touch@0.0.3:
   version "0.0.3"
@@ -8991,6 +9874,11 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -9024,6 +9912,11 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-fest@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
+  integrity sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==
 
 type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
@@ -9180,6 +10073,13 @@ update-notifier@^2.3.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -9217,17 +10117,11 @@ use@^3.1.0:
   dependencies:
     kind-of "^6.0.2"
 
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  dependencies:
-    os-homedir "^1.0.0"
-
 utf8-byte-length@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
@@ -9447,7 +10341,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
@@ -9506,6 +10400,14 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -9544,9 +10446,17 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
+
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  integrity sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=
   dependencies:
     mkdirp "^0.5.1"
 
@@ -9701,3 +10611,15 @@ yauzl@2.4.1:
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
   dependencies:
     fd-slicer "~1.0.1"
+
+yup@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.27.0.tgz#f8cb198c8e7dd2124beddc2457571329096b06e7"
+  integrity sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fn-name "~2.0.1"
+    lodash "^4.17.11"
+    property-expr "^1.5.0"
+    synchronous-promise "^2.0.6"
+    toposort "^2.0.2"


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
Similar to closed PR #924 I'd like to add code formatting with pre-commit hook. It will improve development experience as you don't have to care about semicolons, spacings etc. because it will be automatically formatted on save to a consistent code style.

I first wanted to go with prettier but it was problematic to have function paren formatting working.
Then I decided to use [standard](https://www.npmjs.com/package/standard) because it's exactly doing what we need with an exception - it can't be customized.
So in the end I'm using [standardx](https://www.npmjs.com/package/standardx) - it is using standard lib under the hood but can be customized.

The only drawback of **standardx** is that vscode can only use **standard** and that's why I have added the configuration into `package.json` as well. So vscode is using `package.json` and `yarn lint` is using `.eslintrc` file.
Not perfect but I think OK to start with. Once the [PR](https://github.com/standard/vscode-standardjs/pull/71) is merged / released we can use Standardx in VS code and remove the config from `package.json`.

Styles we're having (basically according to standard style - just to mention some of the styles):
- 2 space indent
- no semis
- space before parens
- no-unused vars
- no-prop warnings JSX (disabled by custom rule)
- prefer-const

**Summary**
- Added vscode `settings` & `recommendations`
- Pre-commit prevents commiting with linting errors (see screenrecording below) (could be by-passed during dev. by `--no-verify` command line arg)
- No code changes - I've added some notes & `eslint-disable-line` to remove some warnings. We could fix these later:
  - The no-useless escapes are disabled inline because in VS code these are not ignored because the ignore setting is not applied - so I've added them
  - Not changed `ComponentWillReceiveProps` - not sure why the unsafe use warning from linting is not present
- Some new lint disables because they cause a lot of linting errors & I think it's OK to ignore them:
  - "no-loop-func"
   - "default-case"
   - "no-useless-concat"
   - "jsx-a11y/alt-text" Added because `React-App` is adding accessibility rules like this.

**Points I've noticed during setup**
1. JSX indentation is a bit problematic if not every prop is on it's own line - couldn't get the indentation right if the tag starts with `<div someProps={ } ` and then the next prop in the next line couldn't be indented correctly. (I'll add an inline comment to this later.)
2. Sometimes an additional semicolon wasn't removed by VS code but it was correctly formatted in command line - I think that's no problem but that was a bit weird.

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or **development** improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible

**Demo editing with Standardx formatting & linting**
Note: The prop typo is not detected in VS code because it's using `standard` instead of `standardx`. Formatting is happening on save (ctrl+s).
![Screenrecording_Linting_formatting_with_standardx](https://user-images.githubusercontent.com/3046542/57199803-a91a9000-6f83-11e9-8e73-2c5d599e266b.gif)

**Demo - Failing pre-commit hook**
Note: Coloring of the error is not correctly displayed in the recording. But I've fixed that by forcing the coloring.
![Screenrecording_precommit_hook](https://user-images.githubusercontent.com/3046542/57199805-bcc5f680-6f83-11e9-80a4-73e39d116658.gif)

[Here](https://gist.github.com/AWolf81/5f049310e07f9e52e6eab42bc0357b5d) is a test file where I've checked the linting rules.