### PR TITLE
Fix #3174: Enable dragging of notes

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.styl
+++ b/browser/main/Detail/MarkdownNoteDetail.styl
@@ -81,11 +81,4 @@ body[data-theme="dracula"]
   .root
     border-left 1px solid $ui-dracula-borderColor
     background-color $ui-dracula-noteDetail-backgroundColor
-    
-div
-  > button, div
-    -webkit-user-drag none
-    user-select none
-    > img, span
-      -webkit-user-drag none
-      user-select none
+

--- a/browser/main/Detail/NoteDetailInfo.styl
+++ b/browser/main/Detail/NoteDetailInfo.styl
@@ -108,3 +108,11 @@ body[data-theme="dracula"]
   .info
     border-color $ui-dracula-borderColor
     background-color $ui-dracula-noteDetail-backgroundColor
+
+.info > div
+  > button
+    -webkit-user-drag none
+    user-select none
+    > img, span
+      -webkit-user-drag none
+      user-select none

--- a/browser/main/Detail/ToggleModeButton.styl
+++ b/browser/main/Detail/ToggleModeButton.styl
@@ -75,3 +75,10 @@ body[data-theme="dracula"]
     .active
       background-color #bd93f9
       box-shadow 2px 0px 7px #222222
+
+.control-toggleModeButton
+  -webkit-user-drag none
+  user-select none
+  > div img
+    -webkit-user-drag none
+    user-select none


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
`user-drag: none` style from `MarkdownNoteDetail.styl` was applied to every `div` in the app and disabled dragging of notes.

Changed styling to address only the buttons/icons to disable the dragging of them.

One point where I'm not sure - was dragging of notes to trash icon supported by a previous app version because that's not working but I'm not sure if that was available before.

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#3174

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible

## Screenshots
**Note dragging**
![Screenrecording_Note_Dragging](https://user-images.githubusercontent.com/3046542/62310427-cf1fd580-b489-11e9-98bb-825fc243f319.gif)

**Disabled dragging in NoteDetailInfo bar still working**
![Screenrecording_NoteDetailInfo_not_draggable](https://user-images.githubusercontent.com/3046542/62310874-c4b20b80-b48a-11e9-86d1-ac5976eeb65d.gif)

A bit difficult to show in a screenrecording but I clicked every icon in the upper right bar and tried to drag the icon.  The circle on the cursor during dragging is from the screenrecorder indicating a mousedown.
