### PR TITLE
Fix prettier configuration

### DIFF
--- a/browser/main/lib/ConfigManager.js
+++ b/browser/main/lib/ConfigManager.js
@@ -75,7 +75,7 @@ export const DEFAULT_CONFIG = {
     customMarkdownLintConfig: DEFAULT_MARKDOWN_LINT_CONFIG,
     prettierConfig: ` {
       "trailingComma": "es5",
-      "tabWidth": 4,
+      "tabWidth": 2,
       "semi": false,
       "singleQuote": true
     }`,

--- a/prettier.config
+++ b/prettier.config
@@ -1,6 +1,6 @@
 {
   "trailingComma": "es5",
-  "tabWidth": 4,
+  "tabWidth": 2,
   "semi": false,
   "singleQuote": true
 }


### PR DESCRIPTION
## Description
Bug fix (sets tabWidth to 2 on prettier configuration and ConfigManager so checkboxes can be clikable).

## Issue fixed
#3361 

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#3361: Prettify Markdown should not update spaces in checkbox lists](https://issuehunt.io/repos/53266139/issues/3361)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->