### PR TITLE
Dracula theme buttons in storage settings fix

### DIFF
--- a/browser/main/modals/PreferencesModal/StorageItem.styl
+++ b/browser/main/modals/PreferencesModal/StorageItem.styl
@@ -102,3 +102,11 @@ body[data-theme="solarized-dark"]
     border-color $ui-solarized-dark-button-backgroundColor
     background-color $ui-solarized-dark-button-backgroundColor
     color $ui-solarized-dark-text-color
+
+body[data-theme="dracula"]
+  .header
+    border-color $ui-dracula-borderColor
+
+  .header-control-button
+    colorDraculaDefaultButton()
+    border-color $ui-dracula-borderColor

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -410,6 +410,15 @@ $ui-dracula-button--active-color = #f8f8f2
 $ui-dracula-button--active-backgroundColor = #bd93f9
 $ui-dracula-button--hover-backgroundColor = lighten($ui-dracula-backgroundColor, 10%)
 $ui-dracula-button--focus-borderColor = lighten(#44475a, 25%)
+colorDraculaDefaultButton()
+  border-color $ui-dracula-borderColor
+  color $ui-dracula-text-color
+  background-color $ui-dracula-button-backgroundColor
+  &:hover
+    background-color $ui-dracula-button--hover-backgroundColor
+  &:active
+  &:active:hover
+    background-color $ui-dracula-button--active-backgroundColor
 
 modalDracula()
   position relative


### PR DESCRIPTION
Fix for #3237 

## Issue fixed/Description

Before:
<img width="684" alt="Screen Shot 2019-09-02 at 2 10 17 PM" src="https://user-images.githubusercontent.com/28244551/64133855-ff5eda80-cd8d-11e9-9e84-5f1a905a3129.png">
After:
<img width="1091" alt="Screen Shot 2019-09-02 at 2 28 33 PM" src="https://user-images.githubusercontent.com/28244551/64133853-fa9a2680-cd8d-11e9-9773-e9f4dbdd122e.png">
(fixed buttons to the right of My Storage Location for dracula theme)

## Type of changes

- 🔘 Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
