### PR TITLE
Only trigger some shortcuts on key release

### DIFF
--- a/shortcut.js
+++ b/shortcut.js
@@ -1,0 +1,19 @@
+import ee from 'browser/main/lib/eventEmitter'
+
+module.exports = {
+  'toggleMode': {
+    'action': 'keyup',
+    'invoke': () => {
+      ee.emit('topbar:togglemodebutton')
+    }
+  },
+  'deleteNote': () => {
+    ee.emit('hotkey:deletenote')
+  },
+  'toggleMenuBar': {
+    'action': 'keyup',
+    'invoke': () => {
+      ee.emit('menubar:togglemenubar')
+    }
+  }
+}

--- a/shortcutManager.js
+++ b/shortcutManager.js
@@ -1,0 +1,42 @@
+import Mousetrap from 'mousetrap'
+import CM from 'browser/main/lib/ConfigManager'
+import ee from 'browser/main/lib/eventEmitter'
+import { isObjectEqual } from 'browser/lib/utils'
+require('mousetrap-global-bind')
+import functions from './shortcut'
+
+let shortcuts = CM.get().hotkey
+
+ee.on('config-renew', function () {
+  // only update if hotkey changed !
+  const newHotkey = CM.get().hotkey
+  if (!isObjectEqual(newHotkey, shortcuts)) {
+    updateShortcut(newHotkey)
+  }
+})
+
+function updateShortcut (newHotkey) {
+  Mousetrap.reset()
+  shortcuts = newHotkey
+  applyShortcuts(newHotkey)
+}
+
+function formatShortcut (shortcut) {
+  return shortcut.toLowerCase().replace(/ /g, '')
+}
+
+function applyShortcuts (shortcuts) {
+  for (const shortcut in shortcuts) {
+    const toggler = formatShortcut(shortcuts[shortcut])
+    // only bind if the function for that shortcut exists
+    if (typeof functions[shortcut] === 'function') {
+      Mousetrap.bindGlobal(toggler, functions[shortcut])
+    } else if (typeof functions[shortcut] === 'object') {
+      Mousetrap.bindGlobal(toggler, functions[shortcut].invoke, functions[shortcut].action)
+    }
+  }
+}
+
+applyShortcuts(CM.get().hotkey)
+
+module.exports = applyShortcuts


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
Add optional syntax to specify the key event to register for shortcuts in the shortcut manager.

I didn't do that much digging as to why, but the `deleteNote` hotkey behaves strangely when I tried to set all shortcuts to trigger on `keyup` instead of the default (`keydown` for most shortcuts). It would trigger on both `keydown` and `keyup`. I suspect that means some other part of the code besides mousestrap is listening to that shortcut.

This fix was tossed together pretty quick so my feelings won't be hurt if you'd rather perform a refactor of the shortcut system to handle this better :smile: 

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->
#2906

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :radio_button: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
