### PR TITLE
fix: Can't open external browser in Markdown Preview with external link containing '#'

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -1021,22 +1021,24 @@ export default class MarkdownPreview extends React.Component {
     const isStartWithHash = rawHref[0] === '#'
     const { href, hash } = parser
 
-    const maybeExternalLink = /https?:\/\//.test(rawHref)
-    const linkHash = (maybeExternalLink || hash === '') ? rawHref : hash // needed because we're having special link formats that are removed by parser e.g. :line:10
+    const linkHash = hash === '' ? rawHref : hash // needed because we're having special link formats that are removed by parser e.g. :line:10
 
     const extractIdRegex = /file:\/\/.*main.?\w*.html#/ // file://path/to/main(.development.)html
     const regexNoteInternalLink = new RegExp(`${extractIdRegex.source}(.+)`)
-    if (isStartWithHash || regexNoteInternalLink.test(linkHash)) {
-      const extractedId = isStartWithHash ? linkHash.slice(1) : linkHash.replace(extractIdRegex, '')
-      const targetId = mdurl.encode(extractedId)
-      const targetElement = this.refs.root.contentWindow.document.getElementById(
-        targetId
-      )
+    if (isStartWithHash || regexNoteInternalLink.test(rawHref)) {
+      const posOfHash = linkHash.indexOf('#')
+      if (posOfHash > -1) {
+        const extractedId = linkHash.slice(posOfHash + 1)
+        const targetId = mdurl.encode(extractedId)
+        const targetElement = this.refs.root.contentWindow.document.getElementById(
+          targetId
+        )
 
-      if (targetElement != null) {
-        this.getWindow().scrollTo(0, targetElement.offsetTop)
+        if (targetElement != null) {
+          this.getWindow().scrollTo(0, targetElement.offsetTop)
+        }
+        return
       }
-      return
     }
 
     // this will match the new uuid v4 hash and the old hash

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -1014,17 +1014,21 @@ export default class MarkdownPreview extends React.Component {
     e.stopPropagation()
 
     const rawHref = e.target.getAttribute('href')
-    const parser = document.createElement('a')
-    parser.href = e.target.getAttribute('href')
-    const { href, hash } = parser
-    const linkHash = hash === '' ? rawHref : hash // needed because we're having special link formats that are removed by parser e.g. :line:10
-
     if (!rawHref) return // not checked href because parser will create file://... string for [empty link]()
 
-    const extractId = /(main.html)?#/
-    const regexNoteInternalLink = new RegExp(`${extractId.source}(.+)`)
-    if (regexNoteInternalLink.test(linkHash)) {
-      const targetId = mdurl.encode(linkHash.replace(extractId, ''))
+    const parser = document.createElement('a')
+    parser.href = rawHref
+    const isStartWithHash = rawHref[0] === '#'
+    const { href, hash } = parser
+
+    const maybeExternalLink = /https?:\/\//.test(rawHref)
+    const linkHash = (maybeExternalLink || hash === '') ? rawHref : hash // needed because we're having special link formats that are removed by parser e.g. :line:10
+
+    const extractIdRegex = /file:\/\/.*main.?\w*.html#/ // file://path/to/main(.development.)html
+    const regexNoteInternalLink = new RegExp(`${extractIdRegex.source}(.+)`)
+    if (isStartWithHash || regexNoteInternalLink.test(linkHash)) {
+      const extractedId = isStartWithHash ? linkHash.slice(1) : linkHash.replace(extractIdRegex, '')
+      const targetId = mdurl.encode(extractedId)
       const targetElement = this.refs.root.contentWindow.document.getElementById(
         targetId
       )


### PR DESCRIPTION
# Description

Current implementation might mistake  external link with '#' for internal link. This PR fixes this.

Proper behavior should be:

```
- [Open in new browser](http://google.com/#viewport)

- [scrolls to internal heading](#Description)
```


## Issue fixed

- #3213 

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)


## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)

- :radio_button: All existing tests have been passed
