### PR TITLE
Tooltip misplaced

### DIFF
--- a/browser/components/StorageItem.js
+++ b/browser/components/StorageItem.js
@@ -21,7 +21,9 @@ const FolderIcon = ({ className, color, isActive }) => {
 
 /**
  * @param {boolean} isActive
+ * @param {object} tooltipRef,
  * @param {Function} handleButtonClick
+ * @param {Function} handleMouseEnter
  * @param {Function} handleContextMenu
  * @param {string} folderName
  * @param {string} folderColor
@@ -35,7 +37,9 @@ const FolderIcon = ({ className, color, isActive }) => {
 const StorageItem = ({
   styles,
   isActive,
+  tooltipRef,
   handleButtonClick,
+  handleMouseEnter,
   handleContextMenu,
   folderName,
   folderColor,
@@ -49,6 +53,7 @@ const StorageItem = ({
     <button
       styleName={isActive ? 'folderList-item--active' : 'folderList-item'}
       onClick={handleButtonClick}
+      onMouseEnter={handleMouseEnter}
       onContextMenu={handleContextMenu}
       onDrop={handleDrop}
       onDragEnter={handleDragEnter}
@@ -75,7 +80,9 @@ const StorageItem = ({
         <span styleName='folderList-item-noteCount'>{noteCount}</span>
       )}
       {isFolded && (
-        <span styleName='folderList-item-tooltip'>{folderName}</span>
+        <span styleName='folderList-item-tooltip' ref={tooltipRef}>
+          {folderName}
+        </span>
       )}
     </button>
   )
@@ -83,7 +90,9 @@ const StorageItem = ({
 
 StorageItem.propTypes = {
   isActive: PropTypes.bool.isRequired,
+  tooltipRef: PropTypes.object,
   handleButtonClick: PropTypes.func,
+  handleMouseEnter: PropTypes.func,
   handleContextMenu: PropTypes.func,
   folderName: PropTypes.string.isRequired,
   folderColor: PropTypes.string,

--- a/browser/components/StorageItem.styl
+++ b/browser/components/StorageItem.styl
@@ -60,6 +60,7 @@
   border-bottom-right-radius 2px
   height 34px
   line-height 32px
+  transition-property opacity
 
 .folderList-item:hover, .folderList-item--active:hover
   .folderList-item-tooltip

--- a/browser/main/SideNav/StorageItem.js
+++ b/browser/main/SideNav/StorageItem.js
@@ -149,13 +149,7 @@ class StorageItem extends React.Component {
       const buttonEl = e.currentTarget
       const tooltipEl = tooltipRef.current
 
-      const tooltipDisplay = window
-        .getComputedStyle(tooltipEl, null)
-        .getPropertyValue('display')
-
-      tooltipEl.style.display = 'none'
       tooltipEl.style.top = buttonEl.getBoundingClientRect().y + 'px'
-      tooltipEl.style.display = tooltipDisplay
     }
   }
 

--- a/browser/main/SideNav/StorageItem.js
+++ b/browser/main/SideNav/StorageItem.js
@@ -144,6 +144,21 @@ class StorageItem extends React.Component {
     }
   }
 
+  handleFolderMouseEnter(e, tooltipRef, isFolded) {
+    if (isFolded) {
+      const buttonEl = e.currentTarget
+      const tooltipEl = tooltipRef.current
+
+      const tooltipDisplay = window
+        .getComputedStyle(tooltipEl, null)
+        .getPropertyValue('display')
+
+      tooltipEl.style.display = 'none'
+      tooltipEl.style.top = buttonEl.getBoundingClientRect().y + 'px'
+      tooltipEl.style.display = tooltipDisplay
+    }
+  }
+
   handleFolderButtonContextMenu(e, folder) {
     context.popup([
       {
@@ -316,6 +331,7 @@ class StorageItem extends React.Component {
           folder.key
       )
       const isActive = !!location.pathname.match(folderRegex)
+      const tooltipRef = React.createRef(null)
       const noteSet = folderNoteMap.get(storage.key + '-' + folder.key)
 
       let noteCount = 0
@@ -339,7 +355,11 @@ class StorageItem extends React.Component {
           key={folder.key}
           index={index}
           isActive={isActive || folder.key === this.state.draggedOver}
+          tooltipRef={tooltipRef}
           handleButtonClick={e => this.handleFolderButtonClick(folder.key)(e)}
+          handleMouseEnter={e =>
+            this.handleFolderMouseEnter(e, tooltipRef, isFolded)
+          }
           handleContextMenu={e => this.handleFolderButtonContextMenu(e, folder)}
           folderName={folder.name}
           folderColor={folder.color}


### PR DESCRIPTION
## Description

Tooltip misplaced when scrolling down.
https://github.com/BoostIO/Boostnote/pull/3490#pullrequestreview-364499729  


![before](https://user-images.githubusercontent.com/25508292/75354287-b4aabf00-58e7-11ea-8da2-ed931ed1fe54.png)  ![before](https://user-images.githubusercontent.com/25508292/75354296-b5dbec00-58e7-11ea-96b5-89a912559261.gif)

## Issue fixed
![after](https://user-images.githubusercontent.com/25508292/75354347-c9875280-58e7-11ea-9311-7d8c77859537.png)  ![after](https://user-images.githubusercontent.com/25508292/75354357-cd1ad980-58e7-11ea-9e2f-ad5fa403dfde.gif)

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->
## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :white_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
