### PR TITLE
fixes 3644 - no line wrap in tables during PDF export

### DIFF
--- a/browser/main/lib/dataApi/formatHTML.js
+++ b/browser/main/lib/dataApi/formatHTML.js
@@ -760,6 +760,16 @@ body p {
     color: #000;
     background-color: #fff;
   }
+
+  table {
+    overflow-x: visible;
+    table-layout: fixed;
+  }
+
+  table tbody td {
+    word-break: break-word;
+  }
+
   .clipboardButton {
     display: none
   }


### PR DESCRIPTION
## Description
The display of tables in the app displays an x-scrollbar for a table with long text content. This content, while being possible to be seen in the app, gets cut-off when it's export as PDF (it's not to scroll within a pdf page).

Before
![image](https://user-images.githubusercontent.com/16971163/101960028-c48d5880-3c06-11eb-9bf8-4bc814c4511b.png)

Fix
![image](https://user-images.githubusercontent.com/16971163/101960053-d8d15580-3c06-11eb-972a-d7e0ba39abf6.png)


## Issue fixed

- wide table content loss when exporting to PDF.

## Type of changes

- :radio_button: Bugfix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :radio_button: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :radio_button: I have attached a screenshot/video to visualize my change if possible
- :radio_button: This PR will modify the UI or affects the UX
- :white_circle: This PR will add/update/delete a keybinding