### PR TITLE
Fix #888 - Wrong word count due splitting

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -511,7 +511,7 @@ class MarkdownNoteDetail extends React.Component {
           exportAsTxt={this.exportAsTxt}
           exportAsHtml={this.exportAsHtml}
           exportAsPdf={this.exportAsPdf}
-          wordCount={note.content.replace(/\r?\n?\s+/g, ' ').trim().split(' ').length}
+          wordCount={note.content.trim().split(/\s+/g).length}
           letterCount={note.content.replace(/\r?\n/g, '').length}
           type={note.type}
           print={this.print}

--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -511,7 +511,7 @@ class MarkdownNoteDetail extends React.Component {
           exportAsTxt={this.exportAsTxt}
           exportAsHtml={this.exportAsHtml}
           exportAsPdf={this.exportAsPdf}
-          wordCount={note.content.split(' ').length}
+          wordCount={note.content.replace(/\r?\n?\s+/g, ' ').trim().split(' ').length}
           letterCount={note.content.replace(/\r?\n/g, '').length}
           type={note.type}
           print={this.print}


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
Word count on Note Details was incorrect computed by counting words splitted by space. In the event of one word per line, the count was incorrect:

![wrong word count](https://user-images.githubusercontent.com/846063/63816951-83d5d700-c910-11e9-8792-828e56b3b1bf.png)

This was fixed by converting line breaks into spaces and then splitting them for count:

![correct word count](https://user-images.githubusercontent.com/846063/63817005-b67fcf80-c910-11e9-8838-8875eadcb692.png)


## Issue fixed
#888 

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :black_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :black_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :black_circle: I have attached a screenshot/video to visualize my change if possible