### PR TITLE
Export: uses markdown preview dom. Supports diagrams

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -359,7 +359,7 @@ export default class MarkdownPreview extends React.Component {
 
     let styles = ''
     files.forEach(file => {
-      styles += `<link rel="stylesheet" href="css/${path.basename(file)}">`
+      styles += `<link rel="stylesheet" href="../css/${path.basename(file)}">`
     })
 
     return `<html>

--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -339,7 +339,7 @@ export default class MarkdownPreview extends React.Component {
       allowCustomCSS,
       customCSS
     })
-    let body = this.markdown.render(noteContent)
+    let body = this.refs.root.contentWindow.document.body.innerHTML
     body = attachmentManagement.fixLocalURLS(
       body,
       this.props.storagePath


### PR DESCRIPTION
## Description
Changed from re-rendering the Markdown (which doesn't render the SVGs from Mermaid), to referencing the Preview DOM that's already rendered, thereby incorporating the already produced SVGs.

## Issue fixed
- https://github.com/BoostIO/Boostnote/issues/2648
- https://github.com/BoostIO/Boostnote/issues/3229
- https://github.com/BoostIO/Boostnote/issues/3202
- https://github.com/BoostIO/Boostnote/issues/3349

[TestText.txt](https://github.com/BoostIO/Boostnote/files/3775205/TestText.txt)
[TestPDF.pdf](https://github.com/BoostIO/Boostnote/files/3775206/TestPDF.pdf)

HTML and MD files are not supported by Github, so am not able to attach.

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
