### PR TITLE
Added Wiki Link to Help Menu

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -385,6 +385,10 @@ const help = {
       click () { shell.openExternal('https://boostnote.io/') }
     },
     {
+      label: 'Wiki',
+      click () { shell.openExternal('https://github.com/BoostIO/Boostnote/wiki') }
+    },
+    {
       label: 'Issue Tracker',
       click () { shell.openExternal('https://github.com/BoostIO/Boostnote/issues') }
     },


### PR DESCRIPTION
Simple PR to add a link to the Boostnote wiki page under the help menu as requested in #3435