### PR TITLE
Update index.js

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -25,7 +25,7 @@ import queryString from 'query-string'
 
 const { remote } = require('electron')
 const { dialog } = remote
-const WP_POST_PATH = '/wp/v2/posts'
+const WP_POST_PATH = '/wp-json/v2/posts'
 
 const regexMatchStartingTitleNumber = new RegExp('^([0-9]*.?[0-9]+).*$')
 


### PR DESCRIPTION
## Description
Publishing to a standard wordpress installation ( Version 5.3.2 ) fails in boostote 0.15.2. / .3 because WP_POST_PATH does not match REST signature.

## Issue fixed
#3534 https://github.com/BoostIO/Boostnote/issues/3534

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button:  My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :white_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
- :white_circle: This PR will modify the UI or affects the UX
- :white_circle: This PR will add/update/delete a keybinding
