### PR TITLE
Delete Dialog: typo for the "type" property

### DIFF
--- a/browser/lib/confirmDeleteNote.js
+++ b/browser/lib/confirmDeleteNote.js
@@ -6,7 +6,7 @@ const { dialog } = remote
 export function confirmDeleteNote (confirmDeletion, permanent) {
   if (confirmDeletion || permanent) {
     const alertConfig = {
-      ype: 'warning',
+      type: 'warning',
       message: i18n.__('Confirm note deletion'),
       detail: i18n.__('This will permanently remove this note.'),
       buttons: [i18n.__('Confirm'), i18n.__('Cancel')]

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -57,7 +57,7 @@ class SideNav extends React.Component {
 
   deleteTag (tag) {
     const selectedButton = remote.dialog.showMessageBox(remote.getCurrentWindow(), {
-      ype: 'warning',
+      type: 'warning',
       message: i18n.__('Confirm tag deletion'),
       detail: i18n.__('This will permanently remove this tag.'),
       buttons: [i18n.__('Confirm'), i18n.__('Cancel')]


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
Fixes a typo, for OS confirmation dialogue types.

When permanently deleting a note, or when deleting a tag, a `warning` dialogue should be presented. But with the type of `ype` instead of `type`, a generic dialogue is presented.

Current behavior:
![boostnote-pre-fix](https://user-images.githubusercontent.com/6433103/69208980-92a0e400-0b23-11ea-9f28-5dd9fdcf15c5.PNG)
![boostnote-tag-pre-fix](https://user-images.githubusercontent.com/6433103/69208981-92a0e400-0b23-11ea-9f5e-8abf4ebe5d2c.PNG)

Expected Behavior:
![boostnote-tag-post-fix](https://user-images.githubusercontent.com/6433103/69208992-99c7f200-0b23-11ea-93d6-085307d78ac0.PNG)
![boostnote-post-fix](https://user-images.githubusercontent.com/6433103/69208993-9a608880-0b23-11ea-8c80-3886e68f1dc5.PNG)


## Issue fixed
No issues currently exist that identify the issue.

I could not replicate https://github.com/BoostIO/Boostnote/issues/2944, but the OS might be treating generic dialogues differently than warnings.

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :radio_button: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
