### PR TITLE
Unable to scroll when there are many folders  

### DIFF
--- a/browser/components/StorageList.styl
+++ b/browser/components/StorageList.styl
@@ -1,5 +1,7 @@
 .storageList
-  margin-bottom 37px
+  absolute left right
+  bottom 37px
+  top 180px
   overflow-y auto
 
 .storageList-folded


### PR DESCRIPTION
## Description
Scroll bar and search bar cannot be displayed when there are many folders.

## Issue fixed

#3486 Can't scroll in sidebar 

before
![1](https://user-images.githubusercontent.com/25508292/75216000-7620e180-57cd-11ea-97e2-db54d1d04903.png)  ![1](https://user-images.githubusercontent.com/25508292/75213047-e6c30080-57c3-11ea-8187-04982bde6c36.gif)

after
![1](https://user-images.githubusercontent.com/25508292/75212484-08bb8380-57c2-11ea-9f22-4acbfb9ed95b.PNG)  ![2](https://user-images.githubusercontent.com/25508292/75213061-f80c0d00-57c3-11ea-81c8-66ba364d7fe9.gif)  
When the scroll bar is hidden  

![4](https://user-images.githubusercontent.com/25508292/75215272-1e817680-57cb-11ea-883c-d928af5aa8c6.PNG)

![3](https://user-images.githubusercontent.com/25508292/75213584-88971d00-57c5-11ea-9fec-31d4a43ec746.gif)

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
