### PR TITLE
Include build dependency packages cmds on build docs

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -82,13 +82,21 @@ Distribution packages are created by exec `grunt build` on Linux platform (e.g. 
 
 After installing the supported version of `node` and `npm`, install build dependency packages.
 
-Ubuntu/Debian:
+**Ubuntu/Debian:**
+
+```
+$ npm i -g grunt-electron-installer-debian
+```
 
 ```
 $ sudo apt-get install -y rpm fakeroot
 ```
 
-Fedora:
+**Fedora:**
+
+```
+$ npm i -g grunt-electron-installer-redhat
+```
 
 ```
 $ sudo dnf install -y dpkg dpkg-dev rpm-build fakeroot
@@ -100,4 +108,4 @@ Then execute `grunt build`.
 $ grunt build
 ```
 
-You will find `.deb` and `.rpm` in the `dist` directory.
+> You will find `.deb` and `.rpm` in the `dist` directory.

--- a/docs/build.md
+++ b/docs/build.md
@@ -82,21 +82,17 @@ Distribution packages are created by exec `grunt build` on Linux platform (e.g. 
 
 After installing the supported version of `node` and `npm`, install build dependency packages.
 
-**Ubuntu/Debian:**
+```
+$ yarn add --dev grunt-electron-installer-debian grunt-electron-installer-redhat
+```
 
-```
-$ npm i -g grunt-electron-installer-debian
-```
+**Ubuntu/Debian:**
 
 ```
 $ sudo apt-get install -y rpm fakeroot
 ```
 
 **Fedora:**
-
-```
-$ npm i -g grunt-electron-installer-redhat
-```
 
 ```
 $ sudo dnf install -y dpkg dpkg-dev rpm-build fakeroot


### PR DESCRIPTION
## Description
Includes the required build dependency packages to build the app
Most people tend to overlook:

> After installing the supported version of `node` and `npm`, **install build dependency** packages.

Including it gives them a heads up.

## Issue fixed

#3278 
https://github.com/BoostIO/Boostnote/issues/3278#issuecomment-545151294

## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- 🔘 Documentation change (Change that modifies documentation. Maybe typo fixes)