### PR TITLE
Add sidebar collapse button to sidebar while viewing the tags list

### DIFF
--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -272,6 +272,7 @@ class SideNav extends React.Component {
           <div styleName='tagList'>
             {this.tagListComponent(data)}
           </div>
+          <NavToggleButton isFolded={isFolded} handleToggleButtonClick={this.handleToggleButtonClick.bind(this)} />
         </div>
       )
     }


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
The sidebar contains a button to collapse the sidebar, but it is only visible when viewing the list of storages and notes. If the user is currently viewing the list of tags, the sidebar collapse button is not visible:
![image](https://user-images.githubusercontent.com/10067384/64228877-0e807e00-ce9d-11e9-81de-1a83801c0b82.png)


Notes view has always shown the sidebar collapse button:
![image](https://user-images.githubusercontent.com/10067384/64228493-e9d7d680-ce9b-11e9-87c8-f0036ff2abbd.png)

The tags list now renders the sidebar collapse button as well:
![image](https://user-images.githubusercontent.com/10067384/64228828-e5f88400-ce9c-11e9-8841-a4a5ce07cf7c.png)

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
Fixes #2097

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

-  :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

-  :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
-  :radio_button: All existing tests have been passed
-  :radio_button: I have attached a screenshot/video to visualize my change if possible
