### PR TITLE
remove redundant conditions of macOS in main-menu

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -86,21 +86,21 @@ const file = {
     },
     {
       label: 'Focus Note',
-      accelerator: macOS ? 'Command+E' : 'Control+E',
+      accelerator: 'CommandOrControl+E',
       click () {
         mainWindow.webContents.send('detail:focus')
       }
     },
     {
       label: 'Delete Note',
-      accelerator: macOS ? 'Command+Shift+Backspace' : 'Control+Shift+Backspace',
+      accelerator: 'CommandOrControl+Shift+Backspace',
       click () {
         mainWindow.webContents.send('detail:delete')
       }
     },
     {
       label: 'Clone Note',
-      accelerator: macOS ? 'Command+D' : 'Control+D',
+      accelerator: 'CommandOrControl+D',
       click () {
         mainWindow.webContents.send('list:clone')
       }
@@ -260,7 +260,7 @@ const view = {
     },
     {
       label: 'Toggle Developer Tools',
-      accelerator: macOS ? 'Command+Alt+I' : 'Control+Shift+I',
+      accelerator: 'CommandOrControl+Alt+I',
       click () {
         BrowserWindow.getFocusedWindow().toggleDevTools()
       }
@@ -314,21 +314,21 @@ const view = {
     },
     {
       label: 'Actual Size',
-      accelerator: macOS ? 'CommandOrControl+0' : 'Control+0',
+      accelerator: 'CommandOrControl+0',
       click () {
         mainWindow.webContents.send('status:zoomreset')
       }
     },
     {
       label: 'Zoom In',
-      accelerator: macOS ? 'CommandOrControl+=' : 'Control+=',
+      accelerator: 'CommandOrControl+=',
       click () {
         mainWindow.webContents.send('status:zoomin')
       }
     },
     {
       label: 'Zoom Out',
-      accelerator: macOS ? 'CommandOrControl+-' : 'Control+-',
+      accelerator: 'CommandOrControl+-',
       click () {
         mainWindow.webContents.send('status:zoomout')
       }


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
I think `macOS ? 'Command+E' : 'Control+E'` is redundant condition, and we should use `CommandOrControl+E`.

## Issue fixed
<!--
Please list out all issue fixed with this PR here.
-->

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :white_circle: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- 🔘  Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- 🔘 My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
