### PR TITLE
Fix long code lines that do not wrap in exports

### DIFF
--- a/browser/components/MarkdownPreview.js
+++ b/browser/components/MarkdownPreview.js
@@ -126,6 +126,8 @@ code {
   background-color: rgba(0,0,0,0.04);
   text-align: left;
   direction: ltr;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .lineNumber {
   ${lineNumber && 'display: block !important;'}


### PR DESCRIPTION
<!--
Before submitting this PR, please make sure that:
- You have read and understand the contributing.md
- You have checked docs/code_style.md for information on code style
-->
## Description
<!--
Tell us what your PR does.
Please attach a screenshot/ video/gif image describing your PR if possible.
-->
Surprising easy fix. Break the line for code snippets so that the snippets do not get cut-off when exporting to HTML and PDF (via. HTML).

#### Editor:
##### Before:
![Selection_439](https://user-images.githubusercontent.com/14221489/73070926-d8768180-3eb1-11ea-9adb-6467910354ef.png)

##### After:
![Selection_440](https://user-images.githubusercontent.com/14221489/73070930-dad8db80-3eb1-11ea-97bc-1837237ebaa7.png)

#### Export:
##### Before:
![Selection_441](https://user-images.githubusercontent.com/14221489/73070937-dd3b3580-3eb1-11ea-85b9-c903042814be.png)

##### After:
![Selection_442](https://user-images.githubusercontent.com/14221489/73070943-e0cebc80-3eb1-11ea-9be9-b49f86590d6a.png)

## Issue fixed
#3051 

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
