### PR TITLE
Add error handling to "New note from URL" dialog

### DIFF
--- a/browser/main/lib/dataApi/createNoteFromUrl.js
+++ b/browser/main/lib/dataApi/createNoteFromUrl.js
@@ -15,8 +15,8 @@ function validateUrl (str) {
 }
 
 const ERROR_MESSAGES = {
-  ENOTFOUND: 'URL not found. Please check the URL, your internet connection and try again.',
-  VALIDATION_ERROR: 'Please check your URL is in correct format. (Example, https://www.google.com)',
+  ENOTFOUND: 'URL not found. Please check the URL, or your internet connection and try again.',
+  VALIDATION_ERROR: 'Please check if the URL follows this format: https://www.google.com',
   UNEXPECTED: 'Unexpected error! Please check console for details!'
 }
 

--- a/browser/main/lib/dataApi/createNoteFromUrl.js
+++ b/browser/main/lib/dataApi/createNoteFromUrl.js
@@ -14,12 +14,18 @@ function validateUrl (str) {
   }
 }
 
+const ERROR_MESSAGES = {
+  ENOTFOUND: 'URL not found. Please check the URL, your internet connection and try again.',
+  VALIDATION_ERROR: 'Please check your URL is in correct format. (Example, https://www.google.com)',
+  UNEXPECTED: 'Unexpected error! Please check console for details!'
+}
+
 function createNoteFromUrl (url, storage, folder, dispatch = null, location = null) {
   return new Promise((resolve, reject) => {
     const td = createTurndownService()
 
     if (!validateUrl(url)) {
-      reject({result: false, error: 'Please check your URL is in correct format. (Example, https://www.google.com)'})
+      reject({result: false, error: ERROR_MESSAGES.VALIDATION_ERROR})
     }
 
     const request = url.startsWith('https') ? https : http
@@ -70,8 +76,9 @@ function createNoteFromUrl (url, storage, folder, dispatch = null, location = nu
 
     req.on('error', (e) => {
       console.error('error in parsing URL', e)
-      reject({result: false, error: e})
+      reject({result: false, error: ERROR_MESSAGES[e.code] || ERROR_MESSAGES.UNEXPECTED})
     })
+
     req.end()
   })
 }


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
Adds error handling for "New note from URL" dialog.

## Issue fixed
Fixes #3308
<!--
Please list out all issue fixed with this PR here.
-->
- Display error message on url not found
- Keep "New note" functional

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible

## Screenshots
**URL not found**
![grafik](https://user-images.githubusercontent.com/3046542/67517038-00332f00-f6a2-11e9-9ac1-792370936fc0.png)

**Wrong url format - missing .com**
![grafik](https://user-images.githubusercontent.com/3046542/67517120-28229280-f6a2-11e9-9d2b-31911ee6a37d.png)

## Comments
- Is it OK to add the messages as a constant into the file? Or is there a constants file where we could add it?
- `Unexpected` error message is just a fallback if the code is not matching and I think that's OK.
- Are the error messages OK? I've added the check your internet connection because you're also getting `ENOTFOUND` with-out internet connection.