### PR TITLE
Tooltip misplaced when scrolling down

### DIFF
--- a/browser/components/StorageItem.styl
+++ b/browser/components/StorageItem.styl
@@ -50,7 +50,7 @@
 
 .folderList-item-tooltip
   tooltip()
-  position fixed
+  position absolute
   padding 0 10px
   left 44px
   z-index 10

--- a/browser/components/StorageList.styl
+++ b/browser/components/StorageList.styl
@@ -2,6 +2,7 @@
   absolute left right
   bottom 37px
   top 180px
+  overflow-x hidden
   overflow-y auto
 
 .storageList-folded

--- a/browser/components/StorageList.styl
+++ b/browser/components/StorageList.styl
@@ -6,7 +6,6 @@
 
 .storageList-folded
   @extend .storageList
-  width 44px
 
 .storageList-empty
   padding 0 10px

--- a/browser/main/SideNav/StorageItem.styl
+++ b/browser/main/SideNav/StorageItem.styl
@@ -78,6 +78,7 @@
 
 .root--folded
   @extend .root
+  width min-content
   .header
     width 100%
     padding-left 5px


### PR DESCRIPTION
## Description

Tooltip misplaced when scrolling down.
 https://github.com/BoostIO/Boostnote/pull/3490#pullrequestreview-364499729  

![before](https://user-images.githubusercontent.com/25508292/75325684-32ed6e00-58b4-11ea-9aad-2dfbdac61370.png)  

This modification is bad, maybe using js is better.
I think it can't be done with css only, because overflow-y: auto and overflow-x: visible cannot be used on the same element

## Issue fixed
![after](https://user-images.githubusercontent.com/25508292/75325666-2d902380-58b4-11ea-976e-80e9e1c29fba.gif)  
This pr caused some style changes.  
May these changes be accepted?  
![2](https://user-images.githubusercontent.com/25508292/75326930-7b0d9000-58b6-11ea-9983-9917f32a8d41.PNG)



## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :white_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
