### PR TITLE
MarkdownPreview should scroll to top after selecting another note, also fix #3023

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -589,6 +589,11 @@ export default class MarkdownPreview extends React.Component {
     if (needsRewriteIframe) {
       this.rewriteIframe()
     }
+
+    // Should scroll to top after selecting another note
+    if (prevProps.noteKey !== this.props.noteKey) {
+      this.getWindow().scrollTo(0, 0)
+    }
   }
 
   getStyleParams () {
@@ -959,8 +964,6 @@ export default class MarkdownPreview extends React.Component {
       overlay.appendChild(zoomImg)
       document.body.appendChild(overlay)
     }
-
-    this.getWindow().scrollTo(0, 0)
   }
 
   focus () {

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -556,7 +556,9 @@ export default class MarkdownPreview extends React.Component {
   }
 
   componentDidUpdate (prevProps) {
-    if (prevProps.value !== this.props.value) this.rewriteIframe()
+    // actual rewriteIframe function should be called only once
+    let needsRewriteIframe = false
+    if (prevProps.value !== this.props.value) needsRewriteIframe = true
     if (
       prevProps.smartQuotes !== this.props.smartQuotes ||
       prevProps.sanitize !== this.props.sanitize ||
@@ -566,7 +568,7 @@ export default class MarkdownPreview extends React.Component {
       prevProps.lineThroughCheckbox !== this.props.lineThroughCheckbox
     ) {
       this.initMarkdown()
-      this.rewriteIframe()
+      needsRewriteIframe = true
     }
     if (
       prevProps.fontFamily !== this.props.fontFamily ||
@@ -581,6 +583,10 @@ export default class MarkdownPreview extends React.Component {
       prevProps.customCSS !== this.props.customCSS
     ) {
       this.applyStyle()
+      needsRewriteIframe = true
+    }
+
+    if (needsRewriteIframe) {
       this.rewriteIframe()
     }
   }


### PR DESCRIPTION
## Description

This PR contains two commits modifying the MarkdownPreview component.

- 6438ff63 Mainly trying to fix #3023, but I guess there might be some more issues  related.

- 81e8f24d aims to improve performance by eliminating redundant calls.

### About the (not added) test

I tried to write some tests for MarkdownPreview component with jest, but got error from `@rokt33r/js-sequence-diagrams` package.

```
 FAIL  tests/components/MarkdownPreview.test.js
  ● Test suite failed to run

    TypeError: _.isEmpty is not a function

      at node_modules/@rokt33r/js-sequence-diagrams/dist/sequence-diagram-min.js:8:24486
      at Object.<anonymous> (node_modules/@rokt33r/js-sequence-diagrams/dist/sequence-diagram-min.js:8:25685)
      at Object.<anonymous> (browser/components/MarkdownPreview.js:47:27)
      at Object.<anonymous> (tests/components/MarkdownPreview.test.js:11:24)
```

Guess the test should be added after this is fixed.


## Issue fixed

- #3023
- #3047  highly possible
- #2038 possible

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :radio_button: All existing tests have been passed


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#3023: MD editor scrolls to the top whenever I add new content](https://issuehunt.io/repos/53266139/issues/3023)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->