### PR TITLE
Dont highlight search term if search field is emptied

### DIFF
--- a/browser/main/TopBar/index.js
+++ b/browser/main/TopBar/index.js
@@ -71,7 +71,7 @@ class TopBar extends React.Component {
     this.refs.search.childNodes[0].blur
     dispatch(push('/searched'))
     e.preventDefault()
-    this.debouncedUpdateKeyword("")
+    this.debouncedUpdateKeyword('')
   }
 
   handleKeyDown (e) {

--- a/browser/main/TopBar/index.js
+++ b/browser/main/TopBar/index.js
@@ -71,6 +71,7 @@ class TopBar extends React.Component {
     this.refs.search.childNodes[0].blur
     dispatch(push('/searched'))
     e.preventDefault()
+    this.debouncedUpdateKeyword("")
   }
 
   handleKeyDown (e) {


### PR DESCRIPTION
## Description
When I search for something and delete the search term from the search field, the search term doesn't stay highlighted in the editor panel.

## Issue fixed
[Deleted search term stays highlighted · Issue #3111 · BoostIO/Boostnote · GitHub](https://github.com/BoostIO/Boostnote/issues/3111)

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible