### PR TITLE
Stricter regex pattern in pathname matching, fix #3183

### DIFF
--- a/browser/main/Detail/index.js
+++ b/browser/main/Detail/index.js
@@ -50,16 +50,14 @@ class Detail extends React.Component {
         const searchStr = params.searchword
         displayedNotes = searchStr === undefined || searchStr === '' ? allNotes
           : searchFromNotes(allNotes, searchStr)
-      }
-
-      if (location.pathname.match(/\/tags/)) {
+      } else if (location.pathname.match(/^\/tags/)) {
         const listOfTags = params.tagname.split(' ')
         displayedNotes = data.noteMap.map(note => note).filter(note =>
           listOfTags.every(tag => note.tags.includes(tag))
         )
       }
 
-      if (location.pathname.match(/\/trashed/)) {
+      if (location.pathname.match(/^\/trashed/)) {
         displayedNotes = trashedNotes
       } else {
         displayedNotes = _.differenceWith(displayedNotes, trashedNotes, (note, trashed) => note.key === trashed.key)


### PR DESCRIPTION
## Description

`location.pathname` regex match should be Stricter

## Issue fixed

- #3183

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
