### PR TITLE
fix: HotkeyTab accidentally set incomplete hotkey, related #3190

### DIFF
--- a/browser/main/modals/PreferencesModal/HotkeyTab.js
+++ b/browser/main/modals/PreferencesModal/HotkeyTab.js
@@ -76,13 +76,13 @@ class HotkeyTab extends React.Component {
 
   handleHotkeyChange (e) {
     const { config } = this.state
-    config.hotkey = {
+    config.hotkey = Object.assign({}, config.hotkey, {
       toggleMain: this.refs.toggleMain.value,
       toggleMode: this.refs.toggleMode.value,
       deleteNote: this.refs.deleteNote.value,
       pasteSmartly: this.refs.pasteSmartly.value,
       toggleMenuBar: this.refs.toggleMenuBar.value
-    }
+    })
     this.setState({
       config
     })


### PR DESCRIPTION
## Description

### Bug reason

Error is thrown in [CodeEditor.js](https://github.com/BoostIO/Boostnote/blob/master/browser/components/CodeEditor.js#L39)  due to undefined `hotkey` input.

```js
function translateHotkey (hotkey) {
  return hotkey.replace(/\s*\+\s*/g, '-').replace(/Command/g, 'Cmd').replace(/Control/g, 'Ctrl')
}
```

### Solution

HotkeyTab should always emit complete hotkeymap.

## Issue fixed

- #3190 

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#3190: App blanks out after setting HotKey](https://issuehunt.io/repos/53266139/issues/3190)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->