### PR TITLE
optimize: should highlight any non-empty search query, fix #3164

### DIFF
--- a/browser/components/CodeEditor.js
+++ b/browser/components/CodeEditor.js
@@ -106,7 +106,7 @@ export default class CodeEditor extends React.Component {
     const component = this
 
     if (component.searchState) cm.removeOverlay(component.searchState)
-    if (msg.length < 3) return
+    if (msg.length < 1) return
 
     cm.operation(function () {
       component.searchState = makeOverlay(msg, 'searching')


### PR DESCRIPTION
## Description

Digg a little into the situation that #3164 describes, turns out it has nothing to do with unicode characters.

The original `msg.length < 3` threshold may be out of performance concern, but since I don't have that much notes kept, it doesn't seem an issue to me.

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)