### PR TITLE
Fixes dracula theme tag background

### DIFF
--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -383,7 +383,7 @@ $ui-dracula-active-color = #bd93f9
 
 $ui-dracula-borderColor = #44475a
 
-$ui-dracula-tag-backgroundColor = #8be9fd
+$ui-dracula-tag-backgroundColor = #44475a
 
 $ui-dracula-button-backgroundColor = #44475a
 $ui-dracula-button--active-color = #f8f8f2


### PR DESCRIPTION
# Description

Tag background has an off color for dracula theme.

![image](https://user-images.githubusercontent.com/16971163/95040728-699e2900-06cc-11eb-8665-c92b0512894d.png)


## Issue fixed

fix #3648 

## Type of changes

- :radio_button: : Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :radio_button: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
- :radio_button: This PR will modify the UI or affects the UX
- :white_circle: This PR will add/update/delete a keybinding
