### PR TITLE
Added link to downloads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@
   </a>
  </p>
 
+## Download
+
+[Find the latest release of Boostnote here!](https://github.com/BoostIO/boost-releases/releases/)
+
 ## Authors & Maintainers
 
 - [Rokt33r](https://github.com/rokt33r)


### PR DESCRIPTION
This PR is a small update to the readme. For user who land on [this page](https://github.com/BoostIO/Boostnote) it is not clear where to download the files to install Boostnote.