### PR TITLE
Fixed #3251 - fixed to use the saved zoom settings value when Boostnote started

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -39,6 +39,7 @@ const windowSize = config.get('windowsize') || {
   width: 1080,
   height: 720
 }
+const zoomFactor = config.get('zoomFactor') || 1.0
 
 const mainWindow = new BrowserWindow({
   x: windowSize.x,
@@ -49,7 +50,7 @@ const mainWindow = new BrowserWindow({
   minWidth: 500,
   minHeight: 320,
   webPreferences: {
-    zoomFactor: 1.0,
+    zoomFactor,
     enableBlinkFeatures: 'OverlayScrollbars'
   },
   icon: path.resolve(__dirname, '../resources/app.png')


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
I fixed to use the saved zoom settings value when Boostnote started.

### Screenshot

![useSavedZoomSettingsValue](https://user-images.githubusercontent.com/11808736/66647191-3369cd00-ec63-11e9-8315-c34e88edad92.gif)


## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#3251

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
