### PR TITLE
Fix Custom CSS Disappears After Saving

### DIFF
--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -152,7 +152,13 @@ function get () {
 
 function set (updates) {
   const currentConfig = get()
-  const newConfig = Object.assign({}, DEFAULT_CONFIG, currentConfig, updates)
+
+  let arrangedUpdates = updates
+  if (updates.preview !== undefined && updates.preview.customCSS === "") {
+    arrangedUpdates.preview.customCSS = DEFAULT_CONFIG.preview.customCSS
+  }
+
+  const newConfig = Object.assign({}, DEFAULT_CONFIG, currentConfig, arrangedUpdates);
   if (!validate(newConfig)) throw new Error('INVALID CONFIG')
   _save(newConfig)
 

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -83,7 +83,7 @@ export const DEFAULT_CONFIG = {
     breaks: true,
     smartArrows: false,
     allowCustomCSS: false,
-    customCSS: '',
+    customCSS: '/* Drop Your Custom CSS Code Here */',
     sanitize: 'STRICT', // 'STRICT', 'ALLOW_STYLES', 'NONE'
     lineThroughCheckbox: true
   },

--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -153,12 +153,12 @@ function get () {
 function set (updates) {
   const currentConfig = get()
 
-  let arrangedUpdates = updates
-  if (updates.preview !== undefined && updates.preview.customCSS === "") {
+  const arrangedUpdates = updates
+  if (updates.preview !== undefined && updates.preview.customCSS === '') {
     arrangedUpdates.preview.customCSS = DEFAULT_CONFIG.preview.customCSS
   }
 
-  const newConfig = Object.assign({}, DEFAULT_CONFIG, currentConfig, arrangedUpdates);
+  const newConfig = Object.assign({}, DEFAULT_CONFIG, currentConfig, arrangedUpdates)
   if (!validate(newConfig)) throw new Error('INVALID CONFIG')
   _save(newConfig)
 

--- a/browser/main/modals/PreferencesModal/UiTab.js
+++ b/browser/main/modals/PreferencesModal/UiTab.js
@@ -883,7 +883,6 @@ class UiTab extends React.Component {
                   onChange={e => this.handleUIChange(e)}
                   ref={e => (this.customCSSCM = e)}
                   value={config.preview.customCSS}
-                  defaultValue={'/* Drop Your Custom CSS Code Here */\n'}
                   options={{
                     lineNumbers: true,
                     mode: 'css',


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understood the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
 
 - Removed the default value of the customCSS on the ReactCodeMirror TAG in order to enable stored the CustomCSS value.
 - Moved the default value to the ConfigManger.js.

## Issue fixed

#3041

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible

## Screenshot

![customcss](https://user-images.githubusercontent.com/5774588/59145213-a7793780-8a1b-11e9-81e7-42cdc5ee15a2.gif)

## Tested

MacOS Mojave (10.14.5)